### PR TITLE
Sometimes, the footer which limit the line is not displayed

### DIFF
--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -64,7 +64,7 @@
     </div>
 {% endif %}
 <div class="fr-container-fluid ds_banner">
-    <div class="fr-container fr-px-3w">
+    <div class="fr-container fr-px-3w fr-mb-3w">
         <div class="fr-grid-row fr-grid-row--gutters fr-card fr-card--no-border">
             <div class="fr-col-md-12">
                 <details class="apilos-order-menu">


### PR DESCRIPTION
Before:

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/454431/229538131-fc39d079-d138-4c0e-a135-7559b809f105.png">


After:

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/454431/229537983-fd81b3f9-dce0-4d48-81a8-2a8f4c3e0717.png">
