### PR TITLE
Ecoloweb: optimisation des requêtes

### DIFF
--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime
 
 from conventions.models import Convention, PieceJointe, PieceJointeType, AvenantType
-from conventions.services.file import ConventionFileService
 from conventions.tasks import promote_piece_jointe
 from programmes.models import Programme
 from .importers import ModelImporter
@@ -42,7 +41,9 @@ class ConventionImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "lot": self._lot_importer.import_one(data.pop("lot_id")),
             "programme": self.resolve_ecolo_reference(
                 ecolo_id=data.pop("programme_id"), model=Programme

--- a/ecoloweb/services/importers_programmes.py
+++ b/ecoloweb/services/importers_programmes.py
@@ -75,7 +75,9 @@ class ProgrammeImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "bailleur": self._bailleur_importer.import_one(data.pop("bailleur_id")),
             "administration": self._administration_importer.import_one(
                 data.pop("administration_id")
@@ -110,7 +112,9 @@ class LotImporter(ModelImporter):
 
     def _prepare_data(self, data: dict) -> dict:
         return {
-            "parent": self.import_one(data.pop("parent_id")),
+            "parent": self.import_one(
+                data.pop("parent_id") if data.pop("is_avenant") else None
+            ),
             "programme": self._programme_importer.import_one(data.pop("programme_id")),
             **data,
         }

--- a/ecoloweb/services/resources/sql/_base_conventions.sql
+++ b/ecoloweb/services/resources/sql/_base_conventions.sql
@@ -1,9 +1,7 @@
 select
     cdg.id||':'||pl.financement as id,
-    case when
-        cp.parent_id is not null and cp.parent_id <> cdg.id then
-            cp.parent_id||':'||pl.financement
-    end as parent_id,
+    lag(cdg.id) over (partition by cdg.conventionapl_id, pl.financement order by cdg.datehistoriquedebut)||':'||pl.financement as parent_id,
+    a.id is not null as is_avenant,
     -- Les avenants sont initialisés avec un type 'commentaires' dont la valeur est un résumé des altérations
     -- déclarées depuis Ecoloweb
     ('{"files": {}, "text": "Avenant issu d''Ecoloweb:\r\n\r\n'||ta.detail_avenant||'"}')::json as comments,
@@ -16,7 +14,7 @@ select
         when cdg.dateannulation is not null then '8. Annulée en suivi'
         when cdg.datedemandedenonciation is not null then '7. Dénoncée'
         when cdg.dateresiliationprefet is not null then '6. Résiliée'
-        when c.etat_convention = 'INS' and c.noreglementaire is null then '2. Instruction requise'
+        when ec.code = 'INS' and c.noreglementaire is null then '2. Instruction requise'
         else '5. Signée'
     end as statut,
     cdg.datehistoriquefin as date_fin_conventionnement,
@@ -69,31 +67,11 @@ select
     nl.code = '6' as attribution_residence_accueil,
     nl.code in ('4', '5', '6') as attribution_residence_sociale_ordinaire
 -- Conventions à leur dernier état connu et actualisé, pour éviter les doublons de convention
-from (
-    select
-        distinct on (cdg.conventionapl_id)
-        c.id,
-        cdg.id as cdg_id,
-        ec.code as etat_convention,
-        c.noreglementaire,
-        c.datedepot,
-        c.datesaisie,
-        c.datemodification
-    from ecolo_conventiondonneesgenerales cdg
-        inner join ecolo_valeurparamstatic ec on ec.id = cdg.etatconvention_id
-        inner join ecolo.ecolo_conventionapl c on cdg.conventionapl_id = c.id
-    order by cdg.conventionapl_id, ec.ordre desc
-    ) c
-    inner join ecolo.ecolo_conventiondonneesgenerales cdg on cdg.id = c.cdg_id
-    -- Conventions et leur parent, soient les avenants par ordre d'ascendance
-    left join (
-        select
-            cdg.id,
-            lag(cdg.id) over (partition by cdg.conventionapl_id order by a.numero nulls first) as parent_id,
-            a.numero
-        from ecolo.ecolo_conventiondonneesgenerales cdg
-            left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
-    ) cp on cp.id = cdg.id
+{% block from %}
+from ecolo.ecolo_conventionapl c
+    inner join ecolo.ecolo_conventiondonneesgenerales cdg on c.id = cdg.conventionapl_id
+    left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
+    inner join ecolo.ecolo_valeurparamstatic ec on ec.id = cdg.etatconvention_id
     -- Détail des modifications, en cas d'avenant
     left join (
         select ta.avenant_id,
@@ -101,7 +79,7 @@ from (
         from ecolo.ecolo_avenant_typeavenant ta
             left join ecolo.ecolo_valeurparamstatic pat on ta.typeavenant_id = pat.id
         group by ta.avenant_id
-    ) ta on ta.avenant_id = cdg.avenant_id
+    ) ta on ta.avenant_id = a.id
     inner join ecolo.ecolo_naturelogement nl on cdg.naturelogement_id = nl.id
     inner join (
         select
@@ -129,9 +107,8 @@ from (
                 group by cb.bailleur_id
             ) cb on cb.bailleur_id = b.id
     ) pl on pl.conventiondonneesgenerales_id = cdg.id
-where
-    {% block where %}
-    1 = 1
-    {% endblock %}
+{% endblock %}
+{% block where %}
+{% endblock %}
 {% block order %}
 {% endblock %}

--- a/ecoloweb/services/resources/sql/conventions.sql
+++ b/ecoloweb/services/resources/sql/conventions.sql
@@ -1,6 +1,7 @@
 {% extends "_base_conventions.sql" %}
 
 {% block where %}
+where
     cdg.id = %s
     and pl.financement = %s
 {% endblock %}

--- a/ecoloweb/services/resources/sql/conventions_many.sql
+++ b/ecoloweb/services/resources/sql/conventions_many.sql
@@ -1,6 +1,22 @@
 {% extends "_base_conventions.sql" %}
 
+{% block from %}
+    {{ block.super }}
+    inner join (
+        -- Historique de convention: toutes les itérations de la convention de la plus récente (toujours courante)
+        -- jusqu'à la première non avenant incluse
+        select distinct on (ch.conventionapl_id, ch.avenant_id) ch.*
+        from (
+            select *
+            from ecolo.ecolo_conventiondonneesgenerales
+            order by conventionapl_id, datehistoriquedebut desc
+        ) ch
+    ) ch on ch.id = cdg.id
+{% endblock %}
+
+
 {% block where %}
+where
     -- On exclue les conventions ayant (au moins) un lot associé à plus d'un bailleur ou d'une commune
     not exists (
         select
@@ -16,5 +32,5 @@
     and pl.departement = %s
 {% endblock %}
 {% block order %}
-order by cdg.conventionapl_id, cdg.datehistoriquedebut, cp.numero nulls first
+-- order by cdg.conventionapl_id, cdg.datehistoriquedebut, a.numero nulls first
 {% endblock %}

--- a/ecoloweb/services/resources/sql/programmes.sql
+++ b/ecoloweb/services/resources/sql/programmes.sql
@@ -35,7 +35,8 @@
 
 select
     cdg.id,
-    cp.parent_id,
+    lag(cdg.id) over (partition by cdg.conventionapl_id order by cdg.datehistoriquedebut) as parent_id,
+    a.id is not null as is_avenant,
     pl.bailleur_id,
     c.entitecreatrice_id as administration_id,
     pl.code_postal,
@@ -71,13 +72,7 @@ Valeurs Ecoloweb
     coalesce(pl.datemisechantier, cdg.datehistoriquedebut) as mis_a_jour_le
 from ecolo.ecolo_conventiondonneesgenerales cdg
     inner join ecolo.ecolo_conventionapl c on cdg.conventionapl_id = c.id
-    left join (
-        select
-            cdg.id,
-            lag(cdg.id) over (partition by cdg.conventionapl_id order by a.numero nulls first) as parent_id
-        from ecolo.ecolo_conventiondonneesgenerales cdg
-            left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
-    ) cp on cp.id = cdg.id
+    left join ecolo.ecolo_avenant a on cdg.avenant_id = a.id
     inner join ecolo.ecolo_naturelogement nl on cdg.naturelogement_id = nl.id
     inner join (
         select


### PR DESCRIPTION
# Ecoloweb: optimisation des requêtes

Pourquoi ? Avec les ajouts des avenants et des foyers & résidence les requêtes SQL se sont grandement rallongées, mais ça ce n'est pas forcément un problème, mais surtout **complexifiées** et donc ... **ralenties** 😢 

Pour vous donner une idée: une convention s'importait en ~15s (10k conventions importées en 4 à 5h). J'ai donc tout donné ce que j'avais comme jus de cerveau pour bien comprendre comment exploiter l'historique des conventions (la fameuse table `ecolo_conventiondonneesgenerales`) et j'ai réussi à trouver un système _sans création de table / view_ 🥳 . Bilan des courses: ~1,2 conventions importées par secondes, soit un import 18x plus rapide!! Si on doit jouer les imports sur 102 départements plusieurs fois ce gain ne mange pas de pain 🥖 

Si ça vous intéresse, dans les grandes lignes:
* définition des itérations _pertinentes_ d'une convention, et surtout triées (cf. requête en dessous) grâce à combo `distinct` et `order by` pas idiot 🤓 
* définition de `parent_id` **ET** `is_avenant` pour `Convention`, `Programme` et `Lot` pour renforcer mais simplifier la recherche du parent
```sql
-- Historique de convention: toutes les itérations de la convention de la plus récente (toujours courante)
        -- jusqu'à la première non avenant incluse
        select distinct on (ch.conventionapl_id, ch.avenant_id) ch.*
        from (
            select *
            from ecolo.ecolo_conventiondonneesgenerales
            order by conventionapl_id, datehistoriquedebut desc
        ) ch
```