### PR TITLE
more resiliant error when use has no habilitation

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -21,6 +21,8 @@ import dj_database_url
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from django.core.exceptions import PermissionDenied
+
 
 def get_env_variable(name, cast=str, default=""):
     try:
@@ -418,6 +420,7 @@ if SENTRY_URL:
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,
+        ignore_errors=[PermissionDenied],
     )
 
 DRAMATIQ_BROKER = {

--- a/siap/siap_client/client.py
+++ b/siap/siap_client/client.py
@@ -6,6 +6,7 @@ import requests
 import jwt
 
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 
 from siap.siap_client.mock_data import (
     config_mock,
@@ -166,7 +167,7 @@ class SIAPClientRemote(SIAPClientInterface):
             except requests.exceptions.JSONDecodeError:
                 if habilitation_id:
                     return self.get_habilitations(user_login, 0)
-        raise Exception(
+        raise PermissionDenied(
             f"user doesn't have SIAP habilitation, SIAP error returned {response.content}"
         )
 


### PR DESCRIPTION
Update the error management to raise a permission denied (better understood by DRF) and ignore permission denied on Sentry