### PR TITLE
Correctifs Docker pour PG15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./pg-init-scripts:/docker-entrypoint-initdb.d
       # Use: delegated to get better performances on docker write workloads where the sync with the host is not mandatory
       - ./pgdata:/var/lib/postgresql/data:delegated
+      - ./pgconf/postgresql.conf:/etc/postgresql/postgresql.conf
     ports:
       - 5433:5432
   redis:

--- a/pg-init-scripts/ecoloweb.sh
+++ b/pg-init-scripts/ecoloweb.sh
@@ -4,9 +4,10 @@ set -e
 set -u
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+create database ecoloweb;
 create database ecolotest;
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" ecolotest <<-EOSQL
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname ecolotest <<-EOSQL
 create schema if not exists ecolo;
 EOSQL

--- a/pg-init-scripts/ecoloweb.sh
+++ b/pg-init-scripts/ecoloweb.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -u
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+create database ecolotest;
+EOSQL
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" ecolotest <<-EOSQL
+create schema if not exists ecolo;
+EOSQL

--- a/pg-init-scripts/ecoloweb.sql
+++ b/pg-init-scripts/ecoloweb.sql
@@ -1,3 +1,3 @@
 create database ecolotest;
 
-create schema if not exists ecolotest.ecolo;
+--create schema if not exists ecolotest.ecolo;

--- a/pg-init-scripts/ecoloweb.sql
+++ b/pg-init-scripts/ecoloweb.sql
@@ -1,3 +1,0 @@
-create database ecolotest;
-
---create schema if not exists ecolotest.ecolo;

--- a/pgconf/postgresql.conf
+++ b/pgconf/postgresql.conf
@@ -1,0 +1,1 @@
+listen_addresses = '*'


### PR DESCRIPTION
# Correctifs Docker pour PG15

Suite au passage à PG15 la création de schéma ne fonctionne plus ... du coup je bascule sur un script bash.

Je rajoute aussi un fichier de conf pour ajouter `listen_address = '*'` qui permet de se connecter depuis l'os host. 💡 on pourrait ranger tous les dossiers liés à Docker dans un sous dossier `.docker` 

⚠️ les tests unitaires sont trèèèèès lent désormais