### PR TITLE
S867: Erreur de doublon possible sur une programme par numéro Galion

### DIFF
--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -162,31 +162,38 @@ def get_or_create_programme(
     (adresse, code_postal, ville) = _get_address_from_locdata(
         programme_from_siap["donneesLocalisation"]
     )
-    (programme, _) = Programme.objects.get_or_create(
+
+    programme = Programme.objects.filter(
         numero_galion=programme_from_siap["donneesOperation"]["numeroOperation"],
         bailleur=bailleur,
         administration=administration,
         parent=None,
-        defaults={
-            "nom": programme_from_siap["donneesOperation"]["nomOperation"],
-            "adresse": adresse,
-            "code_postal": code_postal,
-            "ville": ville,
-            "code_insee_commune": programme_from_siap["donneesLocalisation"]["commune"][
+    ).first()
+
+    if programme is None:
+        programme = Programme.objects.create(
+            numero_galion=programme_from_siap["donneesOperation"]["numeroOperation"],
+            bailleur=bailleur,
+            administration=administration,
+            parent=None,
+            nom=programme_from_siap["donneesOperation"]["nomOperation"],
+            adresse=adresse,
+            code_postal=code_postal,
+            ville=ville,
+            code_insee_commune=programme_from_siap["donneesLocalisation"]["commune"][
                 "codeInsee"
             ],
-            "code_insee_departement": programme_from_siap["donneesLocalisation"][
+            code_insee_departement=programme_from_siap["donneesLocalisation"][
                 "departement"
             ]["codeInsee"],
-            "code_insee_region": programme_from_siap["donneesLocalisation"]["region"][
+            code_insee_region=programme_from_siap["donneesLocalisation"]["region"][
                 "codeInsee"
             ],
-            "zone_abc": programme_from_siap["donneesLocalisation"]["zonage123"],
-            "zone_123": programme_from_siap["donneesLocalisation"]["zonageABC"],
-            "type_operation": type_operation,
-            "nature_logement": nature_logement,
-        },
-    )
+            zone_abc=programme_from_siap["donneesLocalisation"]["zonage123"],
+            zone_123=programme_from_siap["donneesLocalisation"]["zonageABC"],
+            type_operation=type_operation,
+            nature_logement=nature_logement,
+        )
     # force type opération = sans travaux
     if (
         type_operation == TypeOperation.SANSTRAVAUX


### PR DESCRIPTION
# S867: Erreur de doublon possible sur une programme par numéro Galion

À l'origine [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/36395/?project=29). Lors de la création d'une convention depuis un financement SIAP, on chercher _naïvement_ un programme par son numéro Galion, or celui-ci n'est pas unique.

J'ai donc sécurisé la manoeuvre en prenant le premier programme qui venait ou, à défaut, je le crée. Je pense qu'on pourrait faire mieux mais je n'arrive à comprendre comment on parvient à extraire les données (je vois des `detailsOperation` dans les données Sentry et `donneesOperation` dans le code ...) et malheureusement je ne peux jouer ce bout de code (même dans le shell avec le même contexte j'obtiens `Exception: user doesn't have enough rights to display operation <Response [500]>`) 