### PR TITLE
Création d'avenant sur des convention créée hors APiLos - validation de l'avenant

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "06:00" # UTC
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "06:00" # UTC
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/conventions/forms/avenant.py
+++ b/conventions/forms/avenant.py
@@ -42,3 +42,26 @@ class AvenantsforavenantForm(forms.Form):
     nom_fichier_signe = forms.FileField(
         required=False,
     )
+
+
+class CompleteforavenantForm(forms.Form):
+    """
+    Formulaire qui permet à l'instructeur de compléter les informations de la convention
+      non-connue d'Apilos avant la validation de l'avenant
+    """
+
+    ville = forms.CharField(
+        label="Ville du programme",
+        max_length=255,
+        required=False,
+        error_messages={
+            "max_length": "La ville ne doit pas excéder 255 caractères",
+        },
+    )
+    nb_logements = forms.IntegerField(
+        label="Nb logements à conventionner",
+        required=False,
+    )
+    nom_fichier_signe = forms.FileField(
+        required=False,
+    )

--- a/conventions/forms/avenant.py
+++ b/conventions/forms/avenant.py
@@ -53,14 +53,14 @@ class CompleteforavenantForm(forms.Form):
     ville = forms.CharField(
         label="Ville du programme",
         max_length=255,
-        required=False,
+        required=True,
         error_messages={
             "max_length": "La ville ne doit pas excéder 255 caractères",
         },
     )
     nb_logements = forms.IntegerField(
         label="Nb logements à conventionner",
-        required=False,
+        required=True,
     )
     nom_fichier_signe = forms.FileField(
         required=False,

--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -409,6 +409,15 @@ class Convention(models.Model):
     def is_avenant(self):
         return self.parent_id is not None
 
+    def is_imported(self):
+        if (
+            not self.parent.programme.ville
+            or not self.parent.lot.nb_logements
+            or not self.parent.nom_fichier_signe
+        ):
+            return self
+        return None
+
     def statut_for_template(self):
         return {
             "statut": self.statut,

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -25,12 +25,14 @@ def convention_summary(request: HttpRequest, convention: Convention):
     convention_number_form = ConventionNumberForm(
         initial={"convention_numero": convention.get_default_convention_number()}
     )
-    complete_for_avenant_form = CompleteforavenantForm(
-        initial={
-            "ville": convention.parent.programme.ville,
-            "nb_logements": convention.parent.lot.nb_logements,
-        }
-    )
+    complete_for_avenant_form = None
+    if convention.is_avenant() and convention.is_imported():
+        complete_for_avenant_form = CompleteforavenantForm(
+            initial={
+                "ville": convention.parent.programme.ville,
+                "nb_logements": convention.parent.lot.nb_logements,
+            }
+        )
 
     opened_comments = Comment.objects.filter(
         convention=convention,

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -207,9 +207,14 @@ def validate_convention(request, convention_uuid):
     request.user.check_perm("convention.change_convention", convention)
     result = convention_validate(request, convention)
     if result["success"] == ReturnStatus.SUCCESS:
-        return HttpResponseRedirect(
-            reverse("conventions:sent", args=[result["convention"].uuid])
-        )
+        if "form" == "convention_number_form":
+            return HttpResponseRedirect(
+                reverse("conventions:sent", args=[result["convention"].uuid])
+            )
+        if "form" == "complete_for_avenant_form":
+            return HttpResponseRedirect(
+                reverse("conventions:recapitulatif", args=[result["convention"].uuid])
+            )
     return render(
         request,
         "conventions/recapitulatif.html",

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -206,14 +206,15 @@ def validate_convention(request, convention_uuid):
     )
     request.user.check_perm("convention.change_convention", convention)
     result = convention_validate(request, convention)
-    if result["success"] == ReturnStatus.SUCCESS:
-        if "form" == "convention_number_form":
+    is_complete_avenant_form = request.POST.get("completeform", False)
+    if is_complete_avenant_form:
+        return HttpResponseRedirect(
+            reverse("conventions:recapitulatif", args=[result["convention"].uuid])
+        )
+    else:
+        if result["success"] == ReturnStatus.SUCCESS:
             return HttpResponseRedirect(
                 reverse("conventions:sent", args=[result["convention"].uuid])
-            )
-        if "form" == "complete_for_avenant_form":
-            return HttpResponseRedirect(
-                reverse("conventions:recapitulatif", args=[result["convention"].uuid])
             )
     return render(
         request,

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -208,9 +208,10 @@ def validate_convention(request, convention_uuid):
     result = convention_validate(request, convention)
     is_complete_avenant_form = request.POST.get("completeform", False)
     if is_complete_avenant_form:
-        return HttpResponseRedirect(
-            reverse("conventions:recapitulatif", args=[result["convention"].uuid])
-        )
+        if result["success"] == ReturnStatus.SUCCESS:
+            return HttpResponseRedirect(
+                reverse("conventions:recapitulatif", args=[result["convention"].uuid])
+            )
     else:
         if result["success"] == ReturnStatus.SUCCESS:
             return HttpResponseRedirect(

--- a/programmes/admin.py
+++ b/programmes/admin.py
@@ -18,6 +18,8 @@ class ProgrammeAdmin(admin.ModelAdmin):
     fields = (
         "uuid",
         "nom",
+        "code_postal",
+        "ville",
         "numero_galion",
         "administration",
         "bailleur",

--- a/templates/conventions/actions/instructeur_validation.html
+++ b/templates/conventions/actions/instructeur_validation.html
@@ -4,7 +4,7 @@
     <div class="fr-col-md-12 fr-mb-5w fr-mt-3w">
         <div role="alert">
             {% if convention.is_avenant %}
-                {% include "conventions/avenant/complete_form_for_avenants.html" %}
+                {% include "conventions/avenant/complete_form_for_avenants.html" with form=complete_for_avenant_form %}
             {% else %}
                 <p class="fr-alert__title">Valider la convention</p>
                 {% with editable_validation=convention|display_deactivated_because_type1and2_config_is_needed|not_op %}

--- a/templates/conventions/actions/instructeur_validation.html
+++ b/templates/conventions/actions/instructeur_validation.html
@@ -4,22 +4,7 @@
     <div class="fr-col-md-12 fr-mb-5w fr-mt-3w">
         <div role="alert">
             {% if convention.is_avenant %}
-                <div class="fr-col-md-12 block--row-strech">
-                    <div class="block--row-strech-1 fr-mr-6w">
-                        <p class="fr-alert__title">Valider l'avenant</p>
-                        <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
-                    </div>
-                    <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
-                        {% csrf_token %}
-                        <input type="hidden"
-                            id="{{conventionNumberForm.convention_numero.id_for_label}}"
-                            name="{{conventionNumberForm.convention_numero.html_name}}"
-                            value="{{conventionNumberForm.convention_numero.value}}">
-                        <button class="fr-btn fr-btn--secondary">
-                            Valider l'avenant
-                        </button>
-                    </form>
-                </div>
+                {% include "conventions/avenant/complete_form_for_avenants.html" %}
             {% else %}
                 <p class="fr-alert__title">Valider la convention</p>
                 {% with editable_validation=convention|display_deactivated_because_type1and2_config_is_needed|not_op %}
@@ -32,6 +17,7 @@
                     <div>
                         <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
                             {% csrf_token %}
+                            <input id="numberform" type="hidden" name="numberform" value="true" disabled="disabled" />
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
                                 <div class="fr-col-12 fr-col-md-6">
                                     {% include "common/form/input_text.html" with form_input=conventionNumberForm.convention_numero editable=editable_validation %}

--- a/templates/conventions/avenant/complete_form_for_avenants.html
+++ b/templates/conventions/avenant/complete_form_for_avenants.html
@@ -3,32 +3,62 @@
 <div>
     <p class="fr-alert__title">Valider l'avenant</p>
     <p class="fr-mb-0">
-        Pour pouvoir valider cet avenant, vous devez remplir les informations suivantes.
+        {% if not convention.parent.programme.ville or not convention.parent.lot.nb_logements or not convention.parent.nom_fichier_signe %}
+            Pour pouvoir valider cet avenant, vous devez remplir les informations suivantes concernant la convention originale.
+            <form method="post"  action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
+                {% csrf_token %}
+                <input id="completeform" type="hidden" name="completeform" value="true">
+                <div class="fr-grid-row fr-grid-row--gutters fr-mt-3w">
+
+                    {% if not convention.parent.programme.ville %}
+                        <div class="fr-col-12 fr-col-md-6">
+                            {% include "common/form/input_text.html" with form_input=complete_for_avenant_form.ville editable=True %}
+                        </div>
+                    {% endif %}
+                    {% if not convention.parent.lot.nb_logements %}
+                        <div class="fr-col-12 fr-col-md-6">
+                            {% include "common/form/input_number.html" with form_input=complete_for_avenant_form.nb_logements editable=True %}
+                        </div>
+                    {% endif %}
+                    {% if not convention.parent.nom_fichier_signe %}
+                        <div class="fr-col-12">
+                            <div class="fr-upload-group fr-my-4w">
+                                <label class="fr-label" for="file-upload">Téléverser la convention (en PDF)
+                                    <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
+                                </label>
+                                <input class="fr-upload" type="file" id="file-upload" name="nom_fichier_signe">
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+                <button>Envoyer</button>
+            </form>
+        {% else %}
+            {% if convention.numero %}
+                <p class="fr-mb-0">L'avenant aura le numéro {{ convention.numero }}</p>
+            {% else %}
+                <div class="fr-col-md-12 block--row-strech">
+                    <div class="block--row-strech-1 fr-mr-6w">
+                        <p class="fr-alert__title">Valider l'avenant</p>
+                        <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+                    </div>
+                    <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
+                        {% csrf_token %}
+                        <input type="hidden"
+                            id="{{conventionNumberForm.convention_numero.id_for_label}}"
+                            name="{{conventionNumberForm.convention_numero.html_name}}"
+                            value="{{conventionNumberForm.convention_numero.value}}">
+                        <button class="fr-btn fr-btn--secondary">
+                            Valider l'avenant
+                        </button>
+                    </form>
+                </div>
+            {% endif %}
+        {% endif %}
     </p>
 </div>
-<form method="post" action="{% url 'conventions:complete_form_for_avenants' convention_uuid=convention.uuid %}" data-turbo="false">
-    {% include "common/form/input_text.html" with form_input=form.ville object_field="programme__ville__"|add:form.uuid.value %}
 
-    <button class="fr-btn fr-btn--secondary">
-        Valider l'avenant
-    </button>
-</form>
-{% if convention.programme.ville %}
-    il y  a une ville au programme
-{% else %}
-    pas de ville
-{% endif %}
-{% if convention.lot.nb_logements %}
-    - il y a des logements
-{% else %}
-    - pas de logements
-{% endif %}
-{% if convention.parent.nom_fichier_signe %}
-    - un fichier
-{% else %}
-    - pas de fichier
-{% endif %}
-<div>
 
-    {{convention.numero}}
-</div>
+
+
+

--- a/templates/conventions/avenant/complete_form_for_avenants.html
+++ b/templates/conventions/avenant/complete_form_for_avenants.html
@@ -1,29 +1,22 @@
-{% load custom_filters %}
-
-<div>
-    <p class="fr-alert__title">Valider l'avenant</p>
-    <p class="fr-mb-0">
-        {% if not convention.parent.programme.ville or not convention.parent.lot.nb_logements or not convention.parent.nom_fichier_signe %}
-            Pour pouvoir valider cet avenant, vous devez remplir les informations suivantes concernant la convention originale.
-            <form method="post"  action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
-                {% csrf_token %}
-                <input id="completeform" type="hidden" name="completeform" value="true">
-                <div class="fr-grid-row fr-grid-row--gutters fr-mt-3w">
-
-                    {% if not convention.parent.programme.ville %}
-                        <div class="fr-col-12 fr-col-md-6">
-                            {% include "common/form/input_text.html" with form_input=complete_for_avenant_form.ville editable=True %}
-                        </div>
-                    {% endif %}
-                    {% if not convention.parent.lot.nb_logements %}
-                        <div class="fr-col-12 fr-col-md-6">
-                            {% include "common/form/input_number.html" with form_input=complete_for_avenant_form.nb_logements editable=True %}
-                        </div>
-                    {% endif %}
+<p class="fr-alert__title">Valider l'avenant</p>
+{% if not convention.parent.programme.ville or not convention.parent.lot.nb_logements or not convention.parent.nom_fichier_signe %}
+    <p class="fr-mb-0">Pour pouvoir valider cet avenant, vous devez remplir les informations suivantes concernant la convention originale.</p>
+    <form method="post"  action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false"  enctype="multipart/form-data">
+        {% csrf_token %}
+        <input id="completeform" type="hidden" name="completeform" value="true">
+        <div class="block--row-strech fr-mt-2w">
+            <div class="block--row-strech-1 fr-mr-5w">
+                <div class="fr-grid-row fr-grid-row--gutters">
+                    <div class="fr-col-12 fr-col-md-6" {% if convention.parent.programme.ville %}hidden{% endif %}>
+                        {% include "common/form/input_text.html" with form_input=complete_for_avenant_form.ville editable=True %}
+                    </div>
+                    <div class="fr-col-12 fr-col-md-4" {% if convention.parent.lot.nb_logements %}{% endif %}>
+                        {% include "common/form/input_number.html" with form_input=complete_for_avenant_form.nb_logements editable=True %}
+                    </div>
                     {% if not convention.parent.nom_fichier_signe %}
                         <div class="fr-col-12">
-                            <div class="fr-upload-group fr-my-4w">
-                                <label class="fr-label" for="file-upload">Téléverser la convention (en PDF)
+                            <div class="fr-upload-group">
+                                <label class="fr-label" for="file-upload">Téléverser la convention initiale (en PDF)
                                     <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
                                 </label>
                                 <input class="fr-upload" type="file" id="file-upload" name="nom_fichier_signe">
@@ -31,32 +24,32 @@
                         </div>
                     {% endif %}
                 </div>
-                <button>Envoyer</button>
+            </div>
+            <button class="fr-btn fr-btn--secondary">Envoyer</button>
+        </div>
+    </form>
+{% else %}
+    {% if convention.numero %}
+        <p class="fr-mb-0">L'avenant aura le numéro {{ convention.numero }}</p>
+    {% else %}
+        <div class="fr-col-md-12 block--row-strech">
+            <div class="block--row-strech-1 fr-mr-6w">
+                <p class="fr-alert__title">Valider l'avenant</p>
+                <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+            </div>
+            <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
+                {% csrf_token %}
+                <input type="hidden"
+                    id="{{conventionNumberForm.convention_numero.id_for_label}}"
+                    name="{{conventionNumberForm.convention_numero.html_name}}"
+                    value="{{conventionNumberForm.convention_numero.value}}">
+                <button class="fr-btn fr-btn--secondary">
+                    Valider l'avenant
+                </button>
             </form>
-        {% else %}
-            {% if convention.numero %}
-                <p class="fr-mb-0">L'avenant aura le numéro {{ convention.numero }}</p>
-            {% else %}
-                <div class="fr-col-md-12 block--row-strech">
-                    <div class="block--row-strech-1 fr-mr-6w">
-                        <p class="fr-alert__title">Valider l'avenant</p>
-                        <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
-                    </div>
-                    <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
-                        {% csrf_token %}
-                        <input type="hidden"
-                            id="{{conventionNumberForm.convention_numero.id_for_label}}"
-                            name="{{conventionNumberForm.convention_numero.html_name}}"
-                            value="{{conventionNumberForm.convention_numero.value}}">
-                        <button class="fr-btn fr-btn--secondary">
-                            Valider l'avenant
-                        </button>
-                    </form>
-                </div>
-            {% endif %}
-        {% endif %}
-    </p>
-</div>
+        </div>
+    {% endif %}
+{% endif %}
 
 
 

--- a/templates/conventions/avenant/complete_form_for_avenants.html
+++ b/templates/conventions/avenant/complete_form_for_avenants.html
@@ -1,5 +1,5 @@
 <p class="fr-alert__title">Valider l'avenant</p>
-{% if not convention.parent.programme.ville or not convention.parent.lot.nb_logements or not convention.parent.nom_fichier_signe %}
+{% if form %}
     <p class="fr-mb-0">Pour pouvoir valider cet avenant, vous devez remplir les informations suivantes concernant la convention originale.</p>
     <form method="post"  action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false"  enctype="multipart/form-data">
         {% csrf_token %}
@@ -29,36 +29,39 @@
         </div>
     </form>
 {% else %}
-    <div class="fr-col-md-12 block--row-strech">
-        {% if convention.numero and convention.numero != conventionNumberForm.convention_numero.value %}
+    <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
+        {% csrf_token %}
+        <div class="fr-col-md-12 block--row-strech">
             <div class="block--row-strech-1 fr-mr-6w">
-                <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
-                <p>En fonction du nombre d'avenants répertoriés dans APiLos, il devrait porter le numéro {{conventionNumberForm.convention_numero.value}}</p>
-            </div>
-            <div><a href="{% url 'conventions:form_avenants_for_avenant' convention_uuid=convention.parent.uuid %}" class="fr-btn fr-btn--secondary fr-icon-upload-line fr-btn--icon-left">Importer les avenants précédents</a></div>
-        {% else %}
-            <div class="block--row-strech-1 fr-mr-6w">
-                {% if convention.numero %}
+                {% if convention.numero and convention.numero != conventionNumberForm.convention_numero.value %}
                     <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
-                    <p>Cette déclaration est cohérente avec l'historique connu dans APiLos.</p>
+                    <p>En fonction du nombre d'avenants répertoriés dans APiLos, il devrait porter le numéro {{conventionNumberForm.convention_numero.value}}</p>
                 {% else %}
-                    <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+                    {% if convention.numero %}
+                        <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
+                        <p>Cette déclaration est cohérente avec l'historique connu dans APiLos.</p>
+                    {% else %}
+                        <p>L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+                    {% endif %}
                 {% endif %}
-            </div>
-            <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
-                {% csrf_token %}
-                <input type="hidden"
+                <p class="fr-mb-0">Vous pouvez le valider avec ce numéro ou modifier le numéro ci-dessous avant de valider.</p>
+                <p><em>N'oubliez pas d'importer les avenants manquants, le cas échéant.</em></p>
+                <input class="fr-input fr-col-6"
                     id="{{conventionNumberForm.convention_numero.id_for_label}}"
                     name="{{conventionNumberForm.convention_numero.html_name}}"
-                    value="{{conventionNumberForm.convention_numero.value}}">
-                <button class="fr-btn fr-btn--secondary">
-                    Valider l'avenant
-                </button>
-            </form>
-        {% endif %}
-    </div>
+                    {% if convention.numero %}
+                        value="{{convention.numero}}"
+                    {% else %}
+                        value="{{conventionNumberForm.convention_numero.value}}"
+                    {% endif %}
+                >
+            </div>
+            <button class="fr-btn fr-btn--secondary">
+                Valider l'avenant {% if convention.numero and convention.numero != conventionNumberForm.convention_numero.value %}avec ce numéro{% endif %}
+            </button>
+        </div>
+    </form>
 {% endif %}
-
 
 
 

--- a/templates/conventions/avenant/complete_form_for_avenants.html
+++ b/templates/conventions/avenant/complete_form_for_avenants.html
@@ -10,7 +10,7 @@
                     <div class="fr-col-12 fr-col-md-6" {% if convention.parent.programme.ville %}hidden{% endif %}>
                         {% include "common/form/input_text.html" with form_input=complete_for_avenant_form.ville editable=True %}
                     </div>
-                    <div class="fr-col-12 fr-col-md-4" {% if convention.parent.lot.nb_logements %}{% endif %}>
+                    <div class="fr-col-12 fr-col-md-4" {% if convention.parent.lot.nb_logements %}hidden{% endif %}>
                         {% include "common/form/input_number.html" with form_input=complete_for_avenant_form.nb_logements editable=True %}
                     </div>
                     {% if not convention.parent.nom_fichier_signe %}
@@ -29,13 +29,21 @@
         </div>
     </form>
 {% else %}
-    {% if convention.numero %}
-        <p class="fr-mb-0">L'avenant aura le numéro {{ convention.numero }}</p>
-    {% else %}
-        <div class="fr-col-md-12 block--row-strech">
+    <div class="fr-col-md-12 block--row-strech">
+        {% if convention.numero and convention.numero != conventionNumberForm.convention_numero.value %}
             <div class="block--row-strech-1 fr-mr-6w">
-                <p class="fr-alert__title">Valider l'avenant</p>
-                <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+                <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
+                <p>En fonction du nombre d'avenants répertoriés dans APiLos, il devrait porter le numéro {{conventionNumberForm.convention_numero.value}}</p>
+            </div>
+            <div><a href="{% url 'conventions:form_avenants_for_avenant' convention_uuid=convention.parent.uuid %}" class="fr-btn fr-btn--secondary fr-icon-upload-line fr-btn--icon-left">Importer les avenants précédents</a></div>
+        {% else %}
+            <div class="block--row-strech-1 fr-mr-6w">
+                {% if convention.numero %}
+                    <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
+                    <p>Cette déclaration est cohérente avec l'historique connu dans APiLos.</p>
+                {% else %}
+                    <p class="fr-mb-0">L'avenant aura le numéro {{conventionNumberForm.convention_numero.value}}.</p>
+                {% endif %}
             </div>
             <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
                 {% csrf_token %}
@@ -47,8 +55,8 @@
                     Valider l'avenant
                 </button>
             </form>
-        </div>
-    {% endif %}
+        {% endif %}
+    </div>
 {% endif %}
 
 

--- a/templates/conventions/avenant_list.html
+++ b/templates/conventions/avenant_list.html
@@ -12,7 +12,7 @@
                 <div class="fr-col-11">
                     <div class="fr-grid-row">
                         <p class="fr-m-0">
-                            Avenant du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>:&nbsp;{% if convention.description_avenant %}
+                            Avenant {{convention.numero }} du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>:&nbsp;{% if convention.description_avenant %}
                                 {{ convention.description_avenant|linebreaksbr }}
                             {% endif %}
                         </p>
@@ -26,7 +26,7 @@
             {% else %}
                 <div class="fr-col-11">
                     <div class="fr-grid-row">
-                        Avenant du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>
+                        Avenant {{convention.numero }} du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>
                         <div class="fr-ml-2w"><strong>{% include "conventions/home/statut_tag.html"  %}</strong></div>
                     </div>
                     <div class="fr-mb-3w fr-mt-n1v">


### PR DESCRIPTION
Dans le cadre de création d'avenants sur des conventions non présentes dans APiLos, il est demandé au bailleur de remplir certaines informations sur la convention au démarrage.

A l'étape  de validation de l'avenant, il est demandé à l'instructeur de compléter avec les informations manquantes sur la convention avant de pouvoir valider l'avenant.
Ces informations sont : 
- villes
- nombre de logements
- pdf de la convention originale si cela manque.