### PR TITLE
Erreur Sentry APILOS-178 "undefined key“ à la réinitialisation de mot de passe

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -94,6 +94,8 @@ if SENDINBLUE_API_KEY:
         "SENDINBLUE_API_KEY": SENDINBLUE_API_KEY,
     }
     EMAIL_BACKEND = "anymail.backends.sendinblue.EmailBackend"
+else:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 env_allowed_hosts = []
 try:

--- a/core/urls.py
+++ b/core/urls.py
@@ -26,7 +26,7 @@ from django.contrib.sitemaps.views import sitemap
 import django_cas_ng.views
 
 from core.sitemaps import SITEMAPS
-
+from core.views import SecurePasswordResetConfirmView
 
 urlpatterns = [
     path("admin/doc/", include("django.contrib.admindocs.urls")),
@@ -84,6 +84,11 @@ if settings.CERBERE_AUTH:
 else:
     urlpatterns = urlpatterns + [
         path("accounts/", include("django.contrib.auth.urls")),
+        path(
+            "accounts/reset/<uidb64>/<token>/",
+            SecurePasswordResetConfirmView.as_view(),
+            name="password_reset_confirm",
+        ),
     ]
 
 if "django_browser_reload" in settings.INSTALLED_APPS:

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.views import (
+    PasswordResetConfirmView,
+    INTERNAL_RESET_SESSION_TOKEN,
+    PasswordContextMixin,
+)
+from django.contrib.auth import login as auth_login
+
+
+class SecurePasswordResetConfirmView(PasswordResetConfirmView):
+    """
+    Redéfinition de la vue de confirmation du mot de passe afin d'éviter une erreur de clef manquante dans la session
+    https://code.djangoproject.com/ticket/30952
+    """
+
+    def form_valid(self, form):
+        user = form.save()
+        # Ensure INTERNAL_RESET_SESSION_TOKEN actually is in session before trying to delete it
+        if INTERNAL_RESET_SESSION_TOKEN in self.request.session:
+            del self.request.session[INTERNAL_RESET_SESSION_TOKEN]
+
+        if self.post_reset_login:
+            auth_login(self.request, user, self.post_reset_login_backend)
+
+        return super(PasswordContextMixin).form_valid(form)


### PR DESCRIPTION
# Erreur Sentry APILOS-178 "undefined key“ à la réinitialisation de mot de passe

[Cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/18119/) qu'on se trimbale depuis longtemps: je pense que des gens doivent cliquer longtemps après sur un email de réinitialisation de MdP si bien que la session n'est plus raccord avec son état d'origine. [Le problème sur Django est remonté depuis plusieurs années](https://code.djangoproject.com/ticket/30952) mais personne ne semble se précipiter à corriger ça ...

Du coup je corrige en rédéfinissant la classe de `view` pour empêcher l'erreur de se produire, ~~pas contre je n'arrive pas à tester chez moi puisque j'ai un souci avec l'emailing visiblement~~ => corrigé avec le second commit et la définition de `console.EmailBackend` en repli si pas de SendinBlue ✅  (utile pour les emails d'auth)