### PR TITLE
Amélioration du contexte de navigation lors de l'hijack

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -27,24 +27,18 @@ def highlight(text, search):
 
 @register.filter
 def is_bailleur(request: HttpRequest) -> bool:
-    return "currently" in request.session and request.session["currently"] in [
-        GroupProfile.STAFF,
-        GroupProfile.BAILLEUR,
-        GroupProfile.SIAP_MO_PERS_MORALE,
-        GroupProfile.SIAP_MO_PERS_PHYS,
-    ]
+    if "currently" in request.session:
+        return request.session["currently"] in GroupProfile.bailleur_profiles()
+
+    return request.user.is_bailleur()
 
 
 @register.filter
 def is_instructeur(request: HttpRequest) -> bool:
-    return "currently" in request.session and request.session["currently"] in [
-        GroupProfile.STAFF,
-        GroupProfile.INSTRUCTEUR,
-        GroupProfile.SIAP_SER_GEST,
-        GroupProfile.SIAP_ADM_CENTRALE,
-        GroupProfile.SIAP_DIR_REG,
-        GroupProfile.SIAP_SER_DEP,
-    ]
+    if "currently" in request.session:
+        return request.session["currently"] in GroupProfile.instructeur_profiles()
+
+    return request.user.is_instructeur()
 
 
 @register.filter

--- a/users/models.py
+++ b/users/models.py
@@ -29,6 +29,26 @@ class GroupProfile(models.TextChoices):
     SIAP_MO_PERS_MORALE = "MO_PERS_MORALE", "Maitre d'ouvrage - personne morale"
     SIAP_MO_PERS_PHYS = "MO_PERS_PHYS", "Maitre d'ouvrage - personne physique"
 
+    @classmethod
+    def instructeur_profiles(cls):
+        return [
+            GroupProfile.STAFF,
+            GroupProfile.INSTRUCTEUR,
+            GroupProfile.SIAP_SER_GEST,
+            GroupProfile.SIAP_ADM_CENTRALE,
+            GroupProfile.SIAP_DIR_REG,
+            GroupProfile.SIAP_SER_DEP,
+        ]
+
+    @classmethod
+    def bailleur_profiles(cls):
+        return [
+            GroupProfile.STAFF,
+            GroupProfile.BAILLEUR,
+            GroupProfile.SIAP_MO_PERS_MORALE,
+            GroupProfile.SIAP_MO_PERS_PHYS,
+        ]
+
 
 class User(AbstractUser):
     # pylint: disable=R0904

--- a/users/urls.py
+++ b/users/urls.py
@@ -7,10 +7,5 @@ urlpatterns = [
         views.home,
         name="home",
     ),
-    path(
-        "update_currently",
-        views.update_currently,
-        name="update_currently",
-    ),
     path("read_popup", views.update_user_popup, name="read_popup"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -20,16 +20,6 @@ def home(request):
     # test si authentifié, si oui, rediriger vers convention/index...
     return render(request, "index.html")
 
-
-@login_required
-@require_POST
-def update_currently(request):
-    if request.user.is_staff or request.user.is_superuser:
-        request.session["currently"] = request.POST.get("currently")
-        return HttpResponseRedirect(reverse("conventions:index"))
-    raise PermissionError("This function is available only for staff")
-
-
 @login_required
 @require_POST
 def update_user_popup(request):


### PR DESCRIPTION
# Amélioration du contexte de navigation lors de l'hijack

Quand je suis connecté "En tant que", je ne suis ni bailleur ni instructeur. Le problème vient des filtres adéquats qui ne tiennent compte que du contexte SIAP