### PR TITLE
Ecoloweb: corriger l'import des pièces jointes

### DIFF
--- a/conventions/services/file.py
+++ b/conventions/services/file.py
@@ -1,6 +1,5 @@
 import datetime
 
-import dramatiq
 from django.conf import settings
 from django.core.files import File
 from django.utils import timezone
@@ -35,9 +34,3 @@ class ConventionFileService:
 
         cls.upload_convention_file(piece_jointe.convention, file)
         return True
-
-    @staticmethod
-    @dramatiq.actor
-    def promote_piece_jointe_async(pk: int):
-        piece_jointe = PieceJointe.objects.get(pk)
-        ConventionFileService.promote_piece_jointe(piece_jointe)

--- a/conventions/services/file.py
+++ b/conventions/services/file.py
@@ -1,0 +1,43 @@
+import datetime
+
+import dramatiq
+from django.conf import settings
+from django.core.files import File
+from django.utils import timezone
+
+from conventions.models import Convention, ConventionStatut, PieceJointe
+from core.storage import client
+from upload.services import UploadService
+
+
+class ConventionFileService:
+
+    @classmethod
+    def upload_convention_file(cls, convention: Convention, file: File):
+        now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
+        filename = f"{now}_convention_{convention.uuid}_signed.pdf"
+        upload_service = UploadService(
+            convention_dirpath=f"conventions/{convention.uuid}/convention_docs",
+            filename=filename,
+        )
+        upload_service.upload_file(file)
+
+        convention.statut = ConventionStatut.SIGNEE
+        convention.nom_fichier_signe = filename
+        convention.televersement_convention_signee_le = timezone.now()
+        convention.save()
+
+    @classmethod
+    def promote_piece_jointe(cls, piece_jointe: PieceJointe) -> bool:
+        file = client.get_object(settings.AWS_ECOLOWEB_BUCKET_NAME, f'piecesJointes/{piece_jointe.fichier}')
+        if file is None:
+            return False
+
+        cls.upload_convention_file(piece_jointe.convention, file)
+        return True
+
+    @staticmethod
+    @dramatiq.actor
+    def promote_piece_jointe_async(pk: int):
+        piece_jointe = PieceJointe.objects.get(pk)
+        ConventionFileService.promote_piece_jointe(piece_jointe)

--- a/conventions/services/services_conventions.py
+++ b/conventions/services/services_conventions.py
@@ -34,6 +34,7 @@ from conventions.models import (
     Pret,
 )
 from conventions.services import convention_generator, upload_objects, utils
+from conventions.services.file import ConventionFileService
 from conventions.tasks import generate_and_send
 from core.services import EmailService
 from programmes.models import Annexe, Financement
@@ -585,19 +586,7 @@ def convention_sent(request, convention_uuid):
     if request.method == "POST":
         upform = UploadForm(request.POST, request.FILES)
         if upform.is_valid():
-            file = request.FILES["file"]
-            now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
-            filename = f"{now}_convention_{convention_uuid}_signed.pdf"
-            upload_service = UploadService(
-                convention_dirpath=f"conventions/{convention_uuid}/convention_docs",
-                filename=filename,
-            )
-            upload_service.upload_file(file)
-
-            convention.statut = ConventionStatut.SIGNEE
-            convention.nom_fichier_signe = filename
-            convention.televersement_convention_signee_le = timezone.now()
-            convention.save()
+            ConventionFileService.upload_convention_file(convention, request.FILES["file"])
             result_status = utils.ReturnStatus.SUCCESS
     else:
         upform = UploadForm()

--- a/conventions/services/services_programmes.py
+++ b/conventions/services/services_programmes.py
@@ -1,9 +1,6 @@
-import datetime
-
 from django.http import HttpRequest
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils import timezone
 from django.conf import settings
 from django.db.models.query import QuerySet
 
@@ -38,10 +35,10 @@ from programmes.forms import (
     ReferenceCadastraleFormSet,
 )
 
-from upload.services import UploadService
 
 from . import utils
 from . import upload_objects
+from .file import ConventionFileService
 
 
 def _get_choices_from_object(object_list):
@@ -132,16 +129,7 @@ class ConventionSelectionService:
             self.convention.save()
             file = self.request.FILES.get("nom_fichier_signe", False)
             if file:
-                now = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M")
-                filename = f"{now}_convention_{self.convention.uuid}_signed.pdf"
-                upload_service = UploadService(
-                    convention_dirpath=f"conventions/{self.convention.uuid}/convention_docs",
-                    filename=filename,
-                )
-                upload_service.upload_file(file)
-                self.convention.nom_fichier_signe = filename
-                self.convention.televersement_convention_signee_le = timezone.now()
-                self.convention.save()
+                ConventionFileService.upload_convention_file(self.convention, file)
             self.return_status = utils.ReturnStatus.SUCCESS
 
     def get_from_db(self):

--- a/conventions/tasks.py
+++ b/conventions/tasks.py
@@ -49,7 +49,6 @@ def generate_and_send(args):
 
 @dramatiq.actor
 def promote_piece_jointe(pk: int):
-    print("Id is ", pk)
     piece_jointe = PieceJointe.objects.get(id=pk)
     if piece_jointe.convention.nom_fichier_signe is None:
         ConventionFileService.promote_piece_jointe(piece_jointe)

--- a/conventions/tasks.py
+++ b/conventions/tasks.py
@@ -2,7 +2,8 @@ from zipfile import ZipFile
 from django.conf import settings
 import dramatiq
 from conventions.services import convention_generator
-from conventions.models import Convention
+from conventions.models import Convention, PieceJointe
+from conventions.services.file import ConventionFileService
 from core.services import EmailService
 
 
@@ -45,3 +46,10 @@ def generate_and_send(args):
         [convention_email_validator],
         str(local_zip_path) if local_zip_path is not None else str(local_pdf_path),
     )
+
+@dramatiq.actor
+def promote_piece_jointe(pk: int):
+    print("Id is ", pk)
+    piece_jointe = PieceJointe.objects.get(id=pk)
+    if piece_jointe.convention.nom_fichier_signe is None:
+        ConventionFileService.promote_piece_jointe(piece_jointe)

--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -173,7 +173,7 @@ urlpatterns = [
         name="fiche_caf",
     ),
     path("new_avenant/<convention_uuid>", views.new_avenant, name="new_avenant"),
-    path("piece_jointe/<piece_jointe_uuid>", views.piece_jointe, name="piece_jointe"),
+    path("piece_jointe/<piece_jointe_uuid>", views.piece_jointe_access, name="piece_jointe"),
     path(
         "piece_jointe/<piece_jointe_uuid>/promote",
         views.piece_jointe_promote,

--- a/conventions/views/viewsconventions.py
+++ b/conventions/views/viewsconventions.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from datetime import datetime
 from typing import List
 
 from zipfile import ZipFile
@@ -19,10 +18,10 @@ from django.http import (
 )
 from django.shortcuts import render
 from django.urls import reverse
-from django.utils import timezone
 from django.views import View
 from django.views.decorators.http import require_GET, require_http_methods
 
+from conventions.services.file import ConventionFileService
 from core.storage import client
 from upload.services import UploadService
 from conventions.models import Convention, ConventionStatut, PieceJointe
@@ -331,7 +330,7 @@ def fiche_caf(request, convention_uuid):
 
 @login_required
 @permission_required("convention.add_convention")
-def piece_jointe(request, piece_jointe_uuid):
+def piece_jointe_access(request, piece_jointe_uuid):
     """
     Display the raw file associated to the pièce jointe
     """
@@ -356,40 +355,22 @@ def piece_jointe_promote(request, piece_jointe_uuid):
     """
     Promote a pièce jointe to the official PDF document of a convention
     """
-    piece_jointe_from_db = PieceJointe.objects.get(uuid=piece_jointe_uuid)
+    piece_jointe = PieceJointe.objects.get(uuid=piece_jointe_uuid)
 
-    if piece_jointe_from_db is None:
+    if piece_jointe is None:
         return HttpResponseNotFound
 
-    if piece_jointe_from_db.convention.ecolo_reference is None:
+    if piece_jointe.convention.ecolo_reference is None:
         return HttpResponseForbidden()
 
-    if not piece_jointe_from_db.is_convention():
+    if not piece_jointe.is_convention():
         return HttpResponseForbidden()
 
-    o = client.get_object(
-        settings.AWS_ECOLOWEB_BUCKET_NAME,
-        f"piecesJointes/{piece_jointe_from_db.fichier}",
-    )
-
-    if o is None:
+    if not ConventionFileService.promote_piece_jointe(piece_jointe):
         return HttpResponseNotFound
-
-    now = datetime.now().strftime("%Y-%m-%d_%H-%M")
-    filename = f"{now}_convention_{piece_jointe_from_db.convention.uuid}_signed.pdf"
-    upload_service = UploadService(
-        convention_dirpath=f"conventions/{piece_jointe_from_db.convention.uuid}/convention_docs",
-        filename=filename,
-    )
-    upload_service.upload_file(o["Body"])
-
-    piece_jointe_from_db.convention.statut = ConventionStatut.SIGNEE
-    piece_jointe_from_db.convention.nom_fichier_signe = filename
-    piece_jointe_from_db.convention.televersement_convention_signee_le = timezone.now()
-    piece_jointe_from_db.convention.save()
 
     return HttpResponseRedirect(
-        reverse("conventions:preview", args=[piece_jointe_from_db.convention.uuid])
+        reverse("conventions:preview", args=[piece_jointe.convention.uuid])
     )
 
 

--- a/conventions/views/viewsconventions.py
+++ b/conventions/views/viewsconventions.py
@@ -329,6 +329,7 @@ def fiche_caf(request, convention_uuid):
 
 
 @login_required
+@require_GET
 @permission_required("convention.add_convention")
 def piece_jointe_access(request, piece_jointe_uuid):
     """
@@ -351,7 +352,7 @@ def piece_jointe_access(request, piece_jointe_uuid):
 
 @login_required
 @permission_required("convention.add_convention")
-def piece_jointe_promote(request, piece_jointe_uuid):
+def piece_jointe_promote(piece_jointe_uuid):
     """
     Promote a pièce jointe to the official PDF document of a convention
     """

--- a/core/storage.py
+++ b/core/storage.py
@@ -1,6 +1,8 @@
 from botocore.exceptions import ClientError
 from django.conf import settings
 import boto3
+from django.core.files import File
+from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class StorageClient:
@@ -29,17 +31,12 @@ class StorageClient:
                 CacheControl="max-age=31556926",  # 1 year
             )
 
-    def get_object(self, bucket, file) -> dict | None:
+    def get_object(self, bucket, file: str) -> File | None:
         if self.is_s3:
-            resource = boto3.resource(
-                "s3",
-                region_name=settings.AWS_S3_REGION_NAME,
-                endpoint_url=settings.AWS_S3_ENDPOINT_URL,
-                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-            )
+            storage = S3Boto3Storage(bucket_name=bucket)
+
             try:
-                return resource.Object(bucket, file).get()
+                return storage.open(file)
             except ClientError:
                 return None
 

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -16,21 +16,10 @@ class ConventionImporterSimple(ModelImporter):
     def _get_query_one(self) -> str | None:
         return self._get_file_content('resources/sql/conventions.sql')
 
-    def _query_single_row(self, pk) -> Dict | None:
-        """
-        Execute a SQL query returning a single result, as dict
-        """
+    def _build_query_parameters(self, pk) -> list:
         args = pk.split(':')
 
-        if self._query_one is None:
-            return None
-
-        self._db_connection.execute(self._query_one, [int(args[0]), args[1]])
-
-        columns = [col[0] for col in self._db_connection.description]
-        row = self._db_connection.fetchone()
-
-        return dict(zip(columns, row)) if row else None
+        return [int(args[0]), args[1], args[2]]
 
 
 class ConventionImporter(ConventionImporterSimple):
@@ -70,19 +59,3 @@ class PieceJointeImporter(ModelImporter):
         return {
             'convention': ConventionImporterSimple
         }
-
-    def import_many(self, fk):
-        """
-        Public entry point method to fetch a list of models from the Ecoloweb database based on its foreign key
-        """
-        args = fk.split(':')
-
-        if self._query_many is not None:
-            iterator = QueryResultIterator(
-                self._db_connection,
-                self._get_query_many(),
-                [int(args[0]), args[1]]
-            )
-
-            for result in iterator:
-                self.process_result(result)

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -38,7 +38,7 @@ class ConventionImporter(ConventionImporterSimple):
 class PieceJointeImporter(ModelImporter):
     model = PieceJointe
 
-    def _get_sql_many_query(self) -> Optional[str]:
+    def _get_query_many(self) -> str | None:
         return self._get_file_content('resources/sql/convention_pieces_jointes.sql')
 
     def _get_o2o_dependencies(self):

--- a/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
+++ b/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
@@ -1,6 +1,6 @@
 select
     pj.id,
-    md5(c.id||'-'||ff.code) as convention_id,
+    c.id||':'||ff.code as convention_id,
     case
         when vps.code = '1' then 'CONVENTION'
         when vps.code = '2' then 'RECTIFICATION'
@@ -21,4 +21,5 @@ from ecolo.ecolo_piecejointe pj
     inner join ecolo.ecolo_typefinancement tf on pl.typefinancement_id = tf.id
     inner join ecolo.ecolo_famillefinancement ff on tf.famillefinancement_id = ff.id
 where
-    md5(c.id||'-'||ff.code) = %s
+    c.id = %s
+    and ff.code = %s

--- a/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
+++ b/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
@@ -1,6 +1,6 @@
 select
     pj.id,
-    c.id||':'||ff.code as convention_id,
+    c.id||':'||ff.code||':'||cdg.datehistoriquedebut as convention_id,
     case
         when vps.code = '1' then 'CONVENTION'
         when vps.code = '2' then 'RECTIFICATION'
@@ -23,3 +23,4 @@ from ecolo.ecolo_piecejointe pj
 where
     c.id = %s
     and ff.code = %s
+    and cdg.datehistoriquedebut = %s

--- a/ecoloweb/services/resources/sql/conventions.sql
+++ b/ecoloweb/services/resources/sql/conventions.sql
@@ -5,7 +5,7 @@
 -- avenant_type                       varchar(25)
 -- parent_id                          FK(conventions) i.e. les avenants
 select
-    c.id||':'||pl.financement as id,
+    c.id||':'||pl.financement||':'||cdg.datehistoriquedebut as id,
     cdg.id as programme_id,
     md5(cdg.id||'-'||pl.financement) as lot_id, -- Les lots d'un programme sont tous les logements partageant le même financement
     pl.financement as financement,
@@ -55,4 +55,5 @@ from ecolo.ecolo_conventionapl c
 where
     c.id = %s
     and pl.financement = %s
+    and cdg.datehistoriquedebut = %s
 

--- a/ecoloweb/services/resources/sql/conventions.sql
+++ b/ecoloweb/services/resources/sql/conventions.sql
@@ -5,7 +5,7 @@
 -- avenant_type                       varchar(25)
 -- parent_id                          FK(conventions) i.e. les avenants
 select
-    md5(c.id||'-'||pl.financement) as id,
+    c.id||':'||pl.financement as id,
     cdg.id as programme_id,
     md5(cdg.id||'-'||pl.financement) as lot_id, -- Les lots d'un programme sont tous les logements partageant le même financement
     pl.financement as financement,
@@ -53,5 +53,6 @@ from ecolo.ecolo_conventionapl c
             inner join ecolo.ecolo_famillefinancement ff on tf.famillefinancement_id = ff.id
     ) pl on pl.conventiondonneesgenerales_id = cdg.id
 where
-    md5(c.id||'-'||pl.financement) = %s
+    c.id = %s
+    and pl.financement = %s
 

--- a/ecoloweb/services/resources/sql/conventions_many.sql
+++ b/ecoloweb/services/resources/sql/conventions_many.sql
@@ -20,7 +20,7 @@
 -- signataire_fonction                varchar(255)
 -- signataire_nom                     varchar(255)
 select
-    md5(c.id||'-'||pl.financement) as id,
+    c.id||':'||pl.financement as id,
     cdg.id as programme_id,
     md5(cdg.id||'-'||pl.financement) as lot_id, -- Les lots d'un programme sont tous les logements partageant le même financement
     pl.financement as financement,

--- a/ecoloweb/services/resources/sql/conventions_many.sql
+++ b/ecoloweb/services/resources/sql/conventions_many.sql
@@ -20,7 +20,7 @@
 -- signataire_fonction                varchar(255)
 -- signataire_nom                     varchar(255)
 select
-    c.id||':'||pl.financement as id,
+    c.id||':'||pl.financement||':'||cdg.datehistoriquedebut as id,
     cdg.id as programme_id,
     md5(cdg.id||'-'||pl.financement) as lot_id, -- Les lots d'un programme sont tous les logements partageant le même financement
     pl.financement as financement,
@@ -59,7 +59,6 @@ from ecolo.ecolo_conventionapl c
     ) pl on pl.conventiondonneesgenerales_id = cdg.id
 where
     nl.code = '1' -- Seulement les "Logements ordinaires"
-    and pl.departement = %s
     -- On exclue les conventions ayant (au moins) un lot associé à plus d'un bailleur ou d'une commune
     and not exists (
         select
@@ -72,5 +71,7 @@ where
         group by pl2.conventiondonneesgenerales_id, ff2.libelle
         having count(distinct(pl2.commune_id)) > 1 or count(distinct(pl2.bailleurproprietaire_id)) > 1
     )
+    and cdg.estcourante
+    and pl.departement = %s
 order by cdg.datehistoriquedebut desc, cdg.datesignatureentitegest desc nulls last
 

--- a/upload/services.py
+++ b/upload/services.py
@@ -1,6 +1,7 @@
 import errno
 
 from django.conf import settings
+from django.core.files import File
 from django.core.files.storage import default_storage
 
 
@@ -17,7 +18,7 @@ class UploadService:
         self.convention_dirpath = convention_dirpath
         self.filename = filename
 
-    def upload_file(self, file) -> None:
+    def upload_file(self, file: File) -> None:
         if (
             settings.DEFAULT_FILE_STORAGE
             == "django.core.files.storage.FileSystemStorage"
@@ -34,7 +35,8 @@ class UploadService:
             "bw",
         )
 
-        destination.write(file.read())
+        for chunk in file.chunks():
+            destination.write(chunk)
         destination.close()
 
     def upload_file_io(self, file_io) -> None:


### PR DESCRIPTION
# Ecoloweb: corriger l'import des pièces jointes

Le problème initial: aucune pièce jointe n'avait été remonté au cours du test sur le Finistère. La cause ? Un renommage de méthode pas intégrée à une sous classe lors d'un quadruple rebase de branches :/ Donc vite corrigée par le renommage de la méthode `PieceJointeImporter._get_query_many`.

**Mais** j'ai intégré 3 changements majeurs:
* la dernière pièce jointe de type `CONVENTION` est _automatiquement_ promue (et uploadée) comme document de convention
* pour ça j'ai [délégué la gestion de l'upload de doc de convention](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/rec7kfR6tsGN2u3WA?blocks=hide) au service `ConventionFileService`
* j'ai optimisé la requête de `PieceJointe` (sans quoi 3s par requête = imports ~4x plus longs) en _splittant_ les clefs composites issues d'Ecolo (id de convention = `<convention_apl.id>:<famille_financement.code>:<convention_donnees_generales.datehistorique_debut>`) => si je vous perds ici c'est normal, je peux vous faire un topo à l'oral si ça vous intéresse (mais pas sûr)
