### PR TITLE
add a worker restart script and schedule it

### DIFF
--- a/bin/restart_workers_script.sh
+++ b/bin/restart_workers_script.sh
@@ -1,0 +1,9 @@
+#!/bin/env bash
+
+if [ -n "$SCALINGO_API_TOKEN" ]; then
+    install-scalingo-cli
+    scalingo login --api-token $SCALINGO_API_TOKEN
+    scalingo --app apilos-staging restart worker
+else
+    echo "SCALINGO_API_TOKEN is not set"
+fi

--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+    "jobs": [
+        {
+            "command": "10 2 * * * ./bin/restart_workers_script.sh"
+        }
+    ]
+}


### PR DESCRIPTION
Add SCALINGO_API_TOKEN token key to env variable. 
Every environment with this env variable will restart workers at 2.10 am UTC
