### PR TITLE
add new input_files template

### DIFF
--- a/conventions/forms/avenant.py
+++ b/conventions/forms/avenant.py
@@ -66,7 +66,8 @@ class CompleteforavenantForm(forms.Form):
         required=True,
     )
     nom_fichier_signe = forms.FileField(
-        required=False,
+        label="Déposer la convention initiale (en PDF)",
+        required=True,
     )
 
 

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -358,7 +358,7 @@ def send_email_correction(
 
 def convention_validate(request: HttpRequest, convention: Convention):
     convention_number_form = ConventionNumberForm(request.POST)
-    complete_for_avenant_form = CompleteforavenantForm(request.POST)
+    complete_for_avenant_form = CompleteforavenantForm(request.POST, request.FILES)
     is_completeform = request.POST.get("completeform", False)
     if is_completeform:
         if complete_for_avenant_form.is_valid():

--- a/templates/common/form/input_files.html
+++ b/templates/common/form/input_files.html
@@ -6,7 +6,13 @@
         {% include "common/form/required_field.html" with form_input=form_input %}
         <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
     </label>
-    <input class="fr-upload fr-mt-0 {% if form_input.errors %}fr-input--error{% endif %}" type="file" id="file-upload" name="{{form_input.html_name}}">
+    <input
+        class="fr-upload fr-mt-0 {% if form_input.errors %}fr-input--error{% endif %}"
+        type="file"
+        id="file-upload"
+        name="{{form_input.html_name}}"
+        accept="application/pdf"
+    >
     {% for error in form_input.errors %}
         <p id="text-input-error-desc-error" class="fr-error-text">
             {{ error }}

--- a/templates/common/form/input_files.html
+++ b/templates/common/form/input_files.html
@@ -1,0 +1,15 @@
+{% load static %}
+
+{% load custom_filters %}
+<div class="fr-upload-group {% if form_input.errors %}fr-select-group--error{% endif %}" id="{{form_input.id_for_label}}_group">
+    <label class="fr-label" for="file-upload">{{ form_input.label }}
+        {% include "common/form/required_field.html" with form_input=form_input %}
+        <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
+    </label>
+    <input class="fr-upload fr-mt-0 {% if form_input.errors %}fr-input--error{% endif %}" type="file" id="file-upload" name="{{form_input.html_name}}">
+    {% for error in form_input.errors %}
+        <p id="text-input-error-desc-error" class="fr-error-text">
+            {{ error }}
+        </p>
+    {% endfor %}
+</div>

--- a/templates/conventions/avenant/complete_form_for_avenants.html
+++ b/templates/conventions/avenant/complete_form_for_avenants.html
@@ -14,13 +14,9 @@
                 </div>
                 {% if not convention.parent.nom_fichier_signe %}
                     <div class="fr-col-12">
-                        <div class="fr-upload-group">
-                            <label class="fr-label" for="file-upload">Déposer la convention initiale (en PDF)
-                                <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
-                            </label>
-                            <input class="fr-upload fr-mt-0" type="file" id="file-upload" name="nom_fichier_signe">
-                        </div>
+                        {% include "common/form/input_files.html" with form_input=complete_for_avenant_form.nom_fichier_signe editable=True %}
                     </div>
+
                 {% endif %}
             </div>
             <button class="fr-btn fr-mt-2w">Envoyer</button>

--- a/templates/conventions/avenant/form_avenants_for_avenant.html
+++ b/templates/conventions/avenant/form_avenants_for_avenant.html
@@ -21,7 +21,14 @@
                         <label class="fr-label" for="file-upload">Déposer l'avenant (en PDF) {% include "common/form/required_field_star.html" %}
                             <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
                         </label>
-                        <input class="fr-upload" type="file" id="file-upload" name="nom_fichier_signe" required>
+                        <input
+                            class="fr-upload"
+                            type="file"
+                            id="file-upload"
+                            name="nom_fichier_signe"
+                            required
+                            accept="application/pdf"
+                        >
                     </div>
                     <button class="fr-btn fr-btn--secondary fr-mt-3w">Créer l'avenant</button>
                 </form>

--- a/templates/conventions/avenant/new_convention_for_avenant.html
+++ b/templates/conventions/avenant/new_convention_for_avenant.html
@@ -62,7 +62,13 @@
             <label class="fr-label" for="file-upload">Déposer la convention (en PDF)
                 <span class="fr-hint-text">Taille maximale : 500 Mo. Formats supportés : pdf</span>
             </label>
-            <input class="fr-upload" type="file" id="file-upload" name="nom_fichier_signe">
+            <input
+                class="fr-upload"
+                type="file"
+                id="file-upload"
+                name="nom_fichier_signe"
+                accept="application/pdf"
+            >
         </div>
         <div class="fr-col-12 fr-mb-2w">
             {% include "common/form/input_text.html" with form_input=form.numero_avenant mandatory_input=True %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19302155/236251684-566f1d37-5527-464d-8f48-b03adfedf559.png)
Suite à la remarque de Nico : "quand on valide un avenant sans mettre en pièce jointe la convention originale, la validation n'est pas effective et l'utilisateur n'est pas prévenu." => en réalité, on ne valide pas l'avenant mais on envoie un fichier (sauf qu'on envoie rien). Il manque donc une gestion d'erreur sur l'envoi du fichier.

Pour rester cohérente avec le reste du code, j'ai créé un template d'input de type upload simple (celui qui existait déjà impliquait un text area).