### PR TITLE
Add team apilos as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @MTES-MCT/apilos


### PR DESCRIPTION
Following docs :
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
* https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team