### PR TITLE
Correctif: la répartition des surfaces ne sont plus affichées

### DIFF
--- a/templates/conventions/recapitulatif/logements.html
+++ b/templates/conventions/recapitulatif/logements.html
@@ -105,7 +105,7 @@
                             <p class="fr-mb-0 notes"><em>Vous n'avez indiqué aucun logement.</em></p>
                             <a class="fr-my-1w fr-link" href="{% url target_url convention_uuid=convention.uuid %}">Ajouter des logements</a>
 
-                            {% if conventions.ecolo_reference and repartition_surfaces %}
+                            {% if convention.ecolo_reference and repartition_surfaces %}
                                 <p class="fr-my-2w notes"><em>Cependant, vous avez déclaré depuis Ecoloweb la répartition des logement suivante:</em></p>
                                 <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
                                     <table aria-label="Répartion des logements par surface">


### PR DESCRIPTION
# Correctif: la répartition des surfaces ne sont plus affichées

Le détail de la répartition des surfaces, issues d'Ecoloweb, n'apparaissent plus suite à [ce correctif](https://github.com/MTES-MCT/apilos/commit/3a208fa5b57ce5bdf0f07f98ea114402f0c2bcee#diff-a6dd1c99a3cc8b0a41c478386b0426761059725256a96ad27921f60c35636cddR108) ... à cause d'une coquille 🙈 