### PR TITLE
S546 get operation address from multiple fields

### DIFF
--- a/siap/siap_client/tests/test_siap_client_utils.py
+++ b/siap/siap_client/tests/test_siap_client_utils.py
@@ -1,12 +1,11 @@
-import unittest
-
+from django.test import TestCase
 from siap.siap_client import utils
 from bailleurs.models import Bailleur
 from core.tests import utils_fixtures
 from instructeurs.models import Administration
 
 
-class GetAddressFromLocdataTest(unittest.TestCase):
+class GetAddressFromLocdataTest(TestCase):
     # pylint: disable=W0212
 
     def test__get_address_from_locdata_empty(self):
@@ -65,7 +64,7 @@ class GetAddressFromLocdataTest(unittest.TestCase):
         self.assertEqual(ville, "MarSeille CEDEX 15")
 
 
-class GetOrCreateProgrammeTest(unittest.TestCase):
+class GetOrCreateProgrammeTest(TestCase):
     def setUp(self):
         utils_fixtures.create_administrations()
         utils_fixtures.create_bailleurs()
@@ -73,15 +72,6 @@ class GetOrCreateProgrammeTest(unittest.TestCase):
     # Test model User
     def test_get_or_create(self):
         data_from_siap = {
-            "donneesMo": {
-                "nom": "13 HABITAT",
-                "siren": "782855696",
-                "commune": None,
-                "adresseLigne3": "",
-                "adresseLigne4": "80 rue d'Albe BP 31",
-                "adresseLigne6": "13234 Marseille - 4e arrondissement",
-                "codeFamilleMO": "HLM",
-            },
             "donneesLocalisation": {
                 "region": {"codeInsee": "93", "libelle": None},
                 "departement": {"codeInsee": "13", "libelle": None},
@@ -105,25 +95,8 @@ class GetOrCreateProgrammeTest(unittest.TestCase):
                 "natureLogement": None,
                 "sansTravaux": True,
             },
-            "detailsOperation": None,
-            "planFinancement": None,
-            "gestionnaire": {
-                "id": 185,
-                "code": "DDI013",
-                "libelle": "DDI013 - DDI Bouches du Rh\xc3\xb4ne",
-                "typeDelegation": None,
-                "typeDelegataire": "3",
-                "typeLocalisation": None,
-                "adresse": None,
-                "commune": None,
-                "email": None,
-                "utilisateurs": [],
-            },
         }
-        bailleur = Bailleur.objects.first()
         programme = utils.get_or_create_programme(
-            data_from_siap,
-            bailleur,
-            Administration.objects.first(),
+            data_from_siap, Bailleur.objects.first(), Administration.objects.first()
         )
         self.assertTrue(programme.uuid)

--- a/siap/siap_client/tests/test_utils.py
+++ b/siap/siap_client/tests/test_utils.py
@@ -1,27 +1,130 @@
 import unittest
+
 from siap.siap_client import utils
+from bailleurs.models import Bailleur
+from core.tests import utils_fixtures
+from instructeurs.models import Administration
 
 
-class UtilsTest(unittest.TestCase):
-
+class GetAddressFromLocdataTest(unittest.TestCase):
+    # pylint: disable=W0212
     # Test model User
-    def test__address_interpretation(self):
-        # pylint: disable=W0212
-        adresse, code_postal, ville = utils._address_interpretation("")
+    def test__get_address_from_locdata_empty(self):
+        self.assertRaises(KeyError, utils._get_address_from_locdata, {})
+        self.assertRaises(
+            KeyError, utils._get_address_from_locdata, {"adresseComplete": {}}
+        )
+        adresse, code_postal, ville = utils._get_address_from_locdata({"adresse": ""})
         self.assertEqual(adresse, "")
         self.assertEqual(code_postal, "")
         self.assertEqual(ville, "")
-        adresse, code_postal, ville = utils._address_interpretation(
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        adresse, code_postal, ville = utils._get_address_from_locdata(
+            {
+                "adresseComplete": {
+                    "adresse": "",
+                    "codePostal": "",
+                    "commune": "",
+                }
+            }
+        )
+        self.assertEqual(adresse, "")
+        self.assertEqual(code_postal, "")
+        self.assertEqual(ville, "")
+
+    def test__get_address_from_locdata_adresse_complete(self):
+        donneesLocalisation = {
+            "adresse": "fake adresse",
+            "adresseComplete": {
+                "adresse": "10 rue fake",
+                "codePostal": "00000",
+                "commune": "Vile-sur-fake ok",
+            },
+        }
+        adresse, code_postal, ville = utils._get_address_from_locdata(
+            donneesLocalisation
+        )
+        self.assertEqual(adresse, "10 rue fake")
+        self.assertEqual(code_postal, "00000")
+        self.assertEqual(ville, "Vile-sur-fake ok")
+
+    def test__get_address_from_locdata_adresse_fallback(self):
+
+        adresse, code_postal, ville = utils._get_address_from_locdata(
+            {"adresse": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."}
         )
         self.assertEqual(
             adresse, "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         )
         self.assertEqual(code_postal, "")
         self.assertEqual(ville, "")
-        adresse, code_postal, ville = utils._address_interpretation(
-            "145, rue des chamallow  13015 MarSeille CEDEX 15"
+        adresse, code_postal, ville = utils._get_address_from_locdata(
+            {"adresse": "145, rue des chamallow  13015 MarSeille CEDEX 15"}
         )
         self.assertEqual(adresse, "145, rue des chamallow")
         self.assertEqual(code_postal, "13015")
         self.assertEqual(ville, "MarSeille CEDEX 15")
+
+
+class GetOrCreateProgrammeTest(unittest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        utils_fixtures.create_administrations()
+        utils_fixtures.create_bailleurs()
+
+    # Test model User
+    def test_get_or_create(self):
+        data_from_siap = {
+            "donneesMo": {
+                "nom": "13 HABITAT",
+                "siren": "782855696",
+                "commune": None,
+                "adresseLigne3": "",
+                "adresseLigne4": "80 rue d'Albe BP 31",
+                "adresseLigne6": "13234 Marseille - 4e arrondissement",
+                "codeFamilleMO": "HLM",
+            },
+            "donneesLocalisation": {
+                "region": {"codeInsee": "93", "libelle": None},
+                "departement": {"codeInsee": "13", "libelle": None},
+                "commune": {"codeInsee": "13001", "libelle": "Aix-en-Provence"},
+                "adresse": "10 Avenue du General Koenig 13100 Aix-en-Provence",
+                "adresseComplete": {
+                    "adresse": "10 Avenue du General Koenig ",
+                    "codePostal": "13100",
+                    "commune": "Aix-en-Provence",
+                    "codePostalCommune": "13100 Aix-en-Provence",
+                },
+                "zonage123": "02",
+                "zonageABC": "A",
+            },
+            "donneesOperation": {
+                "nomOperation": "Sans travaux 2022-10-07",
+                "numeroOperation": "20221000003",
+                "aides": [],
+                "sousNatureOperation": None,
+                "typeConstruction": None,
+                "natureLogement": None,
+                "sansTravaux": True,
+            },
+            "detailsOperation": None,
+            "planFinancement": None,
+            "gestionnaire": {
+                "id": 185,
+                "code": "DDI013",
+                "libelle": "DDI013 - DDI Bouches du Rh\xc3\xb4ne",
+                "typeDelegation": None,
+                "typeDelegataire": "3",
+                "typeLocalisation": None,
+                "adresse": None,
+                "commune": None,
+                "email": None,
+                "utilisateurs": [],
+            },
+        }
+
+        programme = utils.get_or_create_programme(
+            data_from_siap,
+            Bailleur.objects.first(),
+            Administration.objects.first(),
+        )
+        self.assertTrue(programme.uuid)

--- a/siap/siap_client/tests/test_utils.py
+++ b/siap/siap_client/tests/test_utils.py
@@ -8,7 +8,7 @@ from instructeurs.models import Administration
 
 class GetAddressFromLocdataTest(unittest.TestCase):
     # pylint: disable=W0212
-    # Test model User
+
     def test__get_address_from_locdata_empty(self):
         self.assertRaises(KeyError, utils._get_address_from_locdata, {})
         self.assertRaises(
@@ -66,8 +66,7 @@ class GetAddressFromLocdataTest(unittest.TestCase):
 
 
 class GetOrCreateProgrammeTest(unittest.TestCase):
-    @classmethod
-    def setUpTestData(cls):
+    def setUp(self):
         utils_fixtures.create_administrations()
         utils_fixtures.create_bailleurs()
 
@@ -121,10 +120,10 @@ class GetOrCreateProgrammeTest(unittest.TestCase):
                 "utilisateurs": [],
             },
         }
-
+        bailleur = Bailleur.objects.first()
         programme = utils.get_or_create_programme(
             data_from_siap,
-            Bailleur.objects.first(),
+            bailleur,
             Administration.objects.first(),
         )
         self.assertTrue(programme.uuid)


### PR DESCRIPTION
Interpretation de l'adresse de l'opération sur plusieurs lignes quand le champ "adresseComplete" est renseigné

sinon, fallback sur le champ adresse qu'on divise en adresse, code postal et ville grâce à la detection du code postal

Ajout de test de get_or_create_programme