### PR TITLE
Crisp sans crispation

### DIFF
--- a/core/context_processor.py
+++ b/core/context_processor.py
@@ -6,6 +6,7 @@ from core import settings
 def get_environment(request):
     data = {}
     data["ENVIRONMENT"] = settings.ENVIRONMENT
+    data["CRISP_WEBSITE_ID"] = settings.CRISP_WEBSITE_ID
     data["CERBERE_AUTH"] = settings.CERBERE_AUTH
     data["CONVENTION_STATUT"] = {
         convention_statut.name: convention_statut.value

--- a/core/settings.py
+++ b/core/settings.py
@@ -315,6 +315,7 @@ CSRF_COOKIE_SAMESITE = "Strict"
 SESSION_COOKIE_SAMESITE = "Lax"
 
 # https://django-csp.readthedocs.io/en/latest/configuration.html
+# Crisp configuration: https://docs.crisp.chat/guides/others/whitelisting-our-systems/crisp-domain-names/
 CSP_DEFAULT_SRC = "'none'"
 CSP_SCRIPT_SRC = (
     "https://stats.data.gouv.fr/piwik.js",
@@ -330,11 +331,18 @@ CSP_SCRIPT_SRC = (
     # Swagger UI
     "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/swagger-ui-bundle.js",
     "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/swagger-ui-standalone-preset.js",
+    # Crisp
+    "https://client.crisp.chat",
+    "https://settings.crisp.chat",
 )
 CSP_IMG_SRC = (
     "'self'",
     "data:",
     "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/favicon-32x32.png",
+    # Crisp
+    "https://client.crisp.chat",
+    "https://image.crisp.chat",
+    "https://storage.crisp.chat",
 )
 CSP_OBJECT_SRC = "'none'"
 
@@ -343,14 +351,36 @@ CSP_FRAME_SRC = (
     "'self'",
     "https://www.dailymotion.com/embed/video/x8fkp4y",
     "https://www.dailymotion.com/embed/video/x8frr91",
+    # Crisp
+    "https://game.crisp.chat",
 )
-CSP_FONT_SRC = "'self'", "data:"
-CSP_CONNECT_SRC = ("'self'", "https://stats.data.gouv.fr/piwik.php")
+
+CSP_MEDIA_SRC = (
+    # Crisp
+    "https://client.crisp.chat"
+)
+CSP_FONT_SRC = (
+    "'self'",
+    "data:",
+    # Crisp
+    "https://client.crisp.chat",
+)
+CSP_CONNECT_SRC = (
+    "'self'",
+    "https://stats.data.gouv.fr/piwik.php",
+    # Crisp
+    "https://client.crisp.chat",
+    "https://storage.crisp.chat",
+    "wss://client.relay.crisp.chat",
+    "wss://stream.relay.crisp.chat",
+)
 CSP_STYLE_SRC = (
     "'self'",
     "https://code.highcharts.com/css/highcharts.css",
     "https://cdn.jsdelivr.net/npm/swagger-ui-dist@latest/swagger-ui.css",
     "'unsafe-inline'",
+    # Crisp
+    "https://client.crisp.chat",
 )
 CSP_MANIFEST_SRC = "'self'"
 CSP_INCLUDE_NONCE_IN = [
@@ -437,6 +467,8 @@ if CERBERE_AUTH:
 
     LOGIN_URL = "/accounts/cerbere-login"
 
+# Sentry
+
 SENTRY_URL = get_env_variable("SENTRY_URL")
 
 if SENTRY_URL:  # pragma: no cover
@@ -456,6 +488,10 @@ if SENTRY_URL:  # pragma: no cover
         send_default_pii=True,
         ignore_errors=[PermissionDenied],
     )
+
+# Crisp
+
+CRISP_WEBSITE_ID = get_env_variable("CRISP_WEBSITE_ID", default=None)
 
 DRAMATIQ_BROKER = {
     "BROKER": "dramatiq.brokers.redis.RedisBroker",

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -37,6 +37,12 @@
         <!--Js-->
 
         {% block javascript_extras %}{% endblock %}
+        {% if CRISP_WEBSITE_ID %}
+            <script type="text/javascript" nonce="{{request.csp_nonce}}">
+                window.$crisp=[];window.CRISP_WEBSITE_ID="{{ CRISP_WEBSITE_ID }}";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();
+            </script>
+        {% endif %}
+
         {% if ENVIRONMENT == 'production' %}
             <!-- Matomo -->
             <script type="text/javascript" nonce="{{request.csp_nonce}}">
@@ -68,12 +74,15 @@
         {% endblock %}
 
         {% block feedback %}
-            <div class="container__feedback_btn">
-                <a href="mailto:contact@apilos.fr" class="cta">
-                    <span class="apilos-icon fr-fi-mail-line" aria-hidden="true"></span>
-                    <span class="button-text">Faites nous part de vos retours</span>
-                </a>
-            </div>
+            {# Enable the mailto feedback button only as a Crisp fallback #}
+            {% if not CRISP_WEBSITE_ID %}
+                <div class="container__feedback_btn">
+                    <a href="mailto:contact@apilos.fr" class="cta">
+                        <span class="apilos-icon fr-fi-mail-line" aria-hidden="true"></span>
+                        <span class="button-text">Faites nous part de vos retours</span>
+                    </a>
+                </div>
+            {% endif %}
         {% endblock %}
 
         {% include "layout/matomo.html" %}

--- a/templates/layout/base.html
+++ b/templates/layout/base.html
@@ -88,6 +88,13 @@
         {% include "layout/matomo.html" %}
         {% include "layout/sentry.html" %}
         {% include "layout/javascript_load.html" %}
+        {% if CRISP_WEBSITE_ID and user %}
+            <script type="text/javascript" nonce="{{request.csp_nonce}}">
+                {# See Crisp documentation https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/dollar-crisp/ #}
+                $crisp.push(["set", "user:email", "{{ user.email }}"]);
+                $crisp.push(["set", "user:nickname", "{{ user.first_name }} {{ user.last_name }}"]);
+            </script>
+        {% endif %}
         {% block js %}{% endblock %}
     </body>
 </html>


### PR DESCRIPTION
# Crisp sans crispation

Suite [au message d'Audrey](https://mattermost.incubateur.net/fabnum-mte/pl/ouuw546ht388fpfyc8aq45znpo) ce matin, nous avons décidé, elle et moi, que plutôt que de faire machine arrière et remettre le Google form, on allait essayer de "hacker" le problème sur Crisp.

Et j'ai compris que l'idée de base était de rediriger tous les emails vers contact@apilos.fr sur Crisp, et non l'inverse. 

J'ai donc opté de faire plus simple et brancher Crisp **directement** depuis notre site et ... tadaaaa 🎉 !

![image](https://user-images.githubusercontent.com/7372352/213165579-5100cc08-44a9-43e5-935e-95d2b403788c.png)

**BONUS:** les emails vers `contact@apilos.beta.gouv.fr` sont désormais systématiquement redirigés vers Crisp **ET** tous les emails de / vers Crisp envoyés depuis des adresses `@contact.apilos.beta.gouv.fr` (DNS configurés, le domaine apilos.fr est officiellement caduque)
