### PR TITLE
Utiliser mailcatcher sur l'environnement de dév

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -98,6 +98,13 @@ if mailjet_api_key != "":
     EMAIL_BACKEND = "django_mailjet.backends.MailjetBackend"
     MAILJET_API_KEY = mailjet_api_key
     MAILJET_API_SECRET = mailjet_api_secret
+elif get_env_variable("EMAIL_HOST") != '':
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = get_env_variable("EMAIL_HOST")
+    EMAIL_HOST_USER = get_env_variable("EMAIL_USER")
+    EMAIL_HOST_PASSWORD = get_env_variable("EMAIL_PASSWORD")
+    EMAIL_PORT = get_env_variable("EMAIL_PORT", cast=int, default=1025)
+    EMAIL_USE_TLS = get_env_variable("EMAIL_USE_TLS", cast=bool, default=False)
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,13 @@ services:
     <<: *apilos
     command: python manage.py rundramatiq
     ports: []
-
+  mailcatcher:
+    image: sj26/mailcatcher
+    restart: always
+    ports:
+      - "1080:1080"
+    expose:
+      - 1025
 
 volumes:
   cache:

--- a/users/fixtures/auth.json
+++ b/users/fixtures/auth.json
@@ -1,5 +1,12 @@
 [
   {
+    "model": "contenttypes.ContentType",
+    "fields": {
+      "app_label": "django_docx_template",
+      "model": "docxtemplate"
+    }
+  },
+  {
     "model": "auth.permission",
     "fields": {
       "name": "Can add log entry",


### PR DESCRIPTION
# Utiliser mailcatcher sur l'environnement de dév

cf. la [tâche 589](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recu0J5SRj9iqlDFe?blocks=hide) qui a pur but d'intégrer [mailcatcher](https://mailcatcher.me/) qui, comme son nom le laisse présager, est un outil qui permet de "capter" les emails 📫 qui sont envoyés.

Sous le capot il s'agit d'un combo serveur SMTP local branché à une API disponible depuis le web pour pouvoir consulter tous les emails envoyés à tout le monde (c'est d'ailleurs aussi utilisable pour les test unitaires si on veut blinder les scnéarios 🔒). Pour l'utiliser il suffit de déclarer les variables d'environnement associés ;)