### PR TITLE
Correctif listing bailleurs: ne plus afficher la liste complète des bailleurs existants

### DIFF
--- a/apilos_settings/services/services_view.py
+++ b/apilos_settings/services/services_view.py
@@ -691,7 +691,18 @@ class ImportBailleurUsersService:
         return ReturnStatus.ERROR
 
     def _process_formset(self) -> ReturnStatus:
-        self.formset = UserBailleurFormSet(self.request.POST)
+        self.formset = UserBailleurFormSet(
+            self.request.POST,
+            form_kwargs={
+                "bailleur_queryset": Bailleur.objects.filter(
+                    id__in=[
+                        value
+                        for key, value in self.request.POST.items()
+                        if key.endswith("bailleur")
+                    ]
+                )
+            },
+        )
         if self.formset.is_valid():
             for form_user_bailleur in self.formset:
                 UserService.create_user_bailleur(

--- a/apilos_settings/services/services_view.py
+++ b/apilos_settings/services/services_view.py
@@ -675,8 +675,16 @@ class ImportBailleurUsersService:
             self.request.POST, self.request.FILES
         )
         if self.upload_form.is_valid():
+            data = self.upload_form.cleaned_data["users"]
             self.formset = UserBailleurFormSet(
-                self._build_formset_data(self.upload_form.cleaned_data["users"])
+                self._build_formset_data(data),
+                form_kwargs={
+                    "bailleur_queryset": Bailleur.objects.filter(
+                        id__in=[
+                            d["bailleur"].id for d in data if d["bailleur"] is not None
+                        ]
+                    )
+                },
             )
             return ReturnStatus.SUCCESS
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -203,7 +203,8 @@ class UserBailleurForm(forms.Form):
     )
 
     def __init__(self, *args, bailleur_queryset=None, **kwargs) -> None:
-        self.declared_fields["bailleur"].queryset = bailleur_queryset
+        if bailleur_queryset:
+            self.declared_fields["bailleur"].queryset = bailleur_queryset
 
         super().__init__(*args, **kwargs)
 

--- a/users/forms.py
+++ b/users/forms.py
@@ -198,9 +198,14 @@ class UserBailleurForm(forms.Form):
 
     bailleur = forms.ModelChoiceField(
         required=True,
-        queryset=Bailleur.objects.all().order_by("nom"),
+        queryset=Bailleur.objects.none(),
         label="Entreprise bailleur",
     )
+
+    def __init__(self, *args, bailleur_queryset=None, **kwargs) -> None:
+        self.declared_fields["bailleur"].queryset = bailleur_queryset
+
+        super().__init__(*args, **kwargs)
 
     def clean_email(self):
         email = self.cleaned_data["email"]


### PR DESCRIPTION
# Correctif listing bailleurs: ne plus afficher la liste complète des bailleurs existants

Avec toutes les données issues d'Ecoloweb, les `<select>` de bailleurs (notamment) sont devenus immenses. Ceci causant des _timeout_, encore plus sur le formulaire d'upload de listing utilisateur bailleur.

Petit correctif pour n'afficher que la liste des bailleurs mentionnés dans le doc. Si pas trouvé il faut ré-éditer le fichier Excel ...