### PR TITLE
s737 Fix: convention importée sans statut

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,17 +5,17 @@ SECURE_SSL_REDIRECT=True
 LOGLEVEL=ERROR
 
 # Default DB settings
-DB_USER=appel
-DB_NAME=appel
+DB_USER=apilos
+DB_NAME=apilos
 DB_HOST=postgres
-DB_PASSWORD=appel
+DB_PASSWORD=apilos
 DB_PORT=5432
 
 # Read only DB settings
-DB_READONLY=postgres://appel:appel@postgres:5432/appel
+DB_READONLY=postgres://apilos:apilos@postgres:5432/apilos
 
 # Ecolo DB (optionnal & read-only)
-ECOLO_DATABASE_URL=postgres://appel:appel@postgres:5432/ecoloweb?currentSchema=ecolo
+ECOLO_DATABASE_URL=postgres://apilos:apilos@postgres:5432/ecoloweb?currentSchema=ecolo
 
 MAILJET_API_KEY=<MAILJET_API_KEY>
 MAILJET_API_SECRET=<MAILJET_API_SECRET>

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,10 +14,10 @@ jobs:
         ports:
           - 5432:5432
         env:
-          POSTGRES_USER: appel
-          POSTGRES_NAME: appel
+          POSTGRES_USER: apilos
+          POSTGRES_NAME: apilos
           POSTGRES_HOST: postgres
-          POSTGRES_PASSWORD: appel
+          POSTGRES_PASSWORD: apilos
           POSTGRES_PORT: 5432
         options: >-
           --health-cmd pg_isready

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
     -   id: pylint
         name: PyLint
-        entry: python -m pylint.__main__
+        entry: python -m pylint.__main__ --help-msg=django-not-configured
         language: system
         files: \.py$
 -   repo: https://github.com/rtts/djhtml

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,15 +1,17 @@
 [MASTER]
+load-plugins=pylint_django
+django-settings-module=core.settings
 ignore-paths=
+    core/settings.py,
     bailleurs/migrations,
     conventions/migrations,
     programmes/migrations,
     users/migrations,
 disable=
+    django-not-configured,
     C0103, # invalid-name
     C0114, # missing-module-docstring
     C0115, # missing-class-docstring
     C0116, # missing-function-docstring
-load-plugins=pylint_django
-django-settings-module=core.settings
 min-similarity-lines=20
 max-args = 10

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -83,10 +83,10 @@ docker-compose -f docker-compose.db.yml up -d
 Puis, mettre à jour les variable d'environnement dans le fichier [~/.env](~/.env), ci-dessous un exemple compatible avec la configuration docker-compose.db.yml
 
 ```
-DB_USER=appel
-DB_NAME=appel
+DB_USER=apilos
+DB_NAME=apilos
 DB_HOST=localhost
-DB_PASSWORD=appel
+DB_PASSWORD=apilos
 DB_PORT=5433
 ```
 

--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -390,6 +390,8 @@ class Convention(models.Model):
             ConventionStatut.A_SIGNER: "En attente de signature",
             ConventionStatut.SIGNEE: "Finalisée",
             ConventionStatut.RESILIEE: "Résiliée",
+            ConventionStatut.DENONCEE: "Dénoncée",
+            ConventionStatut.ANNULEE: "Annulée",
         }
         return f"{short_status.get(self.statut)}"
 

--- a/conventions/tests/services/test_other_services.py
+++ b/conventions/tests/services/test_other_services.py
@@ -2,6 +2,7 @@ import mock
 
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
+from django.conf import settings
 
 from conventions.models import Convention, ConventionStatut
 from conventions.services import (
@@ -25,13 +26,13 @@ class ServicesConventionsTests(TestCase):
             "https://apilos.beta.gouv.fr/my_convention", convention, ["fix@apilos.com"]
         )
         self.assertEqual(email_sent[0].to, ["raph@apilos.com"])
-        self.assertEqual(email_sent[0].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[0].subject, f"Convention à instruire ({convention})"
         )
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent[0].body)
         self.assertEqual(email_sent[1].to, ["fix@apilos.com"])
-        self.assertEqual(email_sent[1].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[1].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[1].subject, f"Convention à instruire ({convention})"
         )
@@ -47,14 +48,14 @@ class ServicesConventionsTests(TestCase):
             "https://apilos.beta.gouv.fr/my_convention", convention, []
         )
         self.assertEqual(email_sent[0].to, ["contact@apilos.beta.gouv.fr"])
-        self.assertEqual(email_sent[0].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[0].subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à instruire ({convention})",
         )
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent[0].body)
         self.assertEqual(email_sent[1].to, ["contact@apilos.beta.gouv.fr"])
-        self.assertEqual(email_sent[1].from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent[1].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent[1].subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à instruire ({convention})",
@@ -73,7 +74,7 @@ class ServicesConventionsTests(TestCase):
         email_sent = email_service.msg
         self.assertEqual(email_sent.to, ["raph@apilos.com"])
         self.assertEqual(email_sent.cc, ["me@apilos.com"])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention validée ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertIn(
@@ -125,7 +126,7 @@ class ServicesConventionsTests(TestCase):
         email_sent = email_service.msg
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention validée ({convention})",
@@ -145,7 +146,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["raph@apilos.com"])
         self.assertEqual(email_sent.cc, ["me@apilos.com"])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention à modifier ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertIn("Toto à un vélo", email_sent.body)
@@ -156,7 +157,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["fix@apilos.com"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(email_sent.subject, f"Convention modifiée ({convention})")
         self.assertIn("https://apilos.beta.gouv.fr/my_convention", email_sent.body)
         self.assertNotIn("Toto à un vélo", email_sent.body)
@@ -178,7 +179,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention à modifier ({convention})",
@@ -195,7 +196,7 @@ class ServicesConventionsTests(TestCase):
 
         self.assertEqual(email_sent.to, ["contact@apilos.beta.gouv.fr"])
         self.assertEqual(email_sent.cc, [])
-        self.assertEqual(email_sent.from_email, "contact@apilos.beta.gouv.fr")
+        self.assertEqual(email_sent.from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(
             email_sent.subject,
             f"[ATTENTION pas de destinataire à cet email] Convention modifiée ({convention})",

--- a/core/services.py
+++ b/core/services.py
@@ -1,7 +1,7 @@
 from typing import List
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-
+from django.conf import settings
 from conventions.models import Convention
 
 from upload.services import UploadService
@@ -22,7 +22,7 @@ class EmailService:
         cc_emails: List[str] | None = None,
         text_content: str = "",
         html_content: str = "",
-        from_email: str = "contact@apilos.beta.gouv.fr",
+        from_email: str = settings.DEFAULT_FROM_EMAIL,
     ):
         self.subject = subject
         self.to_emails = to_emails

--- a/core/settings.py
+++ b/core/settings.py
@@ -91,7 +91,7 @@ mailjet_api_secret = get_env_variable("MAILJET_API_SECRET")
 sendinblue_api_key = get_env_variable("SENDINBLUE_API_KEY")
 
 
-DEFAULT_FROM_EMAIL = "contact@apilos.beta.gouv.fr"
+DEFAULT_FROM_EMAIL = "ne-pas-repondre@apilos.beta.gouv.fr"
 
 if mailjet_api_key != "":
     EMAIL_BACKEND = "django_mailjet.backends.MailjetBackend"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -722,7 +722,7 @@ button:not(:disabled).apilos-btn--secondary--red:hover {
 .apilos-colored_status--Signee {
   background-color: #D4F4E1;
 }
-.apilos-colored_status--Resiliee {
+.apilos-colored_status--Resiliee, .apilos-colored_status--Annulee_en_suivi, .apilos-colored_status--Denoncee {
   background-color: #E2E2E2;
 }
 .fr-alert--Projet {


### PR DESCRIPTION
# s737: Fix: convention importée sans statut

Cette [tâche](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recbxzAoK25ZymOOh?blocks=hide): en réalité les conventions avaient bien un statut `7. Dénoncée` ou `8. Annulée en suivi`, qui n'étaient tout simplement pas bien configurés pour être affichés