### PR TITLE
🔥 Empêcher les admins de créer des conventions

### DIFF
--- a/conventions/tests/views/test_selection_view.py
+++ b/conventions/tests/views/test_selection_view.py
@@ -42,6 +42,14 @@ class ConventionSelectionFromDBViewTests(AbstractCreateViewTestCase, TestCase):
             msg=f"{self.msg_prefix}",
         )
 
+    def test_view_superuser(self):
+        # login as superuser
+        response = self.client.post(
+            reverse("login"), {"username": "nicolas", "password": "12345"}
+        )
+        response = self.client.get(self.target_path)
+        self.assertEqual(response.status_code, 403, msg=f"{self.msg_prefix}")
+
 
 class ConventionSelectionFromZeroViewTests(AbstractCreateViewTestCase, TestCase):
     fixtures = ["departements.json"]

--- a/conventions/views/convention_form_selection.py
+++ b/conventions/views/convention_form_selection.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
@@ -12,6 +13,9 @@ class ConventionSelectionFromDBView(LoginRequiredMixin, View):
 
     # @permission_required("convention.add_convention")
     def get(self, request):
+        # Temporarily forbid staff users to create conventions
+        if request.user.is_staff:
+            raise PermissionDenied
 
         service = ConventionSelectionService(request)
         service.get_from_db()

--- a/templates/conventions/index.html
+++ b/templates/conventions/index.html
@@ -18,7 +18,7 @@
                                 <div class="block--row-strech-1">
                                     <h1 class="m-0">Conventions et avenants</h1>
                                 </div>
-                                {% if not CERBERE_AUTH %}
+                                {% if not CERBERE_AUTH and not request.user.is_staff %}
                                     <div class="fr-mr-3w">
                                         <a class="fr-btn" href="{% url 'conventions:selection' %}">
                                             <span class="fr-fi-add-line fr-mr-1w" aria-hidden="true"></span>Créer une nouvelle convention
@@ -66,7 +66,7 @@
 
             {% include "conventions/convention_list.html" %}
 
-            {% if not CERBERE_AUTH %}
+            {% if not CERBERE_AUTH and not request.user.is_staff %}
                 <div class="fr-container-fluid">
                     <div class="fr-container">
                         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--center">


### PR DESCRIPTION
# 🔥 Empêcher les admins de créer des conventions

Problème identifié lors des sessions de quick wins: quand un user `staff` clique sur "Créer une convention" la DB, et donc la plateforme, tombe 😭 

Une bonne vieille rustine consiste donc à empêcher que ça arrive ;)