### PR TITLE
S720 Adaptation de la recherche selon l'onglet des conventions (finalisées vs en cours)

### DIFF
--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -59,6 +59,7 @@ class ConventionListService:
         statut_filter: str = "",
         financement_filter: str = "",
         departement_input: str = "",
+        active: bool = True,
         order_by: str = "",
         page: str = 1,
     ):
@@ -66,6 +67,7 @@ class ConventionListService:
         self.statut_filter = statut_filter
         self.financement_filter = financement_filter
         self.departement_input = departement_input
+        self.active = active
         self.order_by = order_by
         self.page = page
         self.my_convention_list = my_convention_list
@@ -73,11 +75,16 @@ class ConventionListService:
     def paginate(self) -> None:
         total_user = self.my_convention_list.count()
         if self.search_input:
-            self.my_convention_list = self.my_convention_list.filter(
-                Q(programme__ville__icontains=self.search_input)
-                | Q(programme__nom__icontains=self.search_input)
-                | Q(programme__numero_galion__icontains=self.search_input)
-            )
+            if self.active:
+                self.my_convention_list = self.my_convention_list.filter(
+                    Q(programme__ville__icontains=self.search_input)
+                    | Q(programme__nom__icontains=self.search_input)
+                    | Q(programme__numero_galion__icontains=self.search_input)
+                )
+            else:
+                self.my_convention_list = self.my_convention_list.filter(
+                    numero__endswith=self.search_input
+                )
         if self.statut_filter:
             self.my_convention_list = self.my_convention_list.filter(
                 statut=self.statut_filter

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -75,16 +75,12 @@ class ConventionListService:
     def paginate(self) -> None:
         total_user = self.my_convention_list.count()
         if self.search_input:
-            if self.active:
-                self.my_convention_list = self.my_convention_list.filter(
-                    Q(programme__ville__icontains=self.search_input)
-                    | Q(programme__nom__icontains=self.search_input)
-                    | Q(programme__numero_galion__icontains=self.search_input)
-                )
-            else:
-                self.my_convention_list = self.my_convention_list.filter(
-                    numero__endswith=self.search_input
-                )
+            self.my_convention_list = self.my_convention_list.filter(
+                Q(programme__ville__icontains=self.search_input)
+                | Q(programme__nom__icontains=self.search_input)
+                | Q(programme__numero_galion__icontains=self.search_input)
+                | Q(numero__endswith=self.search_input)
+            )
         if self.statut_filter:
             self.my_convention_list = self.my_convention_list.filter(
                 statut=self.statut_filter

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -44,7 +44,13 @@ def search(request, active: bool = True):
 
     service = ConventionListService(
         search_input=request.GET.get("search_input", ""),
-        order_by=request.GET.get("order_by", "programme__date_achevement_compile"),
+        order_by=request.GET.get(
+            "order_by",
+            "programme__date_achevement_compile"
+            if active
+            else "televersement_convention_signee_le",
+        ),
+        active=active,
         page=request.GET.get("page", 1),
         statut_filter=request.GET.get("cstatut", ""),
         financement_filter=request.GET.get("financement", ""),

--- a/ecoloweb/services/resources/sql/conventions.sql
+++ b/ecoloweb/services/resources/sql/conventions.sql
@@ -28,7 +28,7 @@ select
         cdg.datesignatureentitegest::timestamp at time zone 'Europe/Paris',
         cdg.datesignaturebailleur::timestamp at time zone 'Europe/Paris',
         cdg.datesignatureprefet::timestamp at time zone 'Europe/Paris'
-    ) as valide_le,
+    ) as televersement_convention_signee_le,
     c.datesaisie::timestamp at time zone 'Europe/Paris' as cree_le,
     c.datemodification::timestamp at time zone 'Europe/Paris' as mis_a_jour_le,
     cdg.datesignatureentitegest::timestamp at time zone 'Europe/Paris' as premiere_soumission_le,

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -102,7 +102,7 @@
                                 {% if active %}
                                     {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='programme__date_achevement_compile' url_target='conventions:index' label_order='Date de réalisation' %}
                                 {% else %}
-                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='signataire_date_deliberation' url_target='conventions:index' label_order='Date de signature' %}
+                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='televersement_convention_signee_le' url_target='conventions:index' label_order='Date de signature' %}
                                 {% endif %}
                             </div>
                         </div>
@@ -208,7 +208,7 @@
                                         {% if active %}
                                             <td>{{convention.programme.date_achevement_compile|date:"d F Y"|default_if_none:'-' }}</td>
                                         {% else %}
-                                            <td>{{convention.signataire_date_deliberation|date:"d F Y"|default_if_none:'-' }}</td>
+                                            <td>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-' }}</td>
                                         {% endif %}
 
 

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -125,15 +125,9 @@
                                     {% if request|display_administration %}
                                         <th scope="col">Instructeur</th>
                                     {% endif %}
-                                    {% if active %}
-                                        <th title="Opération" scope="col" class="col__width--150">
-                                            Opération
-                                        </th>
-                                    {% else %}
-                                        <th title="Numéro" scope="col">
-                                            Numéro
-                                        </th>
-                                    {% endif %}
+                                    <th title="Opération" scope="col" class="col__width--150">
+                                        Opération
+                                    </th>
                                     <th title="Financement" scope="col">
                                         Financement
                                     </th>
@@ -185,11 +179,8 @@
                                         <td>
                                             <div>
                                                 <strong>
-                                                    {% if active %}
-                                                        <span class="apilos-long-name">{{convention.programme.nom}}</span>
-                                                    {% else %}
-                                                        <span class="apilos-long-name">{{convention.numero}}</span>
-                                                    {% endif %}
+                                                    <span class="apilos-long-name">{{convention.programme.nom}}</span>
+                                                    <span class="apilos-long-name">{{convention.numero}}</span>
                                                 </strong>
                                                 {% if convention.is_avenant %}
                                                     <span class="text-title-blue-france fr-p-1w fr-ml-1w apilos-tag-avenant background-white">Avenant</span>

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -95,7 +95,11 @@
                                 {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='lot__nb_logements' url_target='conventions:index' label_order='Nombre de logements' %}
                             </div>
                             <div class="fr-py-1w">
-                                {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='programme__date_achevement_compile' url_target='conventions:index' label_order='Date de réalisation' %}
+                                {% if active %}
+                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='programme__date_achevement_compile' url_target='conventions:index' label_order='Date de réalisation' %}
+                                {% else %}
+                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='signataire_date_deliberation' url_target='conventions:index' label_order='Date de signature' %}
+                                {% endif %}
                             </div>
                         </div>
                     </div>
@@ -129,9 +133,15 @@
                                     <th title="Nombre de logements à conventionner" scope="col">
                                         Logements
                                     </th>
-                                    <th title="Date de livraison et mise en service" scope="col">
-                                        Livraison
-                                    </th>
+                                    {% if active %}
+                                        <th title="Date de livraison et mise en service" scope="col">
+                                            Livraison
+                                        </th>
+                                    {% else %}
+                                        <th title="Date de signature" scope="col">
+                                            Signature
+                                        </th>
+                                    {% endif %}
                                 </tr>
                             </thead>
                             <tbody>

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -80,7 +80,11 @@
                                 </div>
                             {% endif %}
                             <div  class="fr-py-1w">
-                                {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='programme__nom' url_target='conventions:index' label_order='Nom du programme' %}
+                                {% if active %}
+                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='programme__nom' url_target='conventions:index' label_order='Nom du programme' %}
+                                {% else %}
+                                    {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='numero' url_target='conventions:index' label_order='Numéro' %}
+                                {% endif %}
                             </div>
                             <div class="fr-py-1w">
                                 {% include "common/table/display_order_item.html" with order_by=conventions.order_by order_by_column='lot__financement' url_target='conventions:index' label_order='Financement'%}
@@ -121,9 +125,15 @@
                                     {% if request|display_administration %}
                                         <th scope="col">Instructeur</th>
                                     {% endif %}
-                                    <th title="Opération" scope="col">
-                                        Opération
-                                    </th>
+                                    {% if active %}
+                                        <th title="Opération" scope="col" class="col__width--150">
+                                            Opération
+                                        </th>
+                                    {% else %}
+                                        <th title="Numéro" scope="col">
+                                            Numéro
+                                        </th>
+                                    {% endif %}
                                     <th title="Financement" scope="col">
                                         Financement
                                     </th>
@@ -175,13 +185,19 @@
                                         <td>
                                             <div>
                                                 <strong>
-                                                    <span class="apilos-long-name">{{convention.programme.nom}}</span>
+                                                    {% if active %}
+                                                        <span class="apilos-long-name">{{convention.programme.nom}}</span>
+                                                    {% else %}
+                                                        <span class="apilos-long-name">{{convention.numero}}</span>
+                                                    {% endif %}
                                                 </strong>
                                                 {% if convention.is_avenant %}
                                                     <span class="text-title-blue-france fr-p-1w fr-ml-1w apilos-tag-avenant background-white">Avenant</span>
                                                 {%endif%}
                                             </div>
-                                            <em data-test-role="programme-galion-cell">{{convention.programme.numero_galion}}</em>
+                                            {% if convention.programme.numero_galion %}
+                                                <em data-test-role="programme-galion-cell">{{convention.programme.numero_galion}}</em>
+                                            {% endif %}
                                         </td>
                                         <td data-test-role="programme-financement-cell">{{convention.financement}}</td>
                                         <td>
@@ -189,7 +205,13 @@
                                             <em>{{convention.programme.code_postal}}</em>
                                         </td>
                                         <td>{{convention.lot.nb_logements}}</td>
-                                        <td>{{convention.programme.date_achevement_compile|date:"d F Y"|default_if_none:'-' }}</td>
+                                        {% if active %}
+                                            <td>{{convention.programme.date_achevement_compile|date:"d F Y"|default_if_none:'-' }}</td>
+                                        {% else %}
+                                            <td>{{convention.signataire_date_deliberation|date:"d F Y"|default_if_none:'-' }}</td>
+                                        {% endif %}
+
+
                                     </tr>
                                 {% endfor %}
                             </tbody>

--- a/templates/conventions/home/_tab.html
+++ b/templates/conventions/home/_tab.html
@@ -1,4 +1,4 @@
-{% if tab_active and count > 0 %}
+{% if tab_active %}
     {# If tab is currently open, no link needed #}
     <li>
         <div class="fr-tabs__tab" aria-selected="true">{{ count }} convention{% if count > 1 %}s{% endif %} {{ label }}</div>

--- a/templates/conventions/index.html
+++ b/templates/conventions/index.html
@@ -7,95 +7,97 @@
 {% block page_title %}Conventions - APiLos{% endblock%}
 
 {% block content %}
+    {% with total_conventions=nb_active_conventions|add:nb_completed_conventions %}
 
-    {% if conventions.total_conventions > 0 %}
+        {% if total_conventions > 0 %}
 
-        <div class="fr-container-fluid ds_banner">
-            <div class="fr-container">
-                <div class="fr-grid-row fr-mt-2w fr-grid-row--gutters">
-                    <div class="fr-col-12 fr-my-3w block--row-strech fr-grid-row--middle">
-                        {% if request|is_bailleur %}
-                            <div class="block--row-strech-1">
-                                <h1 class="m-0">Conventions et avenants</h1>
-                            </div>
-                            {% if not CERBERE_AUTH %}
-                                <div class="fr-mr-3w">
-                                    <a class="fr-btn" href="{% url 'conventions:selection' %}">
-                                        <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer une nouvelle convention
-                                    </a>
-                                    {% comment %}
-                                    {#  Disable as there is no route to initialize avenant from zero yet #}
-                                    <a class="fr-btn fr-btn--secondary" href="{% url 'avenants:selection' %}">
+            <div class="fr-container-fluid ds_banner">
+                <div class="fr-container">
+                    <div class="fr-grid-row fr-mt-2w fr-grid-row--gutters">
+                        <div class="fr-col-12 fr-my-3w block--row-strech fr-grid-row--middle">
+                            {% if request|is_bailleur %}
+                                <div class="block--row-strech-1">
+                                    <h1 class="m-0">Conventions et avenants</h1>
+                                </div>
+                                {% if not CERBERE_AUTH %}
+                                    <div class="fr-mr-3w">
+                                        <a class="fr-btn" href="{% url 'conventions:selection' %}">
+                                            <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer une nouvelle convention
+                                        </a>
+                                        {% comment %}
+                                        {#  Disable as there is no route to initialize avenant from zero yet #}
+                                        <a class="fr-btn fr-btn--secondary" href="{% url 'avenants:selection' %}">
+                                            <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
+                                        </a>
+                                        {% endcomment %}
+                                    </div>
+                                {% endif %}
+                                <div hidden>
+                                    <a class="fr-btn  fr-btn--secondary " href="{% url 'conventions:new_avenant_start' %}">
                                         <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
                                     </a>
-                                    {% endcomment %}
                                 </div>
+                            {% elif request|is_instructeur or request.user.is_superuser %}
+                                <div class="block--row-strech-1">
+                                    <h2 class="fr-mb-3w">Bienvenue dans votre espace Instructeur</h2>
+                                    <p class="apilos-subtitle">{{total_conventions}} convention{{ total_conventions|pluralize }} liée{{ total_conventions|pluralize }} à votre administration trouvée{{ total_conventions|pluralize }} dans APiLos</p>
+                                </div>
+                            {% else %}
+                                <p class="fr-mb-3w">Votre profil n'est pas bien configuré, merci de vous rapprocher de votre instructeur</p>
                             {% endif %}
-                            <div hidden>
-                                <a class="fr-btn  fr-btn--secondary " href="{% url 'conventions:new_avenant_start' %}">
-                                    <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
-                                </a>
-                            </div>
-                        {% elif request|is_instructeur or request.user.is_superuser %}
-                            <div class="block--row-strech-1">
-                                <h2 class="fr-mb-3w">Bienvenue dans votre espace Instructeur</h2>
-                                <p class="apilos-subtitle">{{conventions.total_conventions}} convention{{ conventions.total_conventions|pluralize }} liée{{ conventions.total_conventions|pluralize }} à votre administration trouvée{{ conventions.total_conventions|pluralize }} dans APiLos</p>
-                            </div>
-                        {% else %}
-                            <p class="fr-mb-3w">Votre profil n'est pas bien configuré, merci de vous rapprocher de votre instructeur</p>
-                        {% endif %}
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="fr-container-fluid">
-                <div class="fr-tabs fr-col-12">
-                    <div class="fr-container">
-                        <ul class="fr-tabs__list" role="tablist" aria-label="list convention">
-                            {% include 'conventions/home/_tab.html' with tab_active=active count=nb_active_conventions label='en cours' title='Conventions en cours' route='conventions:search_active' %}
-                            {% include 'conventions/home/_tab.html' with tab_active=active|negate count=nb_completed_conventions label='finalisées' title='Conventions finalisées' route='conventions:search_completed' %}
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {% include "conventions/convention_list.html" %}
-
-        {% if not CERBERE_AUTH %}
-            <div class="fr-container-fluid">
-                <div class="fr-container">
-                    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
-                        <div class="fr-my-5w">
-                            <a class="fr-btn" href="{% url 'conventions:selection' %}">
-                                <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>
-                                {% if request|is_instructeur %}
-                                    Créer une nouvelle convention comme un bailleur
-                                {% else %}
-                                    Créer une nouvelle convention
-                                {% endif %}
-                            </a>
+                <div class="fr-container-fluid">
+                    <div class="fr-tabs fr-col-12">
+                        <div class="fr-container">
+                            <ul class="fr-tabs__list" role="tablist" aria-label="list convention">
+                                {% include 'conventions/home/_tab.html' with tab_active=active count=nb_active_conventions label='en cours' title='Conventions en cours' route='conventions:search_active' %}
+                                {% include 'conventions/home/_tab.html' with tab_active=active|negate count=nb_completed_conventions label='finalisées' title='Conventions finalisées' route='conventions:search_completed' %}
+                            </ul>
                         </div>
                     </div>
                 </div>
             </div>
-        {% endif %}
 
-    {% else %}
-        {% if request|is_bailleur %}
-            {% if CERBERE_AUTH %}
-                {% include "conventions/home/bailleur_cerbere_no_convention.html" %}
-            {% else %}
-                {% include "conventions/home/bailleur_no_convention.html" %}
+            {% include "conventions/convention_list.html" %}
+
+            {% if not CERBERE_AUTH %}
+                <div class="fr-container-fluid">
+                    <div class="fr-container">
+                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">
+                            <div class="fr-my-5w">
+                                <a class="fr-btn" href="{% url 'conventions:selection' %}">
+                                    <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>
+                                    {% if request|is_instructeur %}
+                                        Créer une nouvelle convention comme un bailleur
+                                    {% else %}
+                                        Créer une nouvelle convention
+                                    {% endif %}
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             {% endif %}
-        {% elif  request|is_instructeur %}
-            {% if CERBERE_AUTH %}
-                {% include "conventions/home/instructeur_cerbere_no_convention.html" %}
-            {% else %}
-                {% include "conventions/home/instructeur_no_convention.html" %}
-            {% endif %}
+
         {% else %}
-            {% include "conventions/home/no_profile.html" %}
+            {% if request|is_bailleur %}
+                {% if CERBERE_AUTH %}
+                    {% include "conventions/home/bailleur_cerbere_no_convention.html" %}
+                {% else %}
+                    {% include "conventions/home/bailleur_no_convention.html" %}
+                {% endif %}
+            {% elif  request|is_instructeur %}
+                {% if CERBERE_AUTH %}
+                    {% include "conventions/home/instructeur_cerbere_no_convention.html" %}
+                {% else %}
+                    {% include "conventions/home/instructeur_no_convention.html" %}
+                {% endif %}
+            {% else %}
+                {% include "conventions/home/no_profile.html" %}
+            {% endif %}
         {% endif %}
-    {% endif %}
+    {% endwith %}
 
 {% endblock %}


### PR DESCRIPTION
# S720 Adaptation de la recherche selon l'onglet des conventions (finalisées vs en cours)

soit [ce ticket](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recmlkgYDo5yI6NBU?blocks=hide). Dans le détail:
* la date de signature remplace la date de livraison dans l'onglet "Finalisées"
* le numéro de la convention remplace le nom du programme dans l'onglet "Finalisées"
* la recherche textuelle cherche les conventions dont "le numéro finit par ..." dans l'onglet "Finalisées"
* j'ai rétabli le calcul du total comme somme de "en cours" et "finalisées" pour ne pas afficher le message de bienvenue si on a que des conventions finalisées (cas du Finistère pendant l'import Ecolo)