### PR TITLE
Les logements ne sont plus affichés sur le récap des avenants

### DIFF
--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -33,13 +33,13 @@
                 {% endif %}
                 {% if convention.is_avenant %}
                     {% if 'bailleur' in avenant_list %}
-                        {% include "conventions/recapitulatif/bailleur.html" with target_url='conventions:avenant_bailleur' %}
+                        {% include "conventions/recapitulatif/bailleur.html" with target_url='conventions:avenant_bailleur' bailleur=convention.bailleur %}
                     {% endif %}
                     {% if 'logements' in avenant_list %}
-                        {% include "conventions/recapitulatif/foyer_residence_logements.html" with target_url='conventions:avenant_foyer_residence_logements' %}
-                        {% include "conventions/recapitulatif/collectif.html" with target_url='conventions:avenant_collectif' %}
-                        {% include "conventions/recapitulatif/logements.html" with target_url='conventions:avenant_logements' %}
-                        {% include "conventions/recapitulatif/annexes.html" with target_url='conventions:avenant_annexes' %}
+                        {% include "conventions/recapitulatif/foyer_residence_logements.html" with target_url='conventions:avenant_foyer_residence_logements' lot=convention.lot logements=convention.lot.logements.all %}
+                        {% include "conventions/recapitulatif/collectif.html" with target_url='conventions:avenant_collectif' lot=convention.lot %}
+                        {% include "conventions/recapitulatif/logements.html" with target_url='conventions:avenant_logements' lot=convention.lot logements=convention.lot.logements.all %}
+                        {% include "conventions/recapitulatif/annexes.html" with target_url='conventions:avenant_annexes' annexes=convention.lot.annexes.all lot=convention.lot %}
                     {% endif %}
                     {% if 'duree' in avenant_list %}
                         {% include "conventions/recapitulatif/financement.html" with target_url='conventions:avenant_financement' %}

--- a/templates/conventions/recapitulatif/logements.html
+++ b/templates/conventions/recapitulatif/logements.html
@@ -105,7 +105,7 @@
                             <p class="fr-mb-0 notes"><em>Vous n'avez indiqué aucun logement.</em></p>
                             <a class="fr-my-1w fr-link" href="{% url target_url convention_uuid=convention.uuid %}">Ajouter des logements</a>
 
-                            {% if repartition_surfaces %}
+                            {% if conventions.ecolo_reference and repartition_surfaces %}
                                 <p class="fr-my-2w notes"><em>Cependant, vous avez déclaré depuis Ecoloweb la répartition des logement suivante:</em></p>
                                 <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
                                     <table aria-label="Répartion des logements par surface">


### PR DESCRIPTION
# Les logements ne sont plus affichés sur le récap des avenants

cf. [le problème de Pusic](https://mattermost.incubateur.net/fabnum-mte/pl/wit77b59yffwbmybzh7j85qhgc) remonté par @MarjolaineLB , on a remarqué que les templates du récap n'étaient pas appelés avec les arguments comme pour les conventions racines. 

On rajoute en plus une vérification pour ne pas afficher le détail des surfaces d'une convention / avenant non issu d'Ecoloweb