### PR TITLE
Fix regle de calcul fin de convention PLS/sans travaux

### DIFF
--- a/conventions/forms/convention_form_financement.py
+++ b/conventions/forms/convention_form_financement.py
@@ -75,9 +75,9 @@ class ConventionFinancementForm(forms.Form):
           et finissant au 30 juin
         """
         today = datetime.date.today()
-        date_signature = self.convention.parent.televersement_convention_signee_le
-        if date_signature:
-            today = date_signature
+        if self.convention.parent:
+            if self.convention.parent.televersement_convention_signee_le:
+                today = self.convention.parent.televersement_convention_signee_le
         min_years = today.year + 15
         max_years = today.year + 40
         if today.month > 6:
@@ -107,9 +107,9 @@ class ConventionFinancementForm(forms.Form):
           et finissant au 30 juin
         """
         today = datetime.date.today()
-        date_signature = self.convention.parent.televersement_convention_signee_le
-        if date_signature:
-            today = date_signature
+        if self.convention.parent:
+            if self.convention.parent.televersement_convention_signee_le:
+                today = self.convention.parent.televersement_convention_signee_le
 
         min_years = today.year + 9
         if today.month > 6:

--- a/conventions/forms/convention_form_financement.py
+++ b/conventions/forms/convention_form_financement.py
@@ -34,7 +34,7 @@ class ConventionFinancementForm(forms.Form):
         required=True,
         label="",
         coerce=int,
-        choices=[(str(year), str(year)) for year in range(2021, 2121)],
+        choices=[(str(year), str(year)) for year in range(2010, 2121)],
         error_messages={
             "required": "La date de fin de conventionnement est obligatoire",
         },
@@ -75,7 +75,9 @@ class ConventionFinancementForm(forms.Form):
           et finissant au 30 juin
         """
         today = datetime.date.today()
-
+        date_signature = self.convention.parent.televersement_convention_signee_le
+        if date_signature:
+            today = date_signature
         min_years = today.year + 15
         max_years = today.year + 40
         if today.month > 6:
@@ -105,6 +107,9 @@ class ConventionFinancementForm(forms.Form):
           et finissant au 30 juin
         """
         today = datetime.date.today()
+        date_signature = self.convention.parent.televersement_convention_signee_le
+        if date_signature:
+            today = date_signature
 
         min_years = today.year + 9
         if today.month > 6:
@@ -206,8 +211,8 @@ class PretForm(forms.Form):
     def clean(self):
         """
         Validations:
-          - si le prêteur est CDCF ou CDCL, alors le numéro, la date d'octroi et la durée sont obligatoires
-          - si le prêteur est autre, alors le champ autre est obligatoire
+          - si le prêteur est CDCF ou CDCL, numéro,date d'octroi et durée sont obligatoires
+          - si le prêteur est autre, le champ autre est obligatoire
         """
         cleaned_data = super().clean()
         preteur = cleaned_data.get("preteur")
@@ -250,7 +255,8 @@ class BasePretFormSet(BaseFormSet):
 
     def manage_cdc_validation(self):
         """
-        Validation : Hors convention PLS et Sans Travaux, au moins un prêt CDCF ou CDCL doit-être déclaré
+        Validation : Hors convention PLS et Sans Travaux,
+        au moins un prêt CDCF ou CDCL doit-être déclaré
         """
         if (
             self.convention is not None

--- a/conventions/forms/convention_form_financement.py
+++ b/conventions/forms/convention_form_financement.py
@@ -30,11 +30,10 @@ class ConventionFinancementForm(forms.Form):
         required=False,
         label="Prêts et financements",
     )
-    annee_fin_conventionnement = forms.TypedChoiceField(
+    annee_fin_conventionnement = forms.IntegerField(
         required=True,
         label="",
-        coerce=int,
-        choices=[(str(year), str(year)) for year in range(2010, 2121)],
+        initial=datetime.date.today().year,
         error_messages={
             "required": "La date de fin de conventionnement est obligatoire",
         },
@@ -70,7 +69,7 @@ class ConventionFinancementForm(forms.Form):
 
     def _pls_end_date_validation(self, annee_fin_conventionnement):
         """
-        Validation: date de fin de conventionnement pour un PLS
+        Validation : date de fin de conventionnement pour un PLS
           entre 15 et 40 ans après la date de début de conventionnement (date courante)
           et finissant au 30 juin
         """

--- a/templates/conventions/financement.html
+++ b/templates/conventions/financement.html
@@ -125,9 +125,9 @@
                                                 <div class="fr-text--xs">
                                                     <div>
                                                         {% if convention.financement == 'PLS' %}
-                                                            La convention bénéficie d'un finncement PLS, la durée de conventionnement doit-être comprise entre 15 et 40 ans<br>
+                                                            La convention bénéficie d'un financement PLS, la durée de conventionnement doit être comprise entre 15 et 40 ans.<br>
                                                         {% elif convention.financement == 'SANS_FINANCEMENT' %}
-                                                            La conventionne bénéficie pas de financement, la durée de convnetionnement doit-être supérieur à 9 ans.
+                                                            La convention ne bénéficie pas de financement, la durée de conventionnement doit-être supérieur à 9 ans.
                                                         {% else %}
                                                             Année de signature de la convention + au moins la durée du prêt le plus long. <br>
                                                             Elle ne peut être inférieure à 9 ans.

--- a/templates/conventions/financement.html
+++ b/templates/conventions/financement.html
@@ -127,7 +127,7 @@
                                                         {% if convention.financement == 'PLS' %}
                                                             La convention bénéficie d'un financement PLS, la durée de conventionnement doit être comprise entre 15 et 40 ans.<br>
                                                         {% elif convention.financement == 'SANS_FINANCEMENT' %}
-                                                            La convention ne bénéficie pas de financement, la durée de conventionnement doit-être supérieur à 9 ans.
+                                                            La convention ne bénéficie pas de financement, la durée de conventionnement doit être supérieure à 9 ans.
                                                         {% else %}
                                                             Année de signature de la convention + au moins la durée du prêt le plus long. <br>
                                                             Elle ne peut être inférieure à 9 ans.

--- a/templates/conventions/financement.html
+++ b/templates/conventions/financement.html
@@ -149,7 +149,7 @@
                                                     {% endif %}
                                                 </div>
                                                 <div class="block--row-strech-1">
-                                                    {% include "common/form/input_select.html" with form_input=form.annee_fin_conventionnement object_field="convention__annee_fin_conventionnement__"|add:form.uuid.value %}
+                                                    {% include "common/form/input_number.html" with form_input=form.annee_fin_conventionnement object_field="convention__annee_fin_conventionnement__"|add:form.uuid.value %}
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
se baser sur la date de signature de la convention original pour les avenants (dans les cas de PLS et sans travaux) 
+ correction de quelques coquilles