### PR TITLE
S752 Ecoloweb: ré-activer la promotion asynchrone des PDF

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -494,6 +494,7 @@ DRAMATIQ_BROKER = {
         "url": config("REDIS_URL", default="redis://redis:6379"),
     },
     "MIDDLEWARE": [
+        "django_dramatiq.middleware.DbConnectionsMiddleware",
         "django_dramatiq.middleware.AdminMiddleware",
     ],
 }

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 
 from conventions.models import Convention, PieceJointe, PieceJointeType, AvenantType
-from conventions.services.file import ConventionFileService
 from conventions.tasks import promote_piece_jointe
 from programmes.models import Programme
 from .importers import ModelImporter
@@ -42,7 +41,9 @@ class ConventionImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "lot": self._lot_importer.import_one(data.pop("lot_id")),
             "programme": self.resolve_ecolo_reference(
                 ecolo_id=data.pop("programme_id"), model=Programme

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from conventions.models import Convention, PieceJointe, PieceJointeType, AvenantType
 from conventions.services.file import ConventionFileService
+from conventions.tasks import promote_piece_jointe
 from programmes.models import Programme
 from .importers import ModelImporter
 from .importers_programmes import LotImporter
@@ -72,12 +73,7 @@ class ConventionImporter(ModelImporter):
 
             # Automatically promote the latest piece jointe with type CONVENTION as official convention document
             if piece_jointe is not None:
-                try:
-                    ConventionFileService.promote_piece_jointe(piece_jointe)
-                except FileNotFoundError as e:
-                    logger.info(
-                        f"Unable to automatically upload PDF for convention {model.uuid}: {e}"
-                    )
+                promote_piece_jointe.send(piece_jointe.id)
 
 
 class PieceJointeImporter(ModelImporter):

--- a/ecoloweb/services/importers_programmes.py
+++ b/ecoloweb/services/importers_programmes.py
@@ -75,7 +75,9 @@ class ProgrammeImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "bailleur": self._bailleur_importer.import_one(data.pop("bailleur_id")),
             "administration": self._administration_importer.import_one(
                 data.pop("administration_id")
@@ -110,7 +112,9 @@ class LotImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "programme": self._programme_importer.import_one(data.pop("programme_id")),
             **data,
         }

--- a/ecoloweb/services/resources/sql/_base_conventions.sql
+++ b/ecoloweb/services/resources/sql/_base_conventions.sql
@@ -1,9 +1,7 @@
 select
     cdg.id||':'||pl.financement as id,
-    case when
-        cp.parent_id is not null and cp.parent_id <> cdg.id then
-            cp.parent_id||':'||pl.financement
-    end as parent_id,
+    lag(cdg.id) over (partition by cdg.conventionapl_id, pl.financement order by cdg.datehistoriquedebut)||':'||pl.financement as parent_id,
+    a.id is not null as is_avenant,
     -- Les avenants sont initialisés avec un type 'commentaires' dont la valeur est un résumé des altérations
     -- déclarées depuis Ecoloweb
     ('{"files": {}, "text": "Avenant issu d''Ecoloweb:\r\n\r\n'||ta.detail_avenant||'"}')::json as comments,
@@ -16,7 +14,7 @@ select
         when cdg.dateannulation is not null then '8. Annulée en suivi'
         when cdg.datedemandedenonciation is not null then '7. Dénoncée'
         when cdg.dateresiliationprefet is not null then '6. Résiliée'
-        when c.etat_convention = 'INS' and c.noreglementaire is null then '2. Instruction requise'
+        when ec.code = 'INS' and c.noreglementaire is null then '2. Instruction requise'
         else '5. Signée'
     end as statut,
     cdg.datehistoriquefin as date_fin_conventionnement,
@@ -69,31 +67,11 @@ select
     nl.code = '6' as attribution_residence_accueil,
     nl.code in ('4', '5', '6') as attribution_residence_sociale_ordinaire
 -- Conventions à leur dernier état connu et actualisé, pour éviter les doublons de convention
-from (
-    select
-        distinct on (cdg.conventionapl_id)
-        c.id,
-        cdg.id as cdg_id,
-        ec.code as etat_convention,
-        c.noreglementaire,
-        c.datedepot,
-        c.datesaisie,
-        c.datemodification
-    from ecolo_conventiondonneesgenerales cdg
-        inner join ecolo_valeurparamstatic ec on ec.id = cdg.etatconvention_id
-        inner join ecolo.ecolo_conventionapl c on cdg.conventionapl_id = c.id
-    order by cdg.conventionapl_id, ec.ordre desc
-    ) c
-    inner join ecolo.ecolo_conventiondonneesgenerales cdg on cdg.id = c.cdg_id
-    -- Conventions et leur parent, soient les avenants par ordre d'ascendance
-    left join (
-        select
-            cdg.id,
-            lag(cdg.id) over (partition by cdg.conventionapl_id order by a.numero nulls first) as parent_id,
-            a.numero
-        from ecolo.ecolo_conventiondonneesgenerales cdg
-            left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
-    ) cp on cp.id = cdg.id
+{% block from %}
+from ecolo.ecolo_conventionapl c
+    inner join ecolo.ecolo_conventiondonneesgenerales cdg on c.id = cdg.conventionapl_id
+    left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
+    inner join ecolo.ecolo_valeurparamstatic ec on ec.id = cdg.etatconvention_id
     -- Détail des modifications, en cas d'avenant
     left join (
         select ta.avenant_id,
@@ -101,7 +79,7 @@ from (
         from ecolo.ecolo_avenant_typeavenant ta
             left join ecolo.ecolo_valeurparamstatic pat on ta.typeavenant_id = pat.id
         group by ta.avenant_id
-    ) ta on ta.avenant_id = cdg.avenant_id
+    ) ta on ta.avenant_id = a.id
     inner join ecolo.ecolo_naturelogement nl on cdg.naturelogement_id = nl.id
     inner join (
         select
@@ -129,9 +107,8 @@ from (
                 group by cb.bailleur_id
             ) cb on cb.bailleur_id = b.id
     ) pl on pl.conventiondonneesgenerales_id = cdg.id
-where
-    {% block where %}
-    1 = 1
-    {% endblock %}
+{% endblock %}
+{% block where %}
+{% endblock %}
 {% block order %}
 {% endblock %}

--- a/ecoloweb/services/resources/sql/conventions.sql
+++ b/ecoloweb/services/resources/sql/conventions.sql
@@ -1,6 +1,7 @@
 {% extends "_base_conventions.sql" %}
 
 {% block where %}
+where
     cdg.id = %s
     and pl.financement = %s
 {% endblock %}

--- a/ecoloweb/services/resources/sql/conventions_many.sql
+++ b/ecoloweb/services/resources/sql/conventions_many.sql
@@ -1,6 +1,22 @@
 {% extends "_base_conventions.sql" %}
 
+{% block from %}
+    {{ block.super }}
+    inner join (
+        -- Historique de convention: toutes les itérations de la convention de la plus récente (toujours courante)
+        -- jusqu'à la première non avenant incluse
+        select distinct on (ch.conventionapl_id, ch.avenant_id) ch.*
+        from (
+            select *
+            from ecolo.ecolo_conventiondonneesgenerales
+            order by conventionapl_id, datehistoriquedebut desc
+        ) ch
+    ) ch on ch.id = cdg.id
+{% endblock %}
+
+
 {% block where %}
+where
     -- On exclue les conventions ayant (au moins) un lot associé à plus d'un bailleur ou d'une commune
     not exists (
         select
@@ -16,5 +32,5 @@
     and pl.departement = %s
 {% endblock %}
 {% block order %}
-order by cdg.conventionapl_id, cdg.datehistoriquedebut, cp.numero nulls first
+-- order by cdg.conventionapl_id, cdg.datehistoriquedebut, a.numero nulls first
 {% endblock %}

--- a/ecoloweb/services/resources/sql/programmes.sql
+++ b/ecoloweb/services/resources/sql/programmes.sql
@@ -35,7 +35,8 @@
 
 select
     cdg.id,
-    cp.parent_id,
+    lag(cdg.id) over (partition by cdg.conventionapl_id order by cdg.datehistoriquedebut) as parent_id,
+    a.id is not null as is_avenant,
     pl.bailleur_id,
     c.entitecreatrice_id as administration_id,
     pl.code_postal,
@@ -71,13 +72,7 @@ Valeurs Ecoloweb
     coalesce(pl.datemisechantier, cdg.datehistoriquedebut) as mis_a_jour_le
 from ecolo.ecolo_conventiondonneesgenerales cdg
     inner join ecolo.ecolo_conventionapl c on cdg.conventionapl_id = c.id
-    left join (
-        select
-            cdg.id,
-            lag(cdg.id) over (partition by cdg.conventionapl_id order by a.numero nulls first) as parent_id
-        from ecolo.ecolo_conventiondonneesgenerales cdg
-            left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
-    ) cp on cp.id = cdg.id
+    left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
     inner join ecolo.ecolo_naturelogement nl on cdg.naturelogement_id = nl.id
     inner join (
         select


### PR DESCRIPTION
# S752 Ecoloweb: ré-activer la promotion asynchrone des PDF

Vous vous rappelez que j'avais tout cassé la dernière fois que j'ai fait un import en `staging` ? Comme [je l'avais supposé ](https://mattermost.incubateur.net/fabnum-mte/pl/5xwhgy3msifm7dtrdgmq17zyyc) c'était bien un problème de configuration de `dramatiq`.

J'ai résolu tout seul comme un grand (désolé @kolok je n'aurai pas besoin de faire appel à tes services sur ce coup là) en suivant la doc et rajoutant le middleware `django_dramatiq.middleware.DbConnectionsMiddleware` qui ferme les connections DB comme le disent bien les commentaires:

> This middleware cleans up db connections on worker shutdown.
