### PR TITLE
Jeu de données minimal sur l'env de dév

### DIFF
--- a/users/fixtures/auth.json
+++ b/users/fixtures/auth.json
@@ -1,5 +1,12 @@
 [
   {
+    "model": "contenttypes.ContentType",
+    "fields": {
+      "app_label": "django_docx_template",
+      "model": "docxtemplate"
+    }
+  },
+  {
     "model": "auth.permission",
     "fields": {
       "name": "Can add log entry",


### PR DESCRIPTION
# Jeu de données minimal sur l'env de dév

cf. [tâche n°S588](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recka6Ph21KI5mmqL?blocks=hide)

En installant mon environnement de dév, j'avais occulté la partie "post install" qui suivait la section liée à la configuration native, si bien que je n'avais pas vu la partie concernant le chargement des données.

_Cependant_ quand j'ai lancé ça ne marchait pas ❌:

```
django.contrib.auth.models.Permission.content_type.RelatedObjectDoesNotExist: Permission has no content_type
```

J'ai inspecté (à coup de `jq` et de requête `sql`) et il s'avère qu'il manquait un `ContentType` que [la lib `python-docx`](https://python-docx.readthedocs.io/en/latest/) ne déclarait pas mais rien d'anormal puisque ce n'est pas un module Django (ça  m'étonne que ça ait marché chez vous d'ailleurs 🤔 )