### PR TITLE
S560 Ecolo personne physique

### DIFF
--- a/ecoloweb/services/importers_bailleurs.py
+++ b/ecoloweb/services/importers_bailleurs.py
@@ -40,21 +40,13 @@ class BailleurImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         codesiret = data.pop("codesiret")
-        codesiren = data.pop("codesiren")
-        codepersonne = data.pop("codepersonne")
         date_creation = data["cree_le"]
 
         # Clean SIRET code
         if codesiret is not None:
-            data["siret"] = codesiret
-
-        elif (siret := self._resolve_siret(codesiren, date_creation)) is not None:
-            data["siret"] = siret
-
-        elif codesiren is not None:
-            data["siret"] = codesiren
-
-        else:
-            data["siret"] = codepersonne
+            if data["nature_bailleur"] == "Bailleurs privés" or len(codesiret) == 14:
+                data["siret"] = codesiret
+            elif (siret := self._resolve_siret(codesiret, date_creation)) is not None:
+                data["siret"] = siret
 
         return data

--- a/ecoloweb/services/resources/sql/bailleurs.sql
+++ b/ecoloweb/services/resources/sql/bailleurs.sql
@@ -70,7 +70,7 @@ from ecolo.ecolo_bailleur b
         select
             cb.bailleur_id, string_agg(vps.libelle||' '||cb.prenom||' '||cb.nom, ', ') as noms_contacts
         from ecolo.ecolo_contactbailleur cb
-            inner join ecolo.ecolo_valeurparamstatic vps on cb.civilite_id = vps
+            inner join ecolo.ecolo_valeurparamstatic vps on cb.civilite_id = vps.id
         group by cb.bailleur_id
     ) cb on cb.bailleur_id = b.id
 where

--- a/ecoloweb/services/resources/sql/bailleurs.sql
+++ b/ecoloweb/services/resources/sql/bailleurs.sql
@@ -1,22 +1,22 @@
--- Requête pour alimenter la table conventions_convention
+-- Requête pour alimenter la table bailleurs_bailleur:
 
--- signataire_nom               varchar(255),
 -- signataire_fonction          varchar(255),
 -- signataire_date_deliberation date,
 -- operation_exceptionnelle     text,
 -- capital_social               double precision
 select
     b.id,
-    case when
-        b.raisonsociale = 'ANAH' then 'Personne(s) physique(s)'
+    case
+        when b.raisonsociale = 'ANAH' then 'Personne(s) physique(s)'
         else b.raisonsociale
     end as nom,
-    case when
-        b.raisonsociale = 'ANAH' then 'XXXXXXXXXXXXXX'
-        else b.codesiret
+    case
+        when b.raisonsociale = 'ANAH' then 'XXXXXXXXXXXXXX'
+        when b.codepersonne is not null or snb.code = '611' then b.codepersonne
+        when b.codesiret is not null then b.codesiret
+        else b.codesiren
     end as codesiret,
-    b.codesiren,
-    b.codepersonne,
+    cb.noms_contacts as signataire_nom,
     case
         when b.raisonsociale = 'ANAH' or snb.code = '611' then 'Bailleurs privés'
         when snb.code = '210' then 'SEM'
@@ -66,5 +66,12 @@ from ecolo.ecolo_bailleur b
     left join ecolo.ecolo_adressebailleur ab on b.adresse_id = ab.id
     left join ecolo.ecolo_departement ed on b.departement_id = ed.id
     inner join ecolo.ecolo_sousnaturebailleur snb on b.sousnaturebailleur_id = snb.id
+    left join (
+        select
+            cb.bailleur_id, string_agg(vps.libelle||' '||cb.prenom||' '||cb.nom, ', ') as noms_contacts
+        from ecolo.ecolo_contactbailleur cb
+            inner join ecolo.ecolo_valeurparamstatic vps on cb.civilite_id = vps
+        group by cb.bailleur_id
+    ) cb on cb.bailleur_id = b.id
 where
     b.id = %s


### PR DESCRIPTION
S560 Ecolo personne physique

En réponse à [cette PR](https://github.com/MTES-MCT/apilos/pull/509) de @kolok , j'ai adapté la logique d'import Ecolo pour _essayer_ de produire les mêmes résultats.

Malheureusement dans Ecolo on a 0 ou plusieurs contacts associés à un bailleurs, la majorité du temps **sans** emails (290 renseignés sur 100000 lignes). J'ai donc opté de me replier sur le `codepersonne` qui est toujours rempli.

Ceci étant j'en profite pour ramener le `signataire_nom` comme la liste des intitulés des contacts ("<Mr/Mme> <Nom> <Prénom>") et circonscrire l'usage de l'API de l'INSEE, instable, uniquement aux _réels_ cas de SIREN