### PR TITLE
manage tests template to set env variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
           name: Running tests
           command: |
             . .venv/bin/activate
+            cp .env.template .env.test
             python3 manage.py test
       - store_artifacts:
           path: test-reports/

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,6 +37,7 @@ jobs:
           pip install -r requirements.txt -r dev-requirements.txt
       - name: Execute test with coverage
         run:
+          cp .env.template .env.test
           coverage run --source='.' manage.py test
         env:
           DB_HOST: localhost

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,7 +36,7 @@ jobs:
         run:
           pip install -r requirements.txt -r dev-requirements.txt
       - name: Execute test with coverage
-        run:
+        run: |
           cp .env.template .env.test
           coverage run --source='.' manage.py test
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment variable
 .env
+.env.test
 .venv
 
 #Cache

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -18,7 +18,7 @@ Pour installer APiLos sur votre système en local, vous avez 2 possibilités :
 
 #### Installation
 
-Configurer vos variable d'environnement dans le fichier .env (exemple dans le fichier .env.template)
+Configurer vos variables d'environnement dans le fichier .env (exemple dans le fichier .env.template)
 
 Toute l'application est disponible via docker-compose. L'avantage est l'isolation de la version de python et de la version de postgresql. Pas besoin d'installer un environment virtuel ni une version spécifique de postgresql, docker-compose le fait pour vous au plus proche des versions utilisées en production
 
@@ -131,6 +131,9 @@ Les tests sont organisés comme suit :
 * Tests integration : APPNAME/tests/test_view.py
 * Tests api : APPNAME/api/tests/test_apis.py
 
+### prérequis
+
+Copier vos variables d'environnement .env.template vers .env.test qui sera utilisé par les tests
 
 ### Lancement des tests
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -28,7 +28,7 @@ from django.core.exceptions import PermissionDenied
 BASE_DIR = Path(__file__).resolve().parent.parent
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 if TESTING:
-    config = Config(RepositoryEnv(BASE_DIR / ".env.template"))
+    config = Config(RepositoryEnv(BASE_DIR / ".env.test"))
 else:
     config = decouple.config
 


### PR DESCRIPTION
you'll have to copy .env.template to .env.test before run tests.
.env.test is ignored in git