### PR TITLE
Simplification de l'usage de docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # syntax=docker/dockerfile:1
 FROM python:3.10.4
 ENV PYTHONUNBUFFERED=1
+
 WORKDIR /code
-COPY . /code/
+COPY requirements.txt .
+
 SHELL ["/bin/bash", "-c"]
-RUN source .venv/bin/activate
+
 RUN pip install -r requirements.txt
+
+CMD ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=apilos-test
     volumes:
       - ./pg-init-scripts:/docker-entrypoint-initdb.d
-      - ./pgdata:/var/lib/postgresql/data
+      # Use :delegated to get better performances on docker write workloads where the sync with the host is not mandatory
+      - ./pgdata:/var/lib/postgresql/data:delegated
     ports:
       - 5433:5432
   redis:
@@ -18,13 +19,13 @@ services:
       - 6379
     command: redis-server /usr/local/etc/redis/redis.conf
     volumes:
-      - ./redis-data:/data
+      - ./redis-data:/data:delegated
       - ./redis.conf:/usr/local/etc/redis/redis.conf
   apilos: &apilos
     build: .
-    command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/code
+      # Use :cached to get better performances on read-heavy workloads, typically here the mounted code will be edited on the host
+      - .:/code:cached
     ports:
       - "8001:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=apilos-test
     volumes:
       - ./pg-init-scripts:/docker-entrypoint-initdb.d
-      # Use :delegated to get better performances on docker write workloads where the sync with the host is not mandatory
+      # Use: delegated to get better performances on docker write workloads where the sync with the host is not mandatory
       - ./pgdata:/var/lib/postgresql/data:delegated
     ports:
       - 5433:5432
@@ -24,7 +24,7 @@ services:
   apilos: &apilos
     build: .
     volumes:
-      # Use :cached to get better performances on read-heavy workloads, typically here the mounted code will be edited on the host
+      # Use: cached to get better performances on read-heavy workloads, typically here the mounted code will be edited on the host
       - .:/code:cached
     ports:
       - "8001:8000"


### PR DESCRIPTION
# Simplification de l'usage de docker

En vue de faciliter l'installation de l'environnement de développement via Docker, je vous proposer les altérations suivantes:
* optimisation du build en copiant uniquement le fichier `requirements.txt` sur l'image produite
* intégration de la migration au démarrage du conteneur
* optimisation des I/O avec l'ajout des directives `:cached` ou `:delegated` sur certains volumes en fonction de leur usage

À noter que j'accède au site via http//localhost:8001, @kolok est-ce que tu as déjà envisagé d'utiliser https ou un domaine local genre https://local.apilos.beta.gouv.fr (en vue d'être iso prod (pratique pour le SSO ou les soucis de CORS) ? Si jamais j'ai déjà fait ça un petit paquet de fois ;)