### PR TITLE
Fix lower z-index for sticky header and remove col-X class

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -718,7 +718,7 @@ button:not(:disabled).apilos-btn--secondary--red:hover {
   position: -webkit-sticky; /* Safari */
   position: sticky;
   top: 0;
-  z-index: 10000;
+  z-index: 100;
 }
 
 /*

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -109,28 +109,28 @@
                             {% endif %}
                             <thead>
                                 <tr class="th_inline">
-                                    <th title="Statut de la convention" scope="col" class="col-3">
+                                    <th title="Statut de la convention" scope="col">
                                         Statut
                                     </th>
                                     {% if request|is_instructeur %}
-                                        <th scope="col" class="col-1">Bailleur</th>
+                                        <th scope="col">Bailleur</th>
                                     {% endif %}
                                     {% if request|display_administration %}
-                                        <th scope="col" class="col-1">Instructeur</th>
+                                        <th scope="col">Instructeur</th>
                                     {% endif %}
-                                    <th title="Opération" class="col-2" scope="col">
+                                    <th title="Opération" scope="col">
                                         Opération
                                     </th>
-                                    <th title="Financement" class="col-1" scope="col">
+                                    <th title="Financement" scope="col">
                                         Financement
                                     </th>
-                                    <th title="Ville" class="col-2" scope="col">
+                                    <th title="Ville" scope="col">
                                         Ville
                                     </th>
-                                    <th title="Nombre de logements à conventionner" class="col-1" scope="col">
+                                    <th title="Nombre de logements à conventionner" scope="col">
                                         Logements
                                     </th>
-                                    <th title="Date de livraison et mise en service" class="col-2" scope="col">
+                                    <th title="Date de livraison et mise en service" scope="col">
                                         Livraison
                                     </th>
                                 </tr>


### PR DESCRIPTION
Better display convention list:

![image](https://user-images.githubusercontent.com/454431/195284587-47e79501-ad9f-4665-9b54-903c197311a0.png)

display header dropdown and comment layout upper the sticky header convention form

Before
![CleanShot 2022-10-12 at 08 40 07](https://user-images.githubusercontent.com/454431/195285299-464f6d94-08ca-4408-84a3-362cc32ea71a.png)

After
![image](https://user-images.githubusercontent.com/454431/195285454-2515564f-43f4-4ab1-ac52-fde58728f20b.png)
