### PR TITLE
fix list of programme without programme from avenant

### DIFF
--- a/conventions/services/services_programmes.py
+++ b/conventions/services/services_programmes.py
@@ -41,6 +41,7 @@ def select_programme_create(request):
         .prefetch_related("programme")
         .prefetch_related("convention_set")
         .order_by("programme__ville", "programme__nom", "nb_logements", "financement")
+        .filter(programme__parent_id__isnull=True)
     )
     bailleurs = (
         Bailleur.objects.all().order_by("nom")


### PR DESCRIPTION
Duplicated programmes for avenant are listed in the programme - lot to set convention. It shouldn't