### PR TITLE
Hotfix: erreur Sentry sur l'upload de xlsx de financement

### DIFF
--- a/conventions/services/upload_objects.py
+++ b/conventions/services/upload_objects.py
@@ -39,7 +39,7 @@ def handle_uploaded_xlsx(upform, my_file, myClass, convention, file_name):
     min_row = 3
     if "Data" in my_wb:
         if my_wb["Data"]["E2"].value:
-            min_row = my_wb["Data"]["E2"].value
+            min_row = int(my_wb["Data"]["E2"].value)
 
     save_uploaded_file(my_file, convention, file_name)
 


### PR DESCRIPTION
# Hotfix: erreur Sentry sur l'upload de xlsx de financement

Cf. [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/8831/?environment=staging&project=29&query=is%3Aunresolved&statsPeriod=1h) que j'ai rencontré durant mes tests en staging lors de la phase d'édition des financements. 

Ceci se produisait quand j'éditais le ficher Excel depuis Google Spreadsheet ou Numbers sur Mac qui, je ne sais pourquoi, semblent convertir la valeur placée en Data / E2 en `float`. J'ai testé avec le fix et ça semble rouler (un petit pas en avant vers la compatibilité des outils)