### PR TITLE
Correction des surfaces de logement issues d'Ecoloweb

### DIFF
--- a/conventions/services/convention_generator.py
+++ b/conventions/services/convention_generator.py
@@ -540,17 +540,17 @@ def fiche_caf_doc(convention):
     }
     nb_logements_par_type = {}
     for logement in convention.lot.logements.order_by("typologie").all():
-        logements_totale["sh_totale"] += logement.surface_habitable
-        logements_totale["sa_totale"] += logement.surface_annexes
-        logements_totale["sar_totale"] += logement.surface_annexes_retenue
-        logements_totale["su_totale"] += logement.surface_utile
-        logements_totale["loyer_total"] += logement.loyer
+        logements_totale["sh_totale"] += logement.surface_habitable or 0
+        logements_totale["sa_totale"] += logement.surface_annexes or 0
+        logements_totale["sar_totale"] += logement.surface_annexes_retenue or 0
+        logements_totale["su_totale"] += logement.surface_utile or 0
+        logements_totale["loyer_total"] += logement.loyer or 0
         if logement.get_typologie_display() not in nb_logements_par_type:
             nb_logements_par_type[logement.get_typologie_display()] = 0
         nb_logements_par_type[logement.get_typologie_display()] += 1
 
     lot_num = _prepare_logement_edds(convention)
-    # tester si il logement exists avant de commencer
+    # tester si le logement existe avant de commencer
 
     context = {
         "convention": convention,

--- a/ecoloweb/services/resources/sql/importers/logement.sql
+++ b/ecoloweb/services/resources/sql/importers/logement.sql
@@ -9,10 +9,11 @@ select
         when ptl.code in ('T1B', 'T1P') then 'T1bis'
         else ptl.code -- T2+ are exactly the same
     end as typologie,
+    coalesce(round(cast(l.surfacecorrigee as numeric), 2),  as surface_corrigee,
+    round(cast(l.surfaceutile as numeric), 2) as surface_utile,
     round(cast(l.surfacehabitable as numeric), 2) as surface_habitable,
     round(cast(l.surfaceannexe as numeric), 2) as surface_annexes,
     round(cast(l.surfaceannexe as numeric), 2) as surface_annexes_retenue,
-    round(cast(l.surfaceutile as numeric), 2) as surface_utile,
     l.coefficientmodulation as coeficient,
     l.montantloyer as loyer,
     pl.montantplafondloyerindinitial as loyer_par_metre_carre,


### PR DESCRIPTION
# Correction des surfaces de logement issues d'Ecoloweb

Cette [erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/25078/?environment=production&project=29&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox&statsPeriod=1h) qui a poppé. La convention venait d'Ecolo mais pour autant toutes les surface pouvaient être `None` ce qui semble n'avoir jamais été vu sur Apilos...

Quoi qu'il en soit je rajoute des garde-fous et j'en profite pour rajouter la `surface_corrigee`. Pour la réconcilication il me faudra jouer cette requête:

```sql
update programmes_logement l
set
    surface_habitable = el.surface_habitable,
    surface_corrigee = el.surface_corrigee,
    surface_utile = el.surface_utile,
    surface_annexes = el.surface_annexes,
    surface_annexes_retenue = el.surface_annexes_retenue
from dblink('ecoloweb', '
select
    l.id::text,
    round(cast(coalesce(l.surfacehabitable, l.surfacecorrigee, l.surfaceutile) as numeric), 2) as surface_habitable,
    round(cast(l.surfacecorrigee as numeric), 2) as surface_corrigee,
    round(cast(l.surfaceutile as numeric), 2) as surface_utile,
    round(cast(l.surfaceannexe as numeric), 2) as surface_annexes,
    round(cast(l.surfaceannexe as numeric), 2) as surface_annexes_retenue
from ecolo.ecolo_logement l') as el (ecolo_id text, surface_habitable numeric, surface_corrigee numeric, surface_utile numeric, surface_annexes numeric, surface_annexes_retenue numeric)
    inner join ecoloweb_ecoloreference er on er.ecolo_id = el.ecolo_id and er.apilos_model = 'programmes.Logement'
where l.id = er.apilos_id;
```