### PR TITLE
Corriger l'erreur Sentry "APILOS-10Y"

### DIFF
--- a/conventions/services/utils.py
+++ b/conventions/services/utils.py
@@ -36,12 +36,15 @@ def get_text_and_files_from_field(name, field):
     if field:
         try:
             object_field = json.loads(field)
+            # Fix potentially malformed JSON
+            if type(object_field['files']) is not dict:
+                object_field['files'] = {}
         except json.decoder.JSONDecodeError:
             object_field = {
                 "files": {},
                 "text": field if isinstance(field, str) else "",
             }
-        files = {k: v for k, v in object_field["files"].items() if is_valid_uuid(k)}
+        files = {k: v for k, v in object_field.get("files", files).items() if is_valid_uuid(k)}
     returned_files = {}
     for file in UploadedFile.objects.filter(uuid__in=files):
         returned_files[str(file.uuid)] = {


### PR DESCRIPTION
# Corriger l'erreur Sentry "APILOS-10Y"

Soit [cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/14149/events/efc227d19ab44b179007eed4559491bc/?environment=production&project=29&statsPeriod=24h) remontée ce jour [par Audrey](https://mattermost.incubateur.net/fabnum-mte/pl/kq5eymik13ba3m319ebt416r8r)