### PR TITLE
fix highlight search custom filter

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -14,16 +14,13 @@ from django.utils.safestring import mark_safe
 
 @register.filter(name="highlight")
 def highlight(text, search):
-    if not search:
-        return text
-
     rgx = compile(rescape(search), IGNORECASE)
     return mark_safe(
         rgx.sub(
             lambda m: '<span class="apilos-search-highlight">{}</span>'.format(
                 m.group()
             ),
-            text,
+            str(text),
         )
     )
 

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -171,7 +171,7 @@
                                             </script>
                                         </td>
                                         {% if request|is_instructeur %}
-                                            <td>{{convention.programme.bailleur.nom|highlight:conventions.search_input}}</td>
+                                            <td>{{convention.programme.bailleur|highlight:conventions.search_input}}</td>
                                         {% endif %}
                                         {% if request|display_administration %}
                                             <td>{{convention.programme.administration}}</td>
@@ -179,7 +179,7 @@
                                         <td>
                                             <div class="apilos--flex-row-left-center">
                                                 <strong class="apilos--overflow_ellipsis">
-                                                    {{convention.programme.nom|highlight:conventions.search_input}}
+                                                    {{convention.programme|highlight:conventions.search_input}}
                                                 </strong>
                                                 {% if convention.is_avenant %}
                                                     <span class="text-title-blue-france fr-p-1w fr-ml-1w apilos-tag-avenant background-white">Avenant</span>


### PR DESCRIPTION
le problème était un problème de type mais comme tout est casté en str dans le template, on peut se permettre de le faire direct dans le custom filter