### PR TITLE
fix issue related to habilitation dropdown icon

### DIFF
--- a/static/css/ui_siap.css
+++ b/static/css/ui_siap.css
@@ -16,6 +16,9 @@
   color: #fff;
   text-decoration: none;
 }
+.fr-nav__btn[aria-current].orange-background::after {
+  margin-left: auto;
+}
 
 .habilitation-bloc .fr-btn {
   display: block;


### PR DESCRIPTION
Minifix affichage de l'icone du dropdown des habilitation qui n'était pas toujours collé à droite.

maintenant c'est ok:

![image](https://user-images.githubusercontent.com/454431/236273985-6f2085b5-2fb0-4e46-8f49-9e23081e790a.png)
