### PR TITLE
Mise à jour de la page de formulaire bailleur 

### DIFF
--- a/conventions/services/bailleurs.py
+++ b/conventions/services/bailleurs.py
@@ -44,12 +44,6 @@ class ConventionBailleurService(ConventionService):
         self.form = ConventionBailleurForm(
             initial={
                 "uuid": bailleur.uuid,
-                "nom": bailleur.nom,
-                "siret": bailleur.siret,
-                "capital_social": bailleur.capital_social,
-                "adresse": bailleur.adresse,
-                "code_postal": bailleur.code_postal,
-                "ville": bailleur.ville,
                 "signataire_nom": self.convention.signataire_nom
                 or bailleur.signataire_nom,
                 "signataire_fonction": self.convention.signataire_fonction

--- a/conventions/tests/services/test_bailleur_service.py
+++ b/conventions/tests/services/test_bailleur_service.py
@@ -41,7 +41,6 @@ class ConventionBailleurServiceTests(TestCase):
             self.service.form.initial["uuid"],
             bailleur.uuid,
         )
-        self.assertEqual(self.service.form.initial["nom"], bailleur.nom)
 
     def test_update_bailleur_nom_error(self):
 

--- a/templates/conventions/bailleur.html
+++ b/templates/conventions/bailleur.html
@@ -67,7 +67,7 @@
                     </div>
                 {% endif %}
                 <div class="fr-col-12 fr-mb-0 fr-text--sm"><em>Vous pouvez{% if upform.bailleur.field.choices%} également{% endif %} mettre à jour les informations de votre bailleur, si celles-ci sont erronées, dans
-                    <a href="{% url 'settings:edit_bailleur' bailleur_uuid=convention.bailleur.uuid %}" target="_blank">votre espace d'administration</a></em>
+                    <a href="{% url 'settings:edit_bailleur' bailleur_uuid=convention.bailleur.uuid %}" target="_blank" rel="noopener">votre espace d'administration</a></em>
                 </div>
                 <hr class="fr-col-12 fr-my-3w">
             </div>

--- a/templates/conventions/bailleur.html
+++ b/templates/conventions/bailleur.html
@@ -18,60 +18,62 @@
     <div class="fr-container-fluid ds_banner">
         {% include "conventions/common/form_header.html"%}
         {% include "common/step_progressbar.html"%}
-        <div class="fr-container">
-            <div class="fr-grid-row fr-grid-row--gutters">
-                <div class="fr-col-12">
-                    <h4 class="fr-mb-0">Entreprise bailleur</h4>
-                </div>
-                <div class="fr-col-12 fr-text--lg fr-mb-0">
-                    <strong>
-                        {{convention.bailleur.nom}}
-                    </strong>
-                </div>
-                <div class="fr-col-12 fr-col-lg-6">
-                    <div>{{convention.bailleur.adresse}}</div>
-                    <div>
-                        {{convention.bailleur.code_postal}} {{convention.bailleur.ville}}
-                    </div>
-                </div>
-                <div class="fr-col-12 fr-col-lg-6">
-                    <div class="fr-col-12">SIRET : {{convention.bailleur.siret}}</div>
-                    <div class="fr-col-12">Capital social : {{convention.bailleur.capital_social}}</div>
-                </div>
-                <hr class="fr-col-12 fr-my-3w">
-                {% if upform.bailleur.field.choices|length > 1 or upform.errors %}
+        {% with bailleur=convention.bailleur %}
+            <div class="fr-container">
+                <div class="fr-grid-row fr-grid-row--gutters">
                     <div class="fr-col-12">
-                        <div class="block--row-strech">
-                            <div class="block--row-strech-1 fr-mr-2w">
-                                <div class=" fr-text--lg fr-mb-0"><strong>Ce n'est pas le bon bailleur ? </strong></div>
-                                <div>Vous pouvez demander l'attribution de la convention à un autre bailleur en cliquant ci-dessous.</div>
-                            </div>
-                            <details {% if upform.errors %}open{% endif %} class="fr-mt-3w">
-                                <summary>
-                                    <div class="fr-btn">Changer le bailleur de la convention et de son opération</div>
-                                </summary>
-                                <div>
-                                    <form method="post" action="">
-                                        {% csrf_token %}
-                                        {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
-                                            {% url 'users:search_bailleur' as search_bailleur_url %}
-                                            {% include "common/form/input_search_select.html" with form_input=upform.bailleur url=search_bailleur_url %}
-                                        {% endwith %}
-                                        <button class="fr-btn" name="change_bailleur" value="True">
-                                            Changer le bailleur
-                                        </button>
-                                    </form>
-                                </div>
-                            </details>
+                        <h4 class="fr-mb-0">Entreprise bailleur</h4>
+                    </div>
+                    <div class="fr-col-12 fr-text--lg fr-mb-0">
+                        <strong>
+                            {{bailleur.nom}}
+                        </strong>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-6">
+                        <div>{{bailleur.adresse}}</div>
+                        <div>
+                            {{bailleur.code_postal}} {{bailleur.ville}}
                         </div>
                     </div>
-                {% endif %}
-                <div class="fr-col-12 fr-mb-0 fr-text--sm"><em>Vous pouvez{% if upform.bailleur.field.choices%} également{% endif %} mettre à jour les informations de votre bailleur, si celles-ci sont erronées, dans
-                    <a href="{% url 'settings:edit_bailleur' bailleur_uuid=convention.bailleur.uuid %}" target="_blank" rel="noopener">votre espace d'administration</a></em>
+                    <div class="fr-col-12 fr-col-lg-6">
+                        <div class="fr-col-12">SIRET : {{bailleur.siret}}</div>
+                        <div class="fr-col-12">Capital social : {{bailleur.capital_social}}</div>
+                    </div>
+                    <hr class="fr-col-12 fr-my-3w">
+                    {% if upform.bailleur.field.choices|length > 1 or upform.errors %}
+                        <div class="fr-col-12">
+                            <div class="block--row-strech">
+                                <div class="block--row-strech-1 fr-mr-2w">
+                                    <div class=" fr-text--lg fr-mb-0"><strong>Ce n'est pas le bon bailleur ? </strong></div>
+                                    <div>Vous pouvez demander l'attribution de cette convention à un autre bailleur.</div>
+                                </div>
+                                <details {% if upform.errors %}open{% endif %} class="fr-mt-3w">
+                                    <summary>
+                                        <div class="fr-btn">Changer le bailleur de cette convention et de son opération</div>
+                                    </summary>
+                                    <div>
+                                        <form method="post" action="">
+                                            {% csrf_token %}
+                                            {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
+                                                {% url 'users:search_bailleur' as search_bailleur_url %}
+                                                {% include "common/form/input_search_select.html" with form_input=upform.bailleur url=search_bailleur_url %}
+                                            {% endwith %}
+                                            <button class="fr-btn" name="change_bailleur" value="True">
+                                                Changer le bailleur
+                                            </button>
+                                        </form>
+                                    </div>
+                                </details>
+                            </div>
+                        </div>
+                    {% endif %}
+                    <div class="fr-col-12 fr-mb-0 fr-text--sm"><em>Vous pouvez{% if upform.bailleur.field.choices%} également{% endif %} mettre à jour les informations de votre bailleur, si celles-ci sont erronées, dans
+                        <a href="{% url 'settings:edit_bailleur' bailleur_uuid=convention.bailleur.uuid %}" target="_blank" rel="noopener">votre espace d'administration</a></em>
+                    </div>
+                    <hr class="fr-col-12 fr-my-3w">
                 </div>
-                <hr class="fr-col-12 fr-my-3w">
             </div>
-        </div>
+        {% endwith %}
         <div class="fr-container">
             <form method="post" action="">
                 {% csrf_token %}

--- a/templates/conventions/bailleur.html
+++ b/templates/conventions/bailleur.html
@@ -19,66 +19,65 @@
         {% include "conventions/common/form_header.html"%}
         {% include "common/step_progressbar.html"%}
         <div class="fr-container">
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                    <h4 class="fr-mb-0">Entreprise bailleur</h4>
+                </div>
+                <div class="fr-col-12 fr-text--lg fr-mb-0">
+                    <strong>
+                        {{convention.bailleur.nom}}
+                    </strong>
+                </div>
+                <div class="fr-col-12 fr-col-lg-6">
+                    <div>{{convention.bailleur.adresse}}</div>
+                    <div>
+                        {{convention.bailleur.code_postal}} {{convention.bailleur.ville}}
+                    </div>
+                </div>
+                <div class="fr-col-12 fr-col-lg-6">
+                    <div class="fr-col-12">SIRET : {{convention.bailleur.siret}}</div>
+                    <div class="fr-col-12">Capital social : {{convention.bailleur.capital_social}}</div>
+                </div>
+                <hr class="fr-col-12 fr-my-3w">
+                {% if upform.bailleur.field.choices|length > 1 or upform.errors %}
+                    <div class="fr-col-12">
+                        <div class="block--row-strech">
+                            <div class="block--row-strech-1 fr-mr-2w">
+                                <div class=" fr-text--lg fr-mb-0"><strong>Ce n'est pas le bon bailleur ? </strong></div>
+                                <div>Vous pouvez demander l'attribution de la convention à un autre bailleur en cliquant ci-dessous.</div>
+                            </div>
+                            <details {% if upform.errors %}open{% endif %} class="fr-mt-3w">
+                                <summary>
+                                    <div class="fr-btn">Changer le bailleur de la convention et de son opération</div>
+                                </summary>
+                                <div>
+                                    <form method="post" action="">
+                                        {% csrf_token %}
+                                        {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
+                                            {% url 'users:search_bailleur' as search_bailleur_url %}
+                                            {% include "common/form/input_search_select.html" with form_input=upform.bailleur url=search_bailleur_url %}
+                                        {% endwith %}
+                                        <button class="fr-btn" name="change_bailleur" value="True">
+                                            Changer le bailleur
+                                        </button>
+                                    </form>
+                                </div>
+                            </details>
+                        </div>
+                    </div>
+                {% endif %}
+                <div class="fr-col-12 fr-mb-0 fr-text--sm"><em>Vous pouvez{% if upform.bailleur.field.choices%} également{% endif %} mettre à jour les informations de votre bailleur, si celles-ci sont erronées, dans
+                    <a href="{% url 'settings:edit_bailleur' bailleur_uuid=convention.bailleur.uuid %}" target="_blank">votre espace d'administration</a></em>
+                </div>
+                <hr class="fr-col-12 fr-my-3w">
+            </div>
+        </div>
+        <div class="fr-container">
             <form method="post" action="">
                 {% csrf_token %}
 
                 <div class="fr-grid-row fr-grid-row--gutters">
                     <div class="fr-col-12">
-
-                        <h4>Entreprise bailleur</h4>
-
-                        <div class="apilos-bordered fr-mb-3w">
-
-                            <div role="alert" class="fr-alert fr-alert--info fr-mb-3w">
-                                <p>Les infomations dans ce cadre sont attachées à l'entreprise bailleur,
-                                    les modifications seront donc reportées sur toutes les conventions en
-                                    projet ou en cours d'instruction appartenant à ce bailleur.</p>
-                                {% if upform.bailleur.field.choices|length > 1 or upform.errors %}
-                                    <details {% if upform.errors %}open{% endif %}>
-                                        <summary>
-                                            <span class="fr-link">Vous pouvez aussi demander une modification du bailleur de l'opération de la convention en cliquant sur ce lien</span>
-                                        </summary>
-                                        <div>
-                                            {% csrf_token %}
-                                            {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
-                                                {% url 'users:search_bailleur' as search_bailleur_url %}
-                                                {% include "common/form/input_search_select.html" with form_input=upform.bailleur url=search_bailleur_url %}
-                                            {% endwith %}
-                                            <button class="fr-btn" name="change_bailleur" value="True">
-                                                Changer le bailleur de la convention et de son opération
-                                            </button>
-                                        </div>
-                                    </details>
-                                {% endif %}
-                            </div>
-
-                            {% include "common/form/input_text.html" with form_input=form.nom object_field="bailleur__nom__"|add:form.uuid.value %}
-
-                            <div class="fr-mb-2w">
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                        {% include "common/form/input_text.html" with form_input=form.siret object_field="bailleur__siret__"|add:form.uuid.value %}
-                                    </div>
-                                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
-                                        {% include "common/form/input_number.html" with step="0.01" form_input=form.capital_social object_field="bailleur__capital_social__"|add:form.uuid.value %}
-                                    </div>
-                                </div>
-                            </div>
-
-                            {% include "common/form/input_text.html" with form_input=form.adresse object_field="bailleur__adresse__"|add:form.uuid.value %}
-
-                            <div class="fr-mb-2w">
-                                <div class="fr-grid-row fr-grid-row--gutters">
-                                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                        {% include "common/form/input_text.html" with form_input=form.code_postal object_field="bailleur__code_postal__"|add:form.uuid.value %}
-                                    </div>
-                                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
-                                        {% include "common/form/input_text.html" with form_input=form.ville object_field="bailleur__ville__"|add:form.uuid.value %}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
                         <h4>Signataire de la convention{% if convention.programme.is_foyer or convention.programme.is_residence %} (Propriétaire){% endif %}</h4>
 
                         {% include "common/form/input_text.html" with form_input=form.signataire_nom object_field="bailleur__signataire_nom__"|add:form.uuid.value %}


### PR DESCRIPTION
pour éviter les erreurs de modification de bailleurs

Les informations bailleurs ne sont plus modifiables directement. Un bouton permet de changer l'attribution de la convention à un autre bailleur et un lien renvoie vers le bailleur pour y apporter des modifications si besoin

![image](https://user-images.githubusercontent.com/19302155/233125286-0bfee572-479f-48ff-abfb-856e332a64a1.png)
