### PR TITLE
Support d'ipython + autoreload au build docker build

### DIFF
--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -29,6 +29,13 @@ docker-compose build
 docker-compose up -d
 ```
 
+Si vous souhaitez installer le shell `ipython` avec l'autoreload, définissez la variable d'environnement
+`IPYTHON_AUTORELOAD` au moment du build:
+
+```bash
+IPYTHON_AUTORELOAD=yes docker-compose build apilos
+```
+
 Pensez à rebuilder le container docker lorsque vous ajouter une dépendance. les dépendances sont listées dans le fichier requirements.txt à la base du projet.
 
 le code local est attaché au volume `/code/` à l'interieur du docker apilos. une seconde instance docker est executée pour la base de données. de même, les données de la base de données sont persisté car le dossier de données de la base de donnée est attaché en local dans un répéertoire pgdata ignoré par git.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 # syntax=docker/dockerfile:1
 FROM python:3.10
 ENV PYTHONUNBUFFERED=1
+ARG IPYTHON_AUTORELOAD
 
 WORKDIR /code
 COPY requirements.txt .
 COPY dev-requirements.txt .
+
+# Install ipython & setup autoreload, if required
+RUN echo "${IPYTHON_AUTORELOAD}"
+RUN if [ -n "${IPYTHON_AUTORELOAD}" ]; then pip install ipython; fi
+RUN if [ -n "${IPYTHON_AUTORELOAD}" ]; then ipython profile create; fi
+RUN if [ -n "${IPYTHON_AUTORELOAD}" ]; then echo "c.InteractiveShellApp.exec_lines = []" > ~/.ipython/profile_default/ipython_config.py; fi
+RUN if [ -n "${IPYTHON_AUTORELOAD}" ]; then echo "c.InteractiveShellApp.exec_lines.append('%load_ext autoreload')" >> ~/.ipython/profile_default/ipython_config.py; fi
+RUN if [ -n "${IPYTHON_AUTORELOAD}" ]; then echo "c.InteractiveShellApp.exec_lines.append('%autoreload 2')" >> ~/.ipython/profile_default/ipython_config.py; fi
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,10 @@ services:
       - ./redis-data:/data:delegated
       - ./redis.conf:/usr/local/etc/redis/redis.conf
   apilos: &apilos
-    build: .
+    build:
+      context: .
+      args:
+        - IPYTHON_AUTORELOAD=${IPYTHON_AUTORELOAD:-}
     volumes:
       # Use: cached to get better performances on read-heavy workloads, typically here the mounted code will be edited on the host
       - .:/code:cached


### PR DESCRIPTION
# Support d'ipython + autoreload au build docker build

Il m'arrive de tester en live depuis un `manage.py shell` le code que j'édite. Et pour ça le mieux c'est [`ipython` avec l'_autoreload_](https://stackoverflow.com/questions/1907993/autoreload-of-modules-in-ipython).

Pour pouvoir rebuilder facilement le conteneur sans perdre la config manuelle que j'aurais ajouté, je me propose de rajouter quelques étapes _optionnelles_ de build. Il suffit de définir une variable `IPYTHON_AUTORELOAD=yes` au moment du build