### PR TITLE
Ecoloweb: correction de la détection du SIRET bailleur

### DIFF
--- a/ecoloweb/services/resources/sql/bailleurs.sql
+++ b/ecoloweb/services/resources/sql/bailleurs.sql
@@ -12,9 +12,8 @@ select
     end as nom,
     case
         when b.raisonsociale = 'ANAH' then 'XXXXXXXXXXXXXX'
-        when b.codepersonne is not null or snb.code = '611' then b.codepersonne
-        when b.codesiret is not null then b.codesiret
-        else b.codesiren
+        when b.codepersonne is not null or snb.code = '611' then coalesce(b.codepersonne, b.codesiret, b.codesiren)
+        else coalesce(b.codesiret, b.codesiren, b.codepersonne, )
     end as codesiret,
     cb.noms_contacts as signataire_nom,
     case


### PR DESCRIPTION
# Ecoloweb: correction de la détection du SIRET bailleur

Soit [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/23518/?environment=staging&project=29&query=is%3Aunresolved&statsPeriod=24h) qui est apparue sur l'import du 31: [ce bailleur sur Ecolo](https://metabase.apilos.beta.gouv.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJxdWVyeSIsInF1ZXJ5Ijp7InNvdXJjZS10YWJsZSI6MTc5LCJmaWx0ZXIiOlsiYW5kIixbIj0iLFsiZmllbGQiLDE1NDUsbnVsbF0sMzA3ODU2XV19LCJkYXRhYmFzZSI6NX0sImRpc3BsYXkiOiJ0YWJsZSIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319) de type bailleur privé n'avait pas de `codepersonne` mais un SIREN. Je renforce la requête pour avoir toujours une valeur via des replis sur `coalesce` 