### PR TITLE
Erreur Sentry: "... n’est pas un UUID valide"

### DIFF
--- a/templates/common/step_progressbar.html
+++ b/templates/common/step_progressbar.html
@@ -24,6 +24,7 @@
             </div>
         </div>
     </div>
+    {% if convention.uuid is not None %}
     <script type="text/javascript" nonce="{{request.csp_nonce}}">
         document.addEventListener('DOMContentLoaded', function () {
             var lis = document.getElementById('step_progressbar').children
@@ -35,4 +36,5 @@
             }
         });
     </script>
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
# Erreur Sentry: "... n’est pas un UUID valide"

Soit [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/?environment=production&project=29). En regardant le détail de l'erreur j'ai l'impression que ça vient d'un "lien" dont le `href` est généré via Javascript. En effet l'URL formée est du type `/convention/cadastre/[object Event]` => ça sent 👃 donc l'objet JS qui est casté en `string`.

En investiguant rapidement j'ai jeté mon dévolu sur le breadcrumb qui génère des _faux_ liens (un changement de `location.href` sur un clic sur `<li>` c'est pas joli joli ...). Et à mon avis ça arrive quand on initie une convention sans programme, ce qui fait qu'on arrive à l'étape `Cadastre` directement, sans avoir créé une convention donc sans `uuid`.

J'ai fait ça à l'aveugle cependant 🙈 n'arrivant à reproduire en local: est-ce qu'on a un dump frais quelque part ?