### PR TITLE
Tests unitaires sur la view "Liste des conventions"

### DIFF
--- a/conventions/tests/views/test_index_view.py
+++ b/conventions/tests/views/test_index_view.py
@@ -1,0 +1,42 @@
+from bs4 import BeautifulSoup
+
+from django.test import TestCase
+from django.urls import reverse
+
+from core.tests import utils_fixtures
+
+
+class ConventionIndexViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        utils_fixtures.create_all()
+
+    def test_get_list(self):
+        """
+        Test displaying convention list as superuser without filter nor order
+        """
+        # login as superuser
+        self.client.post(reverse("login"), {"username": "nicolas", "password": "12345"})
+
+        response = self.client.get(reverse("conventions:index"))
+        soup = BeautifulSoup(response.content, 'html.parser')
+        galion_refs = soup.find_all(attrs={'data-test-role': "programme-galion-cell"})
+        financements = soup.find_all(attrs={'data-test-role': "programme-financement-cell"})
+
+        self.assertListEqual([r.text for r in galion_refs], ['12345', '12345', '98765', '98765'])
+        self.assertListEqual([f.text for f in financements], ['PLUS', 'PLAI', 'PLUS', 'PLAI'])
+
+    def test_get_list_ordered_by_bailleur(self):
+        """
+        Test displaying convention list as superuser without filter but with bailleur order
+        """
+        # login as superuser
+        self.client.post(reverse("login"), {"username": "nicolas", "password": "12345"})
+
+        response = self.client.get(reverse("conventions:index"), data={'order_by': "programme__bailleur__nom"})
+        soup = BeautifulSoup(response.content, 'html.parser')
+        galion_refs = soup.find_all(attrs={'data-test-role': "programme-galion-cell"})
+        financements = soup.find_all(attrs={'data-test-role': "programme-financement-cell"})
+
+        self.assertListEqual([r.text for r in galion_refs], ['12345', '12345', '98765', '98765'])
+        self.assertListEqual([f.text for f in financements], ['PLUS', 'PLAI', 'PLUS', 'PLAI'])

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -6,3 +6,4 @@ djhtml
 mock
 pre-commit
 pylint
+beautifulsoup4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,6 +10,10 @@ astroid==2.12.12 \
     # via
     #   -c requirements.txt
     #   pylint
+beautifulsoup4==4.11.1 \
+    --hash=sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30 \
+    --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
+    # via -r dev-requirements.in
 black==22.10.0 \
     --hash=sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7 \
     --hash=sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6 \
@@ -227,6 +231,10 @@ pyyaml==6.0 \
     # via
     #   -c requirements.txt
     #   pre-commit
+soupsieve==2.3.2.post1 \
+    --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759 \
+    --hash=sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
+    # via beautifulsoup4
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -169,9 +169,9 @@
                                         {% endif %}
                                         <td>
                                             <strong>{{convention.programme.nom}}</strong><br/>
-                                            <em>{{convention.programme.numero_galion}}</em>
+                                            <em data-test-role="programme-galion-cell">{{convention.programme.numero_galion}}</em>
                                         </td>
-                                        <td>{{convention.financement}}</td>
+                                        <td data-test-role="programme-financement-cell">{{convention.financement}}</td>
                                         <td>
                                             <strong>{{convention.programme.ville}}</strong><br/>
                                             <em>{{convention.programme.code_postal}}</em>


### PR DESCRIPTION
# Tests unitaires sur la view "Liste des conventions"

Suite au [fix ultra rapide ⚡ 🏃 🚀 de @kolok](https://github.com/MTES-MCT/apilos/pull/408) sur [le problème Sentry de tri par bailleur](https://sentry.incubateur.net/organizations/betagouv/issues/13502/events/) sur la liste des conventions, je rajoute un peu de tests unitaires. Parce qu'on a du code coverage mais aussi parce que j'avais commencé le fix moi aussi :)

Au menu je rajoute [`beautifulsoup4`](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) en dépendance de dév pour exploiter le DOM que je récupère, en ayant au préalable posé des attributs `data-test-role` sur les éléments du DOM que je veux exploiter dans mes tests.