### PR TITLE
add avenant_type.json in post_deploy script

### DIFF
--- a/bin/post_deploy
+++ b/bin/post_deploy
@@ -1,5 +1,5 @@
 #!/bin/env bash
 
 python manage.py migrate
-python manage.py loaddata auth.json departements.json
+python manage.py loaddata auth.json departements.json avenant_type.json
 python manage.py clearsessions


### PR DESCRIPTION
add avenant_type.json in post_deploy script

In case the migration is merged in the future, we won't lost the avenant_type population