### PR TITLE
Déploiement continu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,16 @@ workflows:
           filters:
             branches:
               only: develop
-      - deploy_prod:
+      - validate_deployment:
+          type: approval
           requires:
             - build
+          filters:
+            branches:
+              only: master
+      - deploy_prod:
+          requires:
+            - validate_deployment
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,16 +80,29 @@ workflows:
           filters:
             branches:
               only: develop
-      - validate_deployment:
+      - validate_deployment_in_staging:
           type: approval
           requires:
             - build
           filters:
             branches:
-              only: master
-      - deploy_prod:
+              only: S585_continuous_deployment
+      - deploy_staging:
           requires:
-            - validate_deployment
+            - validate_deployment_in_staging
           filters:
             branches:
-              only: master
+              only: S585_continuous_deployment
+      - validate_deployment_in_prod:
+          type: approval
+          requires:
+            - build
+          filters:
+            branches:
+              only: S585_continuous_deployment
+      - deploy_prod:
+          requires:
+            - validate_deployment_in_prod
+          filters:
+            branches:
+              only: S585_continuous_deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,23 +86,23 @@ workflows:
             - build
           filters:
             branches:
-              only: S585_continuous_deployment
+              only: master
       - deploy_staging:
           requires:
             - validate_deployment_in_staging
           filters:
             branches:
-              only: S585_continuous_deployment
+              only: master
       - validate_deployment_in_prod:
           type: approval
           requires:
             - build
           filters:
             branches:
-              only: S585_continuous_deployment
+              only: master
       - deploy_prod:
           requires:
             - validate_deployment_in_prod
           filters:
             branches:
-              only: S585_continuous_deployment
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,18 @@ jobs:
           name: Deploy Staging APiLos on Scalingo
           command: |
             git push -f git@ssh.osc-fr1.scalingo.com:apilos-staging.git $CIRCLE_SHA1:master
+  deploy_prod:
+    docker:
+      - image: circleci/python:3.9
+    steps:
+      - checkout
+      - run:
+          name: Add Scalingo to known_hosts
+          command: ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+      - run:
+          name: Deploy master branch of APiLos on Scalingo
+          command: |
+            git push -f git@ssh.osc-fr1.scalingo.com:fabnum-apilos.git $CIRCLE_SHA1:master
 
 
 workflows:
@@ -68,3 +80,9 @@ workflows:
           filters:
             branches:
               only: develop
+      - deploy_prod:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
# Déploiement continu

En d'autres termes déployer systématiquement en `prod` à chaque contribution sur la branche `master`.

On en a discuté à l'oral avec @kolok et _techniquement_ chaque merge de `develop` dans `master` est toujours suivi d'un déploiement manuel.

Aussi ça ne mange pas de 🥖 d'automatiser le déploiement comme ce qui est fait pour [le staging](https://staging.apilos.incubateur.net) et `develop`, toujours sur CircleCI donc ;)

**PS:** ceci est ma première liée à [un ticket Airtable](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/reckpBi9LmIHbdB4O?blocks=hide) 🤓 ✈️ 