### PR TITLE
S868: Erreur lors de l'accès à la configuration des utilisateurs

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -142,7 +142,10 @@ class User(AbstractUser):
             raise PermissionDenied
 
     def is_bailleur(self, bailleur_id=None):
-        if self.is_cerbere_user():
+        # Si l'utilisateur a un login Cerbere et le champs siap_habilitation est
+        # proprement initialisé (i.e. dans un contexte web connecté de cet
+        # utilisateur avec session)
+        if self.is_cerbere_user() and self.siap_habilitation:
             return "currently" in self.siap_habilitation and self.siap_habilitation[
                 "currently"
             ] in [GroupProfile.SIAP_MO_PERS_MORALE, GroupProfile.SIAP_MO_PERS_PHYS]
@@ -304,7 +307,7 @@ class User(AbstractUser):
         )
 
     def _bailleur_ids(self) -> list:
-        if self.is_cerbere_user():
+        if self.is_cerbere_user() and self.siap_habilitation:
             return [self.siap_habilitation["bailleur"]["id"]]
 
         bailleur_ids = list(


### PR DESCRIPTION
# S868: Erreur lors de l'accès à la configuration des utilisateurs

Cette [erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/32574/events/caab4429051c44f5b5e003bb0b2df2cb/): quand un utilisateur _bailleur_ est connecté sur Apilos normal mais a un utilisateur _bailleur Cerbère_ cette erreur est jetée.

En réalité on se base sur le contexte SIAP pour un utilisateur Cerbère alors que ce n'est pas cette personne qui est connectée ... et donc le champs `siap_habilitation` n'est pas initialisé :/