### PR TITLE
S701: Ecoloweb: améliorations

### DIFF
--- a/ecoloweb/services/importers_administrations.py
+++ b/ecoloweb/services/importers_administrations.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List
 
 from .importers import ModelImporter
@@ -9,12 +8,8 @@ from instructeurs.models import Administration
 class AdministrationImporter(ModelImporter):
     model = Administration
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query = self._get_file_content('resources/sql/administrations.sql')
-
-    def _get_sql_one_query(self) -> str:
-        return self._query
+    def _get_query_one(self) -> str:
+        return self._get_file_content('resources/sql/administrations.sql')
 
     def _get_identity_keys(self) -> List[str]:
         return ['code']

--- a/ecoloweb/services/importers_bailleurs.py
+++ b/ecoloweb/services/importers_bailleurs.py
@@ -20,23 +20,23 @@ class BailleurImporter(ModelImporter):
     def _get_identity_keys(self) -> List[str]:
         return ['siret']
 
-    # def _prepare_data(self, data: dict) -> dict:
-    #     codesiret = data.pop('codesiret')
-    #     codesiren = data.pop('codesiren')
-    #     codepersonne = data.pop('codepersonne')
-    #     date_creation = data['cree_le']
-    #
-    #     #
-    #     if codesiret is not None:
-    #         data['siret'] = codesiret
-    #
-    #     elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
-    #         data['siret'] = siret
-    #
-    #     elif codesiren is not None:
-    #         data['siret'] = codesiren
-    #
-    #     else:
-    #         data['siret'] = codepersonne
-    #
-    #     return data
+    def _prepare_data(self, data: dict) -> dict:
+        codesiret = data.pop('codesiret')
+        codesiren = data.pop('codesiren')
+        codepersonne = data.pop('codepersonne')
+        date_creation = data['cree_le']
+
+        #
+        if codesiret is not None:
+            data['siret'] = codesiret
+
+        #elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
+        #    data['siret'] = siret
+
+        elif codesiren is not None:
+            data['siret'] = codesiren
+
+        else:
+            data['siret'] = codepersonne
+
+        return data

--- a/ecoloweb/services/importers_bailleurs.py
+++ b/ecoloweb/services/importers_bailleurs.py
@@ -11,32 +11,32 @@ class BailleurImporter(ModelImporter):
 
     def __init__(self, departement: str, import_date: datetime, debug=False):
         super().__init__(departement, import_date, debug)
-        self._siret_resolver = SiretResolver()
-        self._query = self._get_file_content('resources/sql/bailleurs.sql')
 
-    def _get_sql_one_query(self) -> str:
-        return self._query
+        #self._siret_resolver = SiretResolver()
+
+    def _get_query_one(self) -> str:
+        return self._get_file_content('resources/sql/bailleurs.sql')
 
     def _get_identity_keys(self) -> List[str]:
         return ['siret']
 
-    def _prepare_data(self, data: dict) -> dict:
-        codesiret = data.pop('codesiret')
-        codesiren = data.pop('codesiren')
-        codepersonne = data.pop('codepersonne')
-        date_creation = data['cree_le']
-
-        #
-        if codesiret is not None:
-            data['siret'] = codesiret
-
-        elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
-            data['siret'] = siret
-
-        elif codesiren is not None:
-            data['siret'] = codesiren
-
-        else:
-            data['siret'] = codepersonne
-
-        return data
+    # def _prepare_data(self, data: dict) -> dict:
+    #     codesiret = data.pop('codesiret')
+    #     codesiren = data.pop('codesiren')
+    #     codepersonne = data.pop('codepersonne')
+    #     date_creation = data['cree_le']
+    #
+    #     #
+    #     if codesiret is not None:
+    #         data['siret'] = codesiret
+    #
+    #     elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
+    #         data['siret'] = siret
+    #
+    #     elif codesiren is not None:
+    #         data['siret'] = codesiren
+    #
+    #     else:
+    #         data['siret'] = codepersonne
+    #
+    #     return data

--- a/ecoloweb/services/importers_bailleurs.py
+++ b/ecoloweb/services/importers_bailleurs.py
@@ -12,7 +12,7 @@ class BailleurImporter(ModelImporter):
     def __init__(self, departement: str, import_date: datetime, debug=False):
         super().__init__(departement, import_date, debug)
 
-        #self._siret_resolver = SiretResolver()
+        self._siret_resolver = SiretResolver()
 
     def _get_query_one(self) -> str:
         return self._get_file_content('resources/sql/bailleurs.sql')
@@ -26,12 +26,12 @@ class BailleurImporter(ModelImporter):
         codepersonne = data.pop('codepersonne')
         date_creation = data['cree_le']
 
-        #
+        # Clean SIRET code
         if codesiret is not None:
             data['siret'] = codesiret
 
-        #elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
-        #    data['siret'] = siret
+        elif (siret := self._siret_resolver.resolve(codesiren, date_creation)) is not None:
+            data['siret'] = siret
 
         elif codesiren is not None:
             data['siret'] = codesiren

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -1,6 +1,6 @@
 from conventions.models import Convention
 from .importers import ModelImporter
-from .importers_programmes import ProgrammeImporter, ProgrammeLotImporter
+from .importers_programmes import ProgrammeImporter, ProgrammeLotImporter, ProgrammeImporterSimple
 from .query_iterator import QueryResultIterator
 
 
@@ -13,8 +13,8 @@ class ConventionImporter(ModelImporter):
 
     def _get_o2o_dependencies(self):
         return {
-            'programme': ProgrammeImporter(self.departement, self.import_date, self.debug),
-            'lot': ProgrammeLotImporter(self.departement, self.import_date, self.debug),
+            'programme': ProgrammeImporter,
+            'lot': ProgrammeLotImporter,
         }
 
     def get_all_by_departement(self) -> QueryResultIterator:

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -7,7 +7,7 @@ from .query_iterator import QueryResultIterator
 class ConventionImporter(ModelImporter):
     model = Convention
 
-    def _get_sql_one_query(self) -> str:
+    def _get_query_one(self) -> str:
         # No base query as conventions are never requested individually
         return ''
 

--- a/ecoloweb/services/importers_programmes.py
+++ b/ecoloweb/services/importers_programmes.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional
 
 from programmes.models import Programme, Lot, Logement, ReferenceCadastrale, TypeStationnement
@@ -14,12 +13,8 @@ class ProgrammeImporterSimple(ModelImporter):
     """
     model = Programme
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query = self._get_file_content('resources/sql/programmes.sql')
-
-    def _get_sql_one_query(self) -> str:
-        return self._query
+    def _get_query_one(self) -> str:
+        return self._get_file_content('resources/sql/programmes.sql')
 
     def _get_identity_keys(self) -> List[str]:
         return ['numero_galion']
@@ -42,16 +37,11 @@ class ProgrammeLotImporterSimple(ModelImporter):
     """
     model = Lot
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query_one = self._get_file_content('resources/sql/programme_lots.sql')
-        self._query_many = self._get_file_content('resources/sql/programme_lots_many.sql')
+    def _get_query_one(self) -> str:
+        return self._get_file_content('resources/sql/programme_lots.sql')
 
-    def _get_sql_one_query(self) -> str:
-        return self._query_one
-
-    def _get_sql_many_query(self) -> Optional[str]:
-        return self._query_many
+    def _get_query_many(self) -> Optional[str]:
+        return self._get_file_content('resources/sql/programme_lots_many.sql')
 
 
 class ProgrammeLotImporter(ProgrammeLotImporterSimple):
@@ -67,16 +57,8 @@ class ProgrammeLotImporter(ProgrammeLotImporterSimple):
 class ProgrammeLogementImporter(ModelImporter):
     model = Logement
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query = self._get_file_content('resources/sql/programme_logements.sql')
-
-    def _get_sql_one_query(self) -> str:
-        # No single query defined for Lots, as it's only used to fetch one to many
-        return ''
-
-    def _get_sql_many_query(self) -> str:
-        return self._query
+    def _get_query_many(self) -> str:
+        return self._get_file_content('resources/sql/programme_logements.sql')
 
     def _get_o2o_dependencies(self):
         return {
@@ -87,10 +69,6 @@ class ProgrammeLogementImporter(ModelImporter):
 class ReferenceCadastraleImporter(ModelImporter):
     model = ReferenceCadastrale
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query = self._get_file_content('resources/sql/programme_reference_cadastrale.sql')
-
     def _prepare_data(self, data: dict) -> dict:
         superficie = data.pop('superficie', 0)
 
@@ -98,12 +76,8 @@ class ReferenceCadastraleImporter(ModelImporter):
 
         return data
 
-    def _get_sql_one_query(self) -> str:
-        # No single query defined here, as it's only used to fetch one to many
-        return ''
-
-    def _get_sql_many_query(self) -> Optional[str]:
-        return self._query
+    def _get_query_many(self) -> Optional[str]:
+        return self._get_file_content('resources/sql/programme_reference_cadastrale.sql')
 
     def _get_o2o_dependencies(self):
         return {
@@ -114,16 +88,8 @@ class ReferenceCadastraleImporter(ModelImporter):
 class TypeStationnementImporter(ModelImporter):
     model = TypeStationnement
 
-    def __init__(self, departement: str, import_date: datetime, debug=False):
-        super().__init__(departement, import_date, debug)
-        self._query = self._get_file_content('resources/sql/programme_type_stationnement.sql')
-
-    def _get_sql_one_query(self) -> str:
-        # No single query defined here, as it's only used to fetch one to many
-        return ''
-
-    def _get_sql_many_query(self) -> Optional[str]:
-        return self._query
+    def _get_query_many(self) -> Optional[str]:
+        return self._get_file_content('resources/sql/programme_type_stationnement.sql')
 
     def _get_o2o_dependencies(self):
         return {

--- a/ecoloweb/services/importers_programmes.py
+++ b/ecoloweb/services/importers_programmes.py
@@ -8,7 +8,10 @@ from .importers_administrations import AdministrationImporter
 from .importers_bailleurs import BailleurImporter
 
 
-class ProgrammeImporter(ModelImporter):
+class ProgrammeImporterSimple(ModelImporter):
+    """
+    Importer for the Programme model, without one-to-one nor one-to-many dependency
+    """
     model = Programme
 
     def __init__(self, departement: str, import_date: datetime, debug=False):
@@ -21,20 +24,22 @@ class ProgrammeImporter(ModelImporter):
     def _get_identity_keys(self) -> List[str]:
         return ['numero_galion']
 
+
+class ProgrammeImporter(ProgrammeImporterSimple):
     def _get_o2o_dependencies(self):
         return {
-            'bailleur': BailleurImporter(self.departement, self.import_date, self.debug),
-            'administration': AdministrationImporter(self.departement, self.import_date, self.debug),
+            'bailleur': BailleurImporter,
+            'administration': AdministrationImporter,
         }
 
-    def _get_o2m_dependencies(self):
-       return {
-           'lot': ProgrammeLotImporter(self.departement, self.import_date, self.debug),
-           'cadastre': ReferenceCadastraleImporter(self.departement, self.import_date, self.debug)
-       }
+    def _get_o2m_dependencies(self) -> List:
+        return [ReferenceCadastraleImporter]
 
 
-class ProgrammeLotImporter(ModelImporter):
+class ProgrammeLotImporterSimple(ModelImporter):
+    """
+    Importer for the ProgrammeLot model, without one-to-one nor one-to-many dependency
+    """
     model = Lot
 
     def __init__(self, departement: str, import_date: datetime, debug=False):
@@ -48,16 +53,15 @@ class ProgrammeLotImporter(ModelImporter):
     def _get_sql_many_query(self) -> Optional[str]:
         return self._query_many
 
+
+class ProgrammeLotImporter(ProgrammeLotImporterSimple):
     def _get_o2o_dependencies(self):
         return {
-            'programme': ProgrammeImporter(self.departement, self.import_date, self.debug),
+            'programme': ProgrammeImporterSimple,
         }
 
     def _get_o2m_dependencies(self):
-        return {
-            'logement': ProgrammeLogementImporter(self.departement, self.import_date, self.debug),
-            'type_stationnement': TypeStationnementImporter(self.departement, self.import_date, self.debug),
-        }
+        return [ProgrammeLogementImporter, TypeStationnementImporter]
 
 
 class ProgrammeLogementImporter(ModelImporter):
@@ -76,7 +80,7 @@ class ProgrammeLogementImporter(ModelImporter):
 
     def _get_o2o_dependencies(self):
         return {
-            'lot': ProgrammeLotImporter(self.departement, self.import_date, self.debug),
+            'lot': ProgrammeLotImporterSimple,
         }
 
 
@@ -103,7 +107,7 @@ class ReferenceCadastraleImporter(ModelImporter):
 
     def _get_o2o_dependencies(self):
         return {
-            'programme': ProgrammeImporter(self.departement, self.import_date, self.debug),
+            'programme': ProgrammeImporterSimple,
         }
 
 
@@ -123,5 +127,5 @@ class TypeStationnementImporter(ModelImporter):
 
     def _get_o2o_dependencies(self):
         return {
-            'lot': ProgrammeLotImporter(self.departement, self.import_date, self.debug),
+            'lot': ProgrammeLotImporterSimple,
         }


### PR DESCRIPTION
# S701: Ecoloweb: améliorations

[Cette tâche](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/rec9GZveswrsl4yvQ?blocks=hide) qui a pour but les améliorations suivantes:
* ne pas jouer une requête de `import_one` si on peut trouver une `EcoloReference` d'abord
* jouer les one_2_many même si l'objet avait déjà une ref (cas de l'import qui s'est choucrouté)
* la gestion des `Importers` avec requêtes single **et / ou** multiple
* la dépendance entre importers par référence de classe (et non création avec transmission de params)

 