### PR TITLE
Docker: améliorer le démarrage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - .:/code:cached
     ports:
       - "8001:8000"
+    restart: on-failure # Automatically restart on failure (if PG not up yet)
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
# Docker: améliorer le démarrage

Ça m'arrive souvent de démarrer tous les Docker et que pour autant `apilos` ne soit pas "up". Quand je regarde les logs c'est lié à PG qui n'a pas encore démarré => une petite recherche web m'apprend que le `restart: on-failure` relance le conteneur automatiquement :)