### PR TITLE
fix typo calling the function user.is_instructeur()

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -276,7 +276,7 @@ def display_notification_new_convention_instructeur_to_bailleur(convention, requ
         convention.statut == ConventionStatut.PROJET
         and is_instructeur(request)
         and convention.cree_par is not None
-        and convention.cree_par.is_instructeur
+        and convention.cree_par.is_instructeur()
     )
 
 


### PR DESCRIPTION
typo while refactor the CTA