### PR TITLE
Ecoloweb: corrections de donnees suite aux investigations

### DIFF
--- a/ecoloweb/services/resources/sql/importers/convention.sql
+++ b/ecoloweb/services/resources/sql/importers/convention.sql
@@ -14,13 +14,12 @@ select
         else c.noreglementaire
     end as numero,
     case
-        -- Si la convention (ou l'avenant) n'est pas le dernier dans l'historique alors il est systématiquement finalisé
-        when ch.is_last then '5. Signée'
-        -- Sinon on se base sur l'état déclaré dans Ecolo
+        -- On se base sur l'état déclaré dans Ecolo
         when vps.code = 'ANS' then '8. Annulée en suivi'
         when vps.code = 'RES' then '7. Dénoncée'
         when vps.code = 'RES' then '6. Résiliée'
-        when vps.code = 'INS' then '2. Instruction requise'
+        -- Convention en instruction si état = 'INS' ET aucune date de signature
+        when vps.code = 'INS' and coalesce(a.datesignatureprefet, cdg.datesignatureprefet, cdg.datesignatureentitegest) is null then '2. Instruction requise'
         else '5. Signée'
     end as statut,
     -- Dates

--- a/ecoloweb/services/resources/sql/importers/programme.sql
+++ b/ecoloweb/services/resources/sql/importers/programme.sql
@@ -36,8 +36,8 @@ select
     chp.id as parent_id,
     pl.bailleurproprietaire_id as bailleur_id,
     c.entitecreatrice_id as administration_id,
-    pa.codepostal as code_postal,
-    pa.ville,
+    coalesce(cp.codepostal, pa.codepostal, ec.code) as code_postal,
+    ec.libelle as ville,
     pa.ligne1||' '||pa.ligne2||' '||pa.ligne3||' '||pa.ligne4 as adresse,
     case
         when (pl.description <> '') is true then pl.description
@@ -81,6 +81,7 @@ from ecolo.ecolo_conventionhistorique ch
     left join ecolo.ecolo_programmeadresse pa on pl.id = pa.programmelogement_id
     left join ecolo.ecolo_valeurparamstatic nop on pl.natureoperation_id = nop.id
     inner join ecolo.ecolo_commune ec on pl.commune_id = ec.id
+    left join ecolo.ecolo_codepostal cp on ec.code = cp.codeinsee
     inner join ecolo.ecolo_departement ed on ec.departement_id = ed.id
     inner join ecolo.ecolo_region er on ed.region_id = er.id
 where


### PR DESCRIPTION
# Ecoloweb: corrections de donnees suite aux investigations

J'ai mené quelques investigations suite aux retours qu'on a eu sur Crisp des utilisateurs Ecolo. 3 problèmes:
* "des conventions n'ont pas le bon statut": c'est ma faute 🙊  j'ai forcé l'itération d'une convention la plus récente à finalisée sans prendre en compte le fait qu'elles pouvaient avoir été `Résiliée` ou `Dénoncée` ou autre statut post signature ensuite 🤐 
* "des programmes n'ont pas de ville:" je prends la ville liée à l'adresse définie sur le programme mais qui est _optionnelle_. Pourquoi ? Parce que celle-ci peut avoir le code postal qui est requis par Apilos, quand la `commune` sur Ecolo, obligatoire sur un programme, n'a que le code INSEE => il y avait une table `ecolo_codepostal` sous mes yeux depuis le début! En revanche 30 communes n'ont pas de code postal, il faudra surement réconcilier plus tard (ça ne fait que 0,1 %)
* "des conventions n'ont pas le bon nombre de logements" => tout simplement parce que sur Ecolo on peut avoir plusieurs programmes 🧠  (avec les mêmes financement, bailleur et commune), il fallait donc que je fasse la somme de tous les logements (je savais bien que ça me reviendrait à la gueule)

Notes:
* [cette convention](https://apilos.beta.gouv.fr/conventions/recapitulatif/ac5b0738-1a4c-4da6-bc60-4e7e3bb5fbcf) devrait avoir une ville (genre "Equeurdreville") de renseignée une fois corrigée
* [celle-ci](https://apilos.beta.gouv.fr/conventions/post_action/3c004660-2d3d-4d1a-b901-c1a2ea03aa46) devrait avoir 21 logements
* [celle-ci](https://apilos.beta.gouv.fr/conventions/post_action/094ec6c8-3e5d-40e3-a383-240fcb26bbba) doit être "Annulée en suivi"

Tout ceci va régler **BEAUCOUP** de problème. On peut éviter de relancer les imports en lançant des requêtes SQL "cross" grâce à `dblink`:

```sql
-- Correctifs de données suite aux investigations:

-- DB Link connection
select dblink_connect('ecoloweb', 'hostaddr=10.20.11.46 port=32489 dbname=ecoloweb user=<username> password=<password> options=-csearch_path=ecolo');

-- 1. Etat de la convention
update conventions_convention c
set statut= cs.statut
from dblink('ecoloweb', '
select
    ch.id as id,
    case
        -- On se base sur l''état déclaré dans Ecolo
        when vps.code = ''ANS'' then ''8. Annulée en suivi''
        when vps.code = ''RES'' then ''7. Dénoncée''
        when vps.code = ''RES'' then ''6. Résiliée''
        -- Convention en instruction si état = ''INS'' ET aucune date de signature
        when vps.code = ''INS'' and coalesce(a.datesignatureprefet, cdg.datesignatureprefet, cdg.datesignatureentitegest) is null then ''2. Instruction requise''
        else ''5. Signée''
    end as statut
from ecolo.ecolo_conventionhistorique ch
    inner join ecolo.ecolo_conventiondonneesgenerales cdg on cdg.id = ch.conventiondonneesgenerales_id
    left join ecolo.ecolo_avenant a on ch.avenant_id = a.id
    inner join ecolo.ecolo_valeurparamstatic vps on vps.id = cdg.etatconvention_id
')
        as cs (ecolo_id text, statut varchar(25))
    inner join ecoloweb_ecoloreference er on er.ecolo_id = cs.ecolo_id and er.apilos_model = 'conventions.Convention'
where c.id = er.apilos_id;


-- 2. Nombre de logements du lot
update programmes_lot l
set nb_logements = ld.nb_logements
from dblink('ecoloweb', '
select
    ch.id as id,
    pl2.nb_logements as nb_logements
from ecolo.ecolo_programmelogement pl
    inner join ecolo.ecolo_conventionhistorique ch on pl.conventiondonneesgenerales_id = ch.conventiondonneesgenerales_id and ch.programme_ids[1] = pl.id
    inner join (
    -- Nombre total de logement sur tous les programmes d''un même cdg et même financement
    select
        plg.conventiondonneesgenerales_id, plg.financement, sum(plg.nb_logements) as nb_logements
    from (select

        pl2.conventiondonneesgenerales_id,
        case
            when tf.code in (''18'', ''22'', ''93'') then ''SANS_FINANCEMENT''
            else ff.code
            end as financement,
        coalesce(pl2.logementsnombretotal, coalesce(pl2.logementsnombreindtotal, 0) + coalesce(pl2.logementsnombrecoltotal, 0)) as nb_logements
    from ecolo.ecolo_programmelogement pl2
        inner join ecolo.ecolo_typefinancement tf on pl2.typefinancement_id = tf.id
        inner join ecolo.ecolo_famillefinancement ff on tf.famillefinancement_id = ff.id) plg
    group by plg.conventiondonneesgenerales_id, plg.financement) pl2 on pl2.conventiondonneesgenerales_id = ch.conventiondonneesgenerales_id and pl2.financement = ch.financement
')
        as ld (ecolo_id text, nb_logements int)
    inner join ecoloweb_ecoloreference er on er.ecolo_id = ld.ecolo_id and er.apilos_model = 'programmes.Lot'
where l.id = er.apilos_id;

-- 3. Ville du programme
update programmes_programme p
set code_postal = pc.code_postal, ville = pc.ville
from dblink('ecoloweb', '
select
    ch.id,
    coalesce(cp.codepostal, pa.codepostal, ec.code) as code_postal,
    ec.libelle as ville
from ecolo.ecolo_conventionhistorique ch
    inner join ecolo.ecolo_programmelogement pl on pl.id = ch.programme_ids[1]
    inner join ecolo.ecolo_commune ec on pl.commune_id = ec.id
    left join ecolo.ecolo_codepostal cp on ec.code = cp.codeinsee
')
        as pc (ecolo_id text, code_postal varchar(5), ville varchar(235))
    inner join ecoloweb_ecoloreference er on er.ecolo_id = pc.ecolo_id and er.apilos_model = 'programmes.Programme'
where p.id = er.apilos_id;

```
