### PR TITLE
Quick fix sur le header, la liste des conventions

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -22,6 +22,13 @@
   align-items: center;
   justify-content: left;
 }
+.apilos--overflow_ellipsis {
+  display: block;
+  width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .apilos-d-inline {
   display: inline;
@@ -276,8 +283,12 @@ a[href].apilos-block-faqlink:after {
 .apilos-block-faqlink .fr-icon-question-mark {
   color: white;
   background-color: #000091;
-  padding: 0.5rem;
+  padding: 0.2rem;
   border-radius: 2rem;
+}
+.apilos--icon-small:before {
+  --icon-size: 1rem;
+  width: 1.5rem;
 }
 
 

--- a/templates/common/FAQ_link.html
+++ b/templates/common/FAQ_link.html
@@ -1,8 +1,6 @@
 <a class="fr-p-1w fr-grid-row apilos-block-faqlink" href="//docs.apilos.beta.gouv.fr" target="_blank" rel="noopener">
-    <div class="fr-p-2w"><span class="fr-icon-question-mark" aria-hidden="true"></span></div>
+    <div class="fr-p-1w"><span class="fr-icon-question-mark apilos--icon-small" aria-hidden="true"></span></div>
     <div class="fr-p-1w">
         <div><strong>Vous avez besoin d'aide ?</strong></div>
-        <div class="fr-text--light">Retrouvez notre <strong><u>FAQ</u></strong>
-        </div>
     </div>
 </a>

--- a/templates/conventions/common/form_footer_button.html
+++ b/templates/conventions/common/form_footer_button.html
@@ -1,6 +1,13 @@
 <div class="form-button-footer fr-col-md-12 fr-py-5w">
     {% if editable %}
-        {% include "common/button/next_and_save.html" %}
+        <div class="apilos--flex-row-left-center">
+            <div class="fr-mr-4w">
+                {% if form_step.next_target %}
+                <a href="{% url form_step.next_target convention_uuid=convention.uuid %}" class="fr-link">Passer cette étape</a>
+                {% endif %}
+            </div>
+            {% include "common/button/next_and_save.html" %}
+        </div>
         {% if form_step.previous_target %}
             {% include "common/button/previous.html" with precedent=form_step.previous_target convention_uuid=convention.uuid %}
         {% endif %}

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -3,7 +3,7 @@
 <div class="fr-container">
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-md-12 ">
-            <form class="fr-my-3w" method="get" action="" id="search_table">
+            <form class="fr-mt-2w" method="get" action="" id="search_table">
                 <input type="hidden" id="order_by" name="order_by" value="{{conventions.order_by}}">
                 <input type="hidden" id="page" name="page" value="{{conventions.page}}">
                 <div class="fr-grid-row fr-grid-row--gutters">
@@ -62,10 +62,10 @@
     </div>
 </div>
 <div class="fr-container-fluid ds_banner">
-    <div class="fr-container fr-py-3w">
+    <div class="fr-container fr-px-3w">
         <div class="fr-grid-row fr-grid-row--gutters fr-card fr-card--no-border">
             <div class="fr-col-md-12">
-                <details class="fr-py-2w apilos-order-menu">
+                <details class="apilos-order-menu">
                     <summary class="fr-grid-row fr-grid-row--right">Trier par  <span class="apilos-order-name fr-link"></span><span class="fr-icon-arrow-down-s-line"></span></summary>
                     <div class="fr-grid-row fr-grid-row--right">
                         <div class="apilos-order-menu--open fr-p-2w">
@@ -178,7 +178,7 @@
                                         {% endif %}
                                         <td>
                                             <div class="apilos--flex-row-left-center">
-                                                <strong>{{convention.programme.nom}}
+                                                <strong class="apilos--overflow_ellipsis">{{convention.programme.nom}}
                                                 </strong>
                                                 {% if convention.is_avenant %}
                                                     <span class="text-title-blue-france fr-p-1w fr-ml-1w apilos-tag-avenant background-white">Avenant</span>

--- a/templates/layout/header_cerbere.html
+++ b/templates/layout/header_cerbere.html
@@ -25,9 +25,9 @@
             {% if not without_action_button %}
                 <div class="fr-header__tools flex_unset">
                     {% if user.is_authenticated %}
-                        <div class="fr-mb-2w">
+                        <div class="fr-mb-1w">
                             <span class="fr-text--sm fr-px-1w">{{ request.user }}</span>
-                            <a class="fr-mt-1w width-100" href="//docs.apilos.beta.gouv.fr" target="_blank" rel="noopener">
+                            <a class="fr-mt-1w width-100 no-target-blank" href="//docs.apilos.beta.gouv.fr" target="_blank" rel="noopener">
                                 <span class="fr-fi-question-line fr-mr-1w" aria-hidden="true"></span>
                             </a>
                             <a href="{% url 'settings:profile' %}">

--- a/templates/layout/header_no_cerbere.html
+++ b/templates/layout/header_no_cerbere.html
@@ -27,8 +27,8 @@
                     <a href="/" title="Accueil - APiLos">
                         <p class="fr-header__service-title">APiLos</p>
                     </a>
-                    <p class="fr-header__service-tagline">Le portail qui facilite l’accès aux logements sociaux par la simplification des conventions</p>
-                    <p class="fr-header__service-tagline fr-text--sm"><em>Un service du SIAP (Système d'Information des Aides à la Pierre)</em></p>
+                    <p class="fr-header__service-tagline">Votre conventionnement APL simplifié</p>
+                    <p class="fr-header__service-tagline fr-text--sm"><em>Un service du SIAP</em></p>
                 </div>
             </div>
             {% if not without_action_button %}
@@ -64,7 +64,7 @@
                         <ul class="fr-links-group fr-mb-1w">
                                 <li class="fr-mx-2w apilos-flex-wrap">
                                     <div class="width-100 apilos-d-block fr-m-auto">
-                                        <div class="fr-mb-1w">
+                                        <div>
                                             Bonjour&nbsp;
                                             <strong>{{ request.user }}</strong>
                                         </div>

--- a/templates/layout/header_no_cerbere.html
+++ b/templates/layout/header_no_cerbere.html
@@ -36,7 +36,7 @@
                     <div class="fr-header__tools-links">
                         {% if user.is_authenticated %}
                             <div class="fr-container--fluid">
-                                <div class="fr-mb-2w fr-grid-row fr-grid-row--right">
+                                <div class="fr-mb-1w fr-grid-row fr-grid-row--right">
                                     <span class="fr-text--sm fr-px-1w">{{ request.user }}</span>
                                     <span>
                                         <a href="{% url 'settings:profile' %}">


### PR DESCRIPTION
- réduction de la taille du header avec quelques modifs
![image](https://user-images.githubusercontent.com/19302155/219086701-3915870d-51bd-439a-a729-45ee40b916c3.png)

- réduction de quelques marges entre les filtres et la liste

- passage du nom de l'opération sur 1 ligne dans la liste des conventions + elipse
![image](https://user-images.githubusercontent.com/19302155/219087276-849b29d3-4aab-4f7f-a0fe-6bbd7c917e15.png)

- ajout d'un lien pour passer à l'écran suivant du formulaire sans enregistrer
![image](https://user-images.githubusercontent.com/19302155/219086495-45414716-51cc-4ff9-8976-05794249db35.png)
