### PR TITLE
ignore CSP controls for explorer tools

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -333,6 +333,7 @@ CSP_MANIFEST_SRC = "'self'"
 CSP_INCLUDE_NONCE_IN = [
     "script-src",
 ]
+CSP_EXCLUDE_URL_PREFIXES = ("/explorer",)
 
 # Disable whitenoise for test
 STATICFILES_STORAGE = (


### PR DESCRIPTION
Make the schema and save to query functions work

Those functions were inactive because CSP controls block it. I add an exception on route that began by `/explorer` because these routes are accessible by staff only.