### PR TITLE
Correctif liés à Celery et / ou aux pièces jointes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: gunicorn --timeout 300 --chdir core core.wsgi --log-file -
-worker: python -m celery -A core worker -l WARNING
+worker: python -m celery -A core.worker worker -l INFO
 postdeploy: bash bin/post_deploy

--- a/core/settings.py
+++ b/core/settings.py
@@ -491,12 +491,13 @@ CRISP_WEBSITE_ID = get_env_variable("CRISP_WEBSITE_ID")
 
 # Celery (see https://docs.celeryq.dev/en/stable/userguide/configuration.html#configuration)
 CELERY_TIMEZONE = "Europe/Paris"
-CELERY_TASK_TRACK_STARTED = True
-CELERY_TASK_TIME_LIMIT = 10 * 60
+# CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 60 * 60
 CELERY_BROKER_URL = get_env_variable("REDIS_URL")
 CELERY_RESULT_BACKEND = "django-db"
-CELERY_RESULT_EXTENDED = True
-
+CELERY_SEND_EVENTS = True
+CELERY_ACKS_LATE = True
+CELERY_WORKER_MAX_TASKS_PER_CHILD = 5000
 
 # limit reach when an operation has 167 logements
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   worker:
     <<: *apilos
-    command: python -m celery -A core worker -l INFO
+    command: python -m celery -A core.worker worker -l INFO
     ports: []
 
 

--- a/ecoloweb/management/commands/ecoloweb_pj_promote.py
+++ b/ecoloweb/management/commands/ecoloweb_pj_promote.py
@@ -1,0 +1,58 @@
+import sys
+from datetime import date
+
+from django.core.management import BaseCommand
+from django.db import connections
+from django.db import transaction
+
+from tqdm import tqdm
+
+from conventions.models import Convention, PieceJointeType
+from conventions.services.file import ConventionFileService
+from ecoloweb.models import EcoloReference
+from ecoloweb.services import ConventionImporter
+
+
+class Command(BaseCommand):
+    help = "Process piece jointe ot promoted automatically"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "nb_conventions",
+            type=int,
+            default=50,
+            help="Nb of conventions to process",
+        )
+
+    def handle(self, *args, **options):
+        nb_conventions = options["nb_conventions"]
+
+        conventions = Convention.objects.filter(
+            televersement_convention_signee_le__isnull=True,
+            id__in=EcoloReference.objects.filter().only("apilos_id").all(),
+        )[:nb_conventions]
+
+        for convention in conventions:
+            piece_jointe = None
+            if convention.is_avenant():
+                # Le PDF assigné à un avenant est celui de la n-ième pièce jointe par ordre de création de type AVENANT,
+                # avec n le numéro de l'avenant
+                numero = int(convention.numero)
+
+                if numero >= 1:
+                    try:
+                        piece_jointe = convention.pieces_jointes.filter(
+                            type=PieceJointeType.AVENANT
+                        ).order_by("cree_le")[numero - 1]
+                    except IndexError:
+                        piece_jointe = None
+            else:
+                # Le PDF assigné à une convention est celui de la pièce jointe la plus récente de type CONVENTION
+                piece_jointe = (
+                    convention.pieces_jointes.filter(type=PieceJointeType.CONVENTION)
+                    .order_by("-cree_le")
+                    .first()
+                )
+
+            ConventionFileService.promote_piece_jointe(piece_jointe)
+            convention.promote_piece_jointe(False)

--- a/ecoloweb/services/importers_conventions.py
+++ b/ecoloweb/services/importers_conventions.py
@@ -80,7 +80,7 @@ class ConventionImporter(ModelImporter):
     ):
         self._piece_jointe_importer.import_many(ecolo_id)
 
-        if created and model is not None and not settings.TESTING:
+        if model is not None and not settings.TESTING:
             piece_jointe = None
             if model.is_avenant():
                 # Avenant are automatically assigned to the type "commentaires"

--- a/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
+++ b/ecoloweb/services/resources/sql/convention_pieces_jointes.sql
@@ -1,5 +1,5 @@
 select
-    pj.id,
+    ch.id||'-'||pj.id as id,
     ch.id as convention_id,
     case
         when vps.code = '1' then 'CONVENTION'

--- a/ecoloweb/services/resources/sql/programme_logements.sql
+++ b/ecoloweb/services/resources/sql/programme_logements.sql
@@ -16,8 +16,8 @@ select
     l.coefficientmodulation as coeficient,
     l.montantloyer as loyer,
     pl.montantplafondloyerindinitial as loyer_par_metre_carre,
-    l.datecreation as cree_le,
-    l.datecreation as mis_a_jour_le
+    to_timestamp(l.datecreation / 1000)::timestamp at time zone 'Europe/Paris' as cree_le,
+    to_timestamp(l.datecreation / 1000)::timestamp at time zone 'Europe/Paris' as mis_a_jour_le
 from ecolo.ecolo_logement l
     inner join ecolo.ecolo_valeurparamstatic ptl on l.typelogement_id = ptl.id
     inner join ecolo.ecolo_programmelogement pl on l.programmelogement_id = pl.id

--- a/ecoloweb/services/resources/sql/programme_lots.sql
+++ b/ecoloweb/services/resources/sql/programme_lots.sql
@@ -22,8 +22,8 @@ select
     ch.id as id, -- Les lots d'un programme sont tous les logements partageant le même financement
     chp.id as parent_id,
     ch.id as programme_id,
-    coalesce(pl.financementdate, now()) as cree_le,
-    coalesce(pl.financementdate, now()) as mis_a_jour_le,
+    coalesce(pl.financementdate::timestamp at time zone 'Europe/Paris', now()) as cree_le,
+    coalesce(pl.financementdate::timestamp at time zone 'Europe/Paris', now()) as mis_a_jour_le,
     ch.financement,
     coalesce(pl.logementsnombretotal, coalesce(pl.logementsnombreindtotal, 0) + coalesce(pl.logementsnombrecoltotal, 0)) as nb_logements,
     case

--- a/templates/conventions/loyer.html
+++ b/templates/conventions/loyer.html
@@ -84,7 +84,7 @@
                             </div>
 
                             <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                {% include "common/form/input_number.html" with form_input=form.montant editable=True %}
+                                {% include "common/form/input_number.html" with form_input=form.montant editable=True step=".01" %}
                             </div>
 
                             <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">


### PR DESCRIPTION
# Correctif liés à Celery et / ou aux pièces jointes

Suite au passage à Celery, j'ai bien galéré à comprendre ce qui se passait. Ces petits correctifs permettent en même temps de s'assurer que le container `worker` fonctionne et que les pièces jointes sont bien remontées.

Au passage j'ajoute:
* une commande `ecoloweb_pj_promote` pour traiter les fichiers manuellement des fois que l'async se re-choucroute (je suis prévenu désormais)
* des correctifs pour traiter les pièces jointes même sur les conventions d'avenant et même en _ré-import_ (option `--update` )
* la gestion des centimes sur la calculette