### PR TITLE
S753 Page convention sélection qui timeout

### DIFF
--- a/conventions/services/selection.py
+++ b/conventions/services/selection.py
@@ -194,7 +194,7 @@ class ConventionSelectionService:
             .order_by(
                 "programme__ville", "programme__nom", "nb_logements", "financement"
             )
-            .filter(programme__parent_id__isnull=True)
+            .filter(programme__parent_id__isnull=True, conventions__isnull=True)
         )
         self.form = ProgrammeSelectionFromDBForm(
             self.request.POST,

--- a/conventions/services/selection.py
+++ b/conventions/services/selection.py
@@ -180,7 +180,7 @@ class ConventionSelectionService:
             .order_by(
                 "programme__ville", "programme__nom", "nb_logements", "financement"
             )
-            .filter(programme__parent_id__isnull=True)
+            .filter(programme__parent_id__isnull=True, conventions__isnull=True)
         )
         self.form = ProgrammeSelectionFromDBForm(
             lots=_get_choices_from_object(self.lots),

--- a/conventions/tests/services/test_selection_service.py
+++ b/conventions/tests/services/test_selection_service.py
@@ -44,7 +44,7 @@ class ConventionSelectionServiceForInstructeurTests(TestCase):
             .order_by(
                 "programme__ville", "programme__nom", "nb_logements", "financement"
             )
-            .filter(programme__parent_id__isnull=True)
+            .filter(programme__parent_id__isnull=True, conventions__isnull=True)
         )
         self.service.get_from_db()
         self.assertEqual(self.service.return_status, utils.ReturnStatus.ERROR)
@@ -219,7 +219,7 @@ class ConventionSelectionServiceForBailleurTests(TestCase):
             .order_by(
                 "programme__ville", "programme__nom", "nb_logements", "financement"
             )
-            .filter(programme__parent_id__isnull=True)
+            .filter(programme__parent_id__isnull=True, conventions__isnull=True)
         )
         self.service.get_from_db()
         self.assertEqual(self.service.return_status, utils.ReturnStatus.ERROR)


### PR DESCRIPTION
# S753 Page convention sélection qui timeout

Soit [cette tâche](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recgqpDfluMHo7jCZ?blocks=hide): problème observé suite à un import Ecoloweb. En réalité en creusant le problème survient après un import Ecoloweb _supprimé_.

En gros: jusqu'ici un `purge` d'import ne supprimait **que** les objets `Convention` issus d'un import. Avec ce que j'ai fait sur cette PR, suite à la réflexion de @kolok , je supprime **TOUS** les objets, si bien qu'une purge d'import ne laisse plus aucun lot sans convention et donc, d'un point de vue fonctionnel, éligible au conventionnement et donc dans ce menu déroulant.

Au final mon approche ici est simplement de retirer les lots "grisés" de ce `<select>` pour ne garder que les lots réellement issus du SIAP et qui ne devrait, en théorie, pas être des milliers.