### PR TITLE
Changer l'adresse email d'envoi par default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: pylint
         name: PyLint
-        entry: python -m pylint.__main__
+        entry: python -m pylint.__main__ --help-msg=django-not-configured
         language: system
         files: \.py$
 -   repo: https://github.com/rtts/djhtml

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,15 +1,17 @@
 [MASTER]
+load-plugins=pylint_django
+django-settings-module=core.settings
 ignore-paths=
+    core/settings.py,
     bailleurs/migrations,
     conventions/migrations,
     programmes/migrations,
     users/migrations,
 disable=
+    django-not-configured,
     C0103, # invalid-name
     C0114, # missing-module-docstring
     C0115, # missing-class-docstring
     C0116, # missing-function-docstring
-load-plugins=pylint_django
-django-settings-module=core.settings
 min-similarity-lines=20
 max-args = 10

--- a/conventions/tests/services/test_other_services.py
+++ b/conventions/tests/services/test_other_services.py
@@ -2,6 +2,7 @@ import mock
 
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
+from django.conf import settings
 
 from conventions.models import Convention, ConventionStatut
 from conventions.services import (
@@ -25,13 +26,13 @@ class ServicesConventionsTests(TestCase):
             "https://apilos.beta.gouv.fr/my_convention", convention, ["fix@apilos.com"]
         )
         self.assertEqual(email_sent[0].to, ["raph@apilos.com"])
-        self.assertEqual(email_sent[0].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[0].subject, f"Convention à instruire ({convention})"
         )
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent[0].body)
         self.assertEqual(email_sent[1].to, ["fix@apilos.com"])
-        self.assertEqual(email_sent[1].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[1].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[1].subject, f"Convention à instruire ({convention})"
         )
@@ -47,14 +48,14 @@ class ServicesConventionsTests(TestCase):
             "https://apilos.beta.gouv.fr/my_convention", convention, []
         )
         self.assertEqual(email_sent[0].to, ["contact@apilos.beta.gouv.fr"])
-        self.assertEqual(email_sent[0].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[0].subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à instruire ({convention})",
         )
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent[0].body)
         self.assertEqual(email_sent[1].to, ["contact@apilos.beta.gouv.fr"])
-        self.assertEqual(email_sent[1].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[1].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[1].subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à instruire ({convention})",
@@ -73,7 +74,7 @@ class ServicesConventionsTests(TestCase):
         email_sent = email_service.msg
         self.assertEqual(email_sent.to, ["raph@apilos.com"])
         self.assertEqual(email_sent.cc, ["me@apilos.com"])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention validée ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertIn(
@@ -125,7 +126,7 @@ class ServicesConventionsTests(TestCase):
         email_sent = email_service.msg
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention validée ({convention})",
@@ -145,7 +146,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["raph@apilos.com"])
         self.assertEqual(email_sent.cc, ["me@apilos.com"])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention à modifier ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertIn("Toto à un vélo", email_sent.body)
@@ -156,7 +157,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["fix@apilos.com"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention modifiée ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertNotIn("Toto à un vélo", email_sent.body)
@@ -178,7 +179,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à modifier ({convention})",
@@ -195,7 +196,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention modifiée ({convention})",

--- a/core/services.py
+++ b/core/services.py
@@ -1,7 +1,7 @@
 from typing import List
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-
+from django.conf import settings
 from conventions.models import Convention
 
 from upload.services import UploadService
@@ -22,7 +22,7 @@ class EmailService:
         cc_emails: List[str] | None = None,
         text_content: str = "",
         html_content: str = "",
-        from_email: str = "contact@apilos.beta.gouv.fr",
+        from_email: str = settings.DEFAULT_FROM_EMAIL,
     ):
         self.subject = subject
         self.to_emails = to_emails

--- a/core/settings.py
+++ b/core/settings.py
@@ -91,7 +91,7 @@ mailjet_api_secret = get_env_variable("MAILJET_API_SECRET")
 sendinblue_api_key = get_env_variable("SENDINBLUE_API_KEY")
 
 
-DEFAULT_FROM_EMAIL = "contact@apilos.beta.gouv.fr"
+DEFAULT_FROM_EMAIL = "ne-pas-repondre@apilos.beta.gouv.fr"
 
 if mailjet_api_key != "":
     EMAIL_BACKEND = "django_mailjet.backends.MailjetBackend"


### PR DESCRIPTION
# Changer l'adresse email d'envoi par default

cf. [tâche S730](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recQ6Ngp2T4ZqrF6Y?blocks=hide). Faire partir les emails, par défaut, non plus de `contact@apilos.beta.gouv.fr` mais de `ne-pas-repondre@beta.gouv.fr`

_Addendum:_ vous allez sûrement vous dire que les ajouts liés à `pylint` n'ont rien à voir avec la choucroute, comme dirait Nico, mais si justement! Si vous avez suivi [ce magnifique échange entre moi-même](https://mattermost.incubateur.net/fabnum-mte/pl/147a5rgfcbbj7eyp81xn8zpmqw) vous aurez appris que `pylint` se gaufre si jamais on édite le fichier `core/settings.py` de Django, ce qui était mon cas ici. J'ai donc fait et testé les ajustements directement sur cette PR 🤓 Par ailleurs, si comme moi vous voulez désactiver les "pre-commit hooks" au `rebase`, un petit alias avant que ne trépasse:

```conf
[alias]
    rb = rebase --no-verify
```