### PR TITLE
s705 Ecoloweb: intégrer les données ANRU + ANAH

### DIFF
--- a/bailleurs/models.py
+++ b/bailleurs/models.py
@@ -134,6 +134,9 @@ class Bailleur(IngestableModel):
 
     label = property(_get_nom)
 
+    def is_prives(self):
+        return self.nature_bailleur == NatureBailleur.PRIVES
+
     def is_hlm(self):
         return self.sous_nature_bailleur in [
             SousNatureBailleur.OFFICE_PUBLIC_HLM,

--- a/templates/conventions/recapitulatif/bailleur.html
+++ b/templates/conventions/recapitulatif/bailleur.html
@@ -15,34 +15,42 @@
                     </div>
                     {% with bailleur_uuid=bailleur.uuid|slugify %}
                         <div class="fr-grid-row fr-grid-row--gutters">
-                            <div class="fr-col-12 fr-col-lg-6">
-                                <div class="fr-mb-2w">
-                                    <strong>{% include "common/display_field_if_exists.html" with value=bailleur.nom object_field="bailleur__nom__"|add:bailleur_uuid %}</strong>
-                                    <div class="fr-ml-3w">
-                                        {% include "common/display_field_if_exists.html" with value=bailleur.adresse object_field="bailleur__adresse__"|add:bailleur_uuid %}
-                                        <div class="fr-grid-row fr-grid-row--gutters">
-                                            <div class="fr-col-6">
-                                                {% include "common/display_field_if_exists.html" with value=bailleur.code_postal object_field="bailleur__code_postal__"|add:bailleur_uuid %}
-                                            </div>
-                                            <div class="fr-col-6">
-                                                {% include "common/display_field_if_exists.html" with value=bailleur.ville object_field="bailleur__ville__"|add:bailleur_uuid %}
+                            {% if bailleur.is_prives %}
+                                <div class="fr-col-12">
+                                    <div class="fr-mb-2w">
+                                        <strong>{% include "common/display_field_if_exists.html" with value='Personne physique' %}</strong>
+                                    </div>
+                                </div>
+                            {% else %}
+                                <div class="fr-col-12 fr-col-lg-6">
+                                    <div class="fr-mb-2w">
+                                        <strong>{% include "common/display_field_if_exists.html" with value=bailleur.nom object_field="bailleur__nom__"|add:bailleur_uuid %}</strong>
+                                        <div class="fr-ml-3w">
+                                            {% include "common/display_field_if_exists.html" with value=bailleur.adresse object_field="bailleur__adresse__"|add:bailleur_uuid %}
+                                            <div class="fr-grid-row fr-grid-row--gutters">
+                                                <div class="fr-col-6">
+                                                    {% include "common/display_field_if_exists.html" with value=bailleur.code_postal object_field="bailleur__code_postal__"|add:bailleur_uuid %}
+                                                </div>
+                                                <div class="fr-col-6">
+                                                    {% include "common/display_field_if_exists.html" with value=bailleur.ville object_field="bailleur__ville__"|add:bailleur_uuid %}
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
+                                    <div>
+                                        {% include "common/display_field_if_exists.html" with label="SIRET" value=bailleur.siret object_field="bailleur__siret__"|add:bailleur_uuid %}
+                                        {% include "common/display_field_if_exists.html" with label="Capital social" value=bailleur.capital_social object_field="bailleur__capital_social__"|add:bailleur_uuid %}
+                                    </div>
                                 </div>
-                                <div>
-                                    {% include "common/display_field_if_exists.html" with label="SIRET" value=bailleur.siret object_field="bailleur__siret__"|add:bailleur_uuid %}
-                                    {% include "common/display_field_if_exists.html" with label="Capital social" value=bailleur.capital_social object_field="bailleur__capital_social__"|add:bailleur_uuid %}
+                                <div class="fr-col-12 fr-col-lg-6">
+                                    <p class="fr-my-1w"><strong>Signataire de la convention</strong>{% if convention.programme.is_foyer %} (Propriétaire){% endif %}</p>
+                                    <div class="fr-ml-3w">
+                                        {% include "common/display_field_if_exists.html" with value=convention.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}
+                                        <em>{% include "common/display_field_if_exists.html" with value=convention.signataire_fonction object_field="bailleur__signataire_fonction__"|add:bailleur_uuid %}</em>
+                                        {% include "common/display_field_if_exists.html" with label="Date de délibération" value=convention.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:bailleur_uuid %}
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="fr-col-12 fr-col-lg-6">
-                                <p class="fr-my-1w"><strong>Signataire de la convention</strong>{% if convention.programme.is_foyer %} (Propriétaire){% endif %}</p>
-                                <div class="fr-ml-3w">
-                                    {% include "common/display_field_if_exists.html" with value=convention.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}
-                                    <em>{% include "common/display_field_if_exists.html" with value=convention.signataire_fonction object_field="bailleur__signataire_fonction__"|add:bailleur_uuid %}</em>
-                                    {% include "common/display_field_if_exists.html" with label="Date de délibération" value=convention.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:bailleur_uuid %}
-                                </div>
-                            </div>
+                            {% endif %}
                         </div>
                     {% endwith %}
                     {% if convention.programme.is_foyer and convention.gestionnaire %}


### PR DESCRIPTION
# s705 Ecoloweb: intégrer les données ANRU + ANAH

Cette [tâche](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/rec4JnHO3IFjr5N2l?blocks=hide). En gros si le bailleur remonté par Ecoloweb est l'ANAH, soit dont la nature est `Bailleurs privés`, on remplace les infos par "Personne physique". J'ai l'impression qu'on pourrait / devrait afficher beaucoup plus d'infos sur ce sujet mais je n'y connais rien et j'ai la sensation que c'est mineur ...

Pour ce qui est de l'ANRU, j'ai pas réussi à trouver quoi que ce soit côté Ecoloweb qui me permette de remonter l'info :/