### PR TITLE
Fix du bug de l'animation de loading  des commentaires

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -617,6 +617,9 @@ table.fullwidth {
   background-color: #fff;
   z-index: 999;
 }
+#loading[hidden] {
+  display: none;
+}
 
 #loading-image {
   position: absolute;


### PR DESCRIPTION
A l'ouverture de la fenêtre de commentaire, l'animation de loading ne se fermait pas.
![image](https://user-images.githubusercontent.com/19302155/221899649-925584e0-98f7-47ad-aeab-c432f60530e1.png)
