### PR TITLE
Erreur Sentry: local variable 'filename' referenced before assignment

### DIFF
--- a/conventions/views.py
+++ b/conventions/views.py
@@ -470,6 +470,7 @@ def post_action(request, convention_uuid):
 def display_pdf(request, convention_uuid):
     # récupérer le doc PDF
     convention = Convention.objects.get(uuid=convention_uuid)
+    filename = None
     if convention.nom_fichier_signe:
         filename = convention.nom_fichier_signe
     elif default_storage.exists(


### PR DESCRIPTION
# Erreur Sentry: local variable 'filename' referenced before assignment

cf. [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/4628/?environment=production&project=29&query=is%3Aunresolved&statsPeriod=7d) qui vient de popper. Je ne comprends pas bien comment ça ne peut arriver que maintenant mais je vous propose cette grosse rustine :| 