### PR TITLE
Formulaire de mise à jour de la date de signature

### DIFF
--- a/conventions/forms/__init__.py
+++ b/conventions/forms/__init__.py
@@ -1,5 +1,6 @@
 from conventions.forms.avenant import *
 from conventions.forms.bailleur import *
+from conventions.forms.convention_date_signature import *
 from conventions.forms.convention_form_annexes import *
 from conventions.forms.convention_form_attribution import *
 from conventions.forms.convention_form_bailleur import *

--- a/conventions/forms/convention_date_signature.py
+++ b/conventions/forms/convention_date_signature.py
@@ -1,0 +1,12 @@
+from django import forms
+
+
+class ConventionDateForm(forms.Form):
+
+    televersement_convention_signee_le = forms.DateField(
+        required=True,
+        label="Indiquez la date de signature.",
+        error_messages={
+            "required": "Vous devez saisir une date de signature",
+        },
+    )

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -155,23 +155,26 @@ def convention_post_action(request, convention_uuid):
     form_posted = None
     if request.method == "POST":
         resiliation_form = ConventionResiliationForm(request.POST)
-        if resiliation_form.is_valid():
-            convention.statut = ConventionStatut.RESILIEE
-            convention.date_resiliation = resiliation_form.cleaned_data[
-                "date_resiliation"
-            ]
-            convention.save()
-            # SUCCESS
-            result_status = utils.ReturnStatus.SUCCESS
-            form_posted = "resiliation"
         updatedate_form = ConventionDateForm(request.POST)
-        if updatedate_form.is_valid():
-            convention.televersement_convention_signee_le = (
-                updatedate_form.cleaned_data["televersement_convention_signee_le"]
-            )
-            convention.save()
-            result_status = utils.ReturnStatus.SUCCESS
-            form_posted = "date_signature"
+        is_resiliation = request.POST.get("resiliation", False)
+        if is_resiliation:
+            if resiliation_form.is_valid():
+                convention.statut = ConventionStatut.RESILIEE
+                convention.date_resiliation = resiliation_form.cleaned_data[
+                    "date_resiliation"
+                ]
+                convention.save()
+                # SUCCESS
+                result_status = utils.ReturnStatus.SUCCESS
+                form_posted = "resiliation"
+        else:
+            if updatedate_form.is_valid():
+                convention.televersement_convention_signee_le = (
+                    updatedate_form.cleaned_data["televersement_convention_signee_le"]
+                )
+                convention.save()
+                result_status = utils.ReturnStatus.SUCCESS
+                form_posted = "date_signature"
 
     else:
         resiliation_form = ConventionResiliationForm()

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -152,6 +152,7 @@ def convention_sent(request, convention_uuid):
 def convention_post_action(request, convention_uuid):
     convention = Convention.objects.get(uuid=convention_uuid)
     result_status = None
+    form_posted = None
     if request.method == "POST":
         resiliation_form = ConventionResiliationForm(request.POST)
         if resiliation_form.is_valid():
@@ -162,6 +163,7 @@ def convention_post_action(request, convention_uuid):
             convention.save()
             # SUCCESS
             result_status = utils.ReturnStatus.SUCCESS
+            form_posted = "resiliation"
         updatedate_form = ConventionDateForm(request.POST)
         if updatedate_form.is_valid():
             convention.televersement_convention_signee_le = (
@@ -169,6 +171,7 @@ def convention_post_action(request, convention_uuid):
             )
             convention.save()
             result_status = utils.ReturnStatus.SUCCESS
+            form_posted = "date_signature"
 
     else:
         resiliation_form = ConventionResiliationForm()
@@ -191,4 +194,6 @@ def convention_post_action(request, convention_uuid):
         "avenants": avenant_list_service,
         "total_avenants": total_avenants,
         "resiliation_form": resiliation_form,
+        "updatedate_form": updatedate_form,
+        "form_posted": form_posted,
     }

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.db.models.functions import Substr
 from django.http.request import HttpRequest
 
-from conventions.forms import ConventionResiliationForm, UploadForm
+from conventions.forms import ConventionResiliationForm, UploadForm, ConventionDateForm
 from conventions.models import Convention, ConventionStatut
 from conventions.services import utils
 from conventions.services.file import ConventionFileService
@@ -162,9 +162,17 @@ def convention_post_action(request, convention_uuid):
             convention.save()
             # SUCCESS
             result_status = utils.ReturnStatus.SUCCESS
+        updatedate_form = ConventionDateForm(request.POST)
+        if updatedate_form.is_valid():
+            convention.televersement_convention_signee_le = (
+                updatedate_form.cleaned_data["televersement_convention_signee_le"]
+            )
+            convention.save()
+            result_status = utils.ReturnStatus.SUCCESS
 
     else:
         resiliation_form = ConventionResiliationForm()
+        updatedate_form = ConventionDateForm()
 
     upform = UploadForm()
     avenant_list_service = ConventionListService(

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -337,9 +337,14 @@ def post_action(request, convention_uuid):
     # Step 12/12
     result = convention_post_action(request, convention_uuid)
     if result["success"] == ReturnStatus.SUCCESS:
-        return HttpResponseRedirect(
-            reverse("conventions:recapitulatif", args=[convention_uuid])
-        )
+        if result["form_posted"] == "resiliation":
+            return HttpResponseRedirect(
+                reverse("conventions:recapitulatif", args=[convention_uuid])
+            )
+        else:
+            return HttpResponseRedirect(
+                reverse("conventions:post_action", args=[convention_uuid])
+            )
     return render(
         request,
         "conventions/post_action.html",

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -798,7 +798,7 @@ button:not(:disabled).apilos-btn--secondary--red:hover {
   top: 0;
 }
 .apilos-sticky-2 {
-  top: 90px;
+  top: 110px;
 }
 
 /*

--- a/templates/conventions/actions/back_to_instruction.html
+++ b/templates/conventions/actions/back_to_instruction.html
@@ -2,7 +2,7 @@
 
 {% if convention|display_back_to_instruction:request %}
 
-    <div class="fr-col-12 fr-my-2w">
+    <div class="fr-col-12">
         <div class="block--row-strech">
             <div class="block--row-strech-1 fr-mr-6w">
                 <p class="fr-alert__title">

--- a/templates/conventions/actions/update_date_signature.html
+++ b/templates/conventions/actions/update_date_signature.html
@@ -1,5 +1,6 @@
 <form method="post" action="" data-turbo="false">
     {% csrf_token %}
+    <input id="update_date_signature" type="hidden" name="update_date_signature" value="true">
     <div class="fr-col-12 fr-my-2w block--row-strech">
         <div class="block--row-strech-1 fr-mr-6w">
 

--- a/templates/conventions/actions/update_date_signature.html
+++ b/templates/conventions/actions/update_date_signature.html
@@ -1,0 +1,4 @@
+<p>
+
+    mise à jour de la date
+</p>

--- a/templates/conventions/actions/update_date_signature.html
+++ b/templates/conventions/actions/update_date_signature.html
@@ -1,4 +1,16 @@
-<p>
+<form method="post" action="" data-turbo="false">
+    {% csrf_token %}
+    <div class="fr-col-12 fr-my-2w block--row-strech">
+        <div class="block--row-strech-1 fr-mr-6w">
 
-    mise à jour de la date
-</p>
+            <p>
+                Votre convention a été signée le {{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}.<br/>
+                Ce n'est pas la bonne date ?
+            </p>
+            {% include "common/form/input_date.html" with form_input=updatedate_form.televersement_convention_signee_le editable=True %}
+        </div>
+        <button class="fr-btn fr-btn--secondary">
+            Mettre à jour la date
+        </button>
+    </div>
+</form>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -153,6 +153,7 @@
 
                             <form method="post" action="" id="{{resiliation_form.date_resiliation.id_for_label}}_validation_form">
                                 {% csrf_token %}
+                                <input id="resiliation" type="hidden" name="resiliation" value="true">
                                 <div class="block--row-strech">
                                     <div class="block--row-strech-1  fr-mr-6w">
 

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -123,6 +123,33 @@
                         </form>
                     </div>
                 </div>
+                <hr>
+                <div class="fr-col-12">
+                    <div class="fr-mb-2w">
+                        <p class="fr-alert__title">
+                            Date de signature
+                        </p>
+                        <div class="fr-col-12 fr-my-2w block--row-strech">
+                            <div class="block--row-strech-1 fr-mr-6w">
+
+                                <p>
+                                    Votre convention a été signée le {{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}.
+                                </p>
+                                <p>
+                                    Ce n'est pas la bonne date ? Vous pouvez la mettre à jour.
+                                </p>
+                            </div>
+                            <details>
+                                <summary>
+                                    <div class="fr-btn fr-my-1w fr-btn--secondary fr-my-1w">Mettre à jour la date de signature</div>
+                                </summary>
+                                {% include "conventions/actions/update_date_signature.html" %}
+                                <div>Mettre à jour la date</div>
+
+                            </details>
+                        </div>
+                    </div>
+                </div>
             {% endif %}
             {% if convention|display_back_to_instruction:request %}
                 <hr>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -57,7 +57,7 @@
             </div>
             <hr>
             <div class="fr-col-12">
-                <div class="fr-mb-2w fr-pt-2w block--row-strech">
+                <div class="fr-mb-2w block--row-strech">
                     <div class="block--row-strech-1 fr-my-2w">
                         <p class="fr-alert__title">
                             Générer la fiche CAF
@@ -68,7 +68,7 @@
                     </div>
                     <form action="{% url 'conventions:fiche_caf' convention_uuid=convention.uuid %}">
                         {% csrf_token %}
-                        <button class="fr-btn fr-my-1w fr-btn--secondary fr-my-1w fr-icon-download-line fr-btn--icon-left">
+                        <button class="fr-btn fr-btn--secondary fr-my-1w fr-icon-download-line fr-btn--icon-left">
                             Générer la fiche CAF
                         </button>
                     </form>
@@ -77,7 +77,7 @@
             {% if request|is_instructeur %}
                 <hr>
                 <div class="fr-col-12">
-                    <div class="fr-mb-2w fr-pt-2w block--row-strech">
+                    <div class="fr-mb-2w block--row-strech">
                         <div class="block--row-strech-1 fr-my-2w">
                             <p class="fr-alert__title">
                                 Téléverser à nouveau la convention
@@ -96,7 +96,7 @@
                                 accept="application/pdf">
                             <div class="block--row-strech">
                                 <div>
-                                    <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-my-1w fr-btn--secondary fr-my-1w" type="button">
+                                    <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button">
                                         Téléverser la convention signée
                                     </button>
                                     {% for error in upform.file.errors %}
@@ -125,29 +125,11 @@
                 </div>
                 <hr>
                 <div class="fr-col-12">
-                    <div class="fr-mb-2w">
+                    <div class="fr-mb-5w fr-pt-2w">
                         <p class="fr-alert__title">
                             Date de signature
                         </p>
-                        <div class="fr-col-12 fr-my-2w block--row-strech">
-                            <div class="block--row-strech-1 fr-mr-6w">
-
-                                <p>
-                                    Votre convention a été signée le {{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}.
-                                </p>
-                                <p>
-                                    Ce n'est pas la bonne date ? Vous pouvez la mettre à jour.
-                                </p>
-                            </div>
-                            <details>
-                                <summary>
-                                    <div class="fr-btn fr-my-1w fr-btn--secondary fr-my-1w">Mettre à jour la date de signature</div>
-                                </summary>
-                                {% include "conventions/actions/update_date_signature.html" %}
-                                <div>Mettre à jour la date</div>
-
-                            </details>
-                        </div>
+                        {% include "conventions/actions/update_date_signature.html" %}
                     </div>
                 </div>
             {% endif %}
@@ -162,7 +144,7 @@
             <div class="fr-col-12">
                 {% if request|is_instructeur %}
                     <hr>
-                    <div class="fr-mb-5w fr-pt-2w">
+                    <div class="fr-mb-5w">
                         <div class="fr-my-2w">
                             <p class="fr-alert__title">
                                 Résiliation/dénonciation de la convention


### PR DESCRIPTION
Après téléversement du fichier de convention/avenant signé, on trouve dans l'espace de convention un champ permettant la mise à jour de la date de signature.