### PR TITLE
disallow submit when no numero_galion

### DIFF
--- a/conventions/tests/services/test_recapitulatif_service.py
+++ b/conventions/tests/services/test_recapitulatif_service.py
@@ -1,11 +1,10 @@
 from django.http import HttpRequest
 from django.test import TestCase
+
 from conventions.forms.convention_number import ConventionNumberForm
 from conventions.forms.programme_number import ProgrammeNumberForm
 from conventions.models import Convention
-from conventions.services import (
-    recapitulatif,
-)
+from conventions.services import recapitulatif
 from users.models import User
 
 
@@ -44,7 +43,6 @@ class ConventionRecapitulatifServiceTests(TestCase):
         )
 
     def test_update_programme_number_success(self):
-
         self.service.request.POST = {
             "numero_galion": "0" * 255,
             "update_programme_number": "1",
@@ -54,7 +52,6 @@ class ConventionRecapitulatifServiceTests(TestCase):
         self.assertEqual(self.convention.programme.numero_galion, "0" * 255)
 
     def test_update_programme_number_failed(self):
-
         self.service.request.POST = {
             "numero_galion": "0" * 256,
             "update_programme_number": "1",
@@ -62,3 +59,51 @@ class ConventionRecapitulatifServiceTests(TestCase):
         result = self.service.update_programme_number()
 
         self.assertFalse(result["conventionNumberForm"].has_error("numero_galion"))
+
+
+class AvenantRecapitulatifServiceTests(TestCase):
+    fixtures = [
+        "auth.json",
+        "avenant_types.json",
+        "bailleurs_for_tests.json",
+        "instructeurs_for_tests.json",
+        "programmes_for_tests.json",
+        "conventions_for_tests.json",
+        "users_for_tests.json",
+    ]
+
+    def setUp(self):
+        request = HttpRequest()
+
+        request.user = User.objects.get(username="fix")
+        self.convention1 = Convention.objects.get(numero="0001")
+        # set service with avenant
+        self.avenant1 = self.convention1.clone(
+            request.user, convention_origin=self.convention1
+        )
+        self.service = recapitulatif.ConventionRecapitulatifService(
+            convention=self.avenant1, request=request
+        )
+
+    def test_update_avenant_number_success(self):
+        self.service.request.POST = {
+            "numero_galion": "a" * 255,
+            "update_programme_number": "1",
+        }
+        self.service.update_programme_number()
+        self.convention1.refresh_from_db()
+
+        self.assertEqual(self.avenant1.programme.numero_galion, "a" * 255)
+        self.assertEqual(self.convention1.programme.numero_galion, "a" * 255)
+
+    def test_update_convention_number_success(self):
+        self.service.convention = self.convention1
+        self.service.request.POST = {
+            "numero_galion": "b" * 255,
+            "update_programme_number": "1",
+        }
+        self.service.update_programme_number()
+        self.avenant1.refresh_from_db()
+
+        self.assertEqual(self.convention1.programme.numero_galion, "b" * 255)
+        self.assertEqual(self.avenant1.programme.numero_galion, "b" * 255)

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -239,13 +239,16 @@ def save_convention(request, convention_uuid):
     convention = Convention.objects.get(uuid=convention_uuid)
     request.user.check_perm("convention.change_convention", convention)
     result = convention_submit(request, convention)
-    if result["success"] == ReturnStatus.SUCCESS:
+    if result["success"] in [ReturnStatus.SUCCESS, ReturnStatus.WARNING]:
+        result.update(
+            {"siap_operation_not_found": result["success"] == ReturnStatus.WARNING}
+        )
         return render(
             request,
             "conventions/submitted.html",
             result,
         )
-    if result["success"] == ReturnStatus.WARNING:
+    if result["success"] == ReturnStatus.REFRESH:
         return render(
             request,
             "conventions/saved.html",

--- a/core/exceptions/types.py
+++ b/core/exceptions/types.py
@@ -1,3 +1,7 @@
+class SIAPException(Exception):
+    pass
+
+
 class HabilitationSIAPException(Exception):
     pass
 

--- a/programmes/api/tests/test_apis.py
+++ b/programmes/api/tests/test_apis.py
@@ -1,9 +1,8 @@
 from operator import itemgetter
 
 from django.conf import settings
-
 from rest_framework import status
-from rest_framework.test import APITestCase, APIClient
+from rest_framework.test import APIClient, APITestCase
 
 from conventions.models.choices import ConventionStatut
 from conventions.models.convention import Convention
@@ -12,7 +11,6 @@ from programmes.api.tests import fixtures
 from programmes.models import Programme
 from siap.siap_client.client import build_jwt
 from users.models import User
-
 
 operation_response = {
     **fixtures.programme2,

--- a/programmes/services.py
+++ b/programmes/services.py
@@ -3,6 +3,7 @@ from datetime import date
 
 from django.db.models import Q
 
+from core.exceptions.types import SIAPException
 from programmes.models import IndiceEvolutionLoyer, NatureLogement
 from siap.siap_client.client import SIAPClient
 from siap.siap_client.utils import get_or_create_conventions
@@ -10,11 +11,15 @@ from siap.siap_client.utils import get_or_create_conventions
 
 def get_or_create_conventions_from_operation_number(request, numero_operation):
     client = SIAPClient.get_instance()
-    operation = client.get_operation(
-        user_login=request.user.cerbere_login,
-        habilitation_id=request.session["habilitation_id"],
-        operation_identifier=numero_operation,
-    )
+    try:
+        operation = client.get_operation(
+            user_login=request.user.cerbere_login,
+            habilitation_id=request.session["habilitation_id"],
+            operation_identifier=numero_operation,
+        )
+    except SIAPException:
+        # impossible to get operation from SIAP
+        return (None, None, None)
     return get_or_create_conventions(operation, request.user)
 
 

--- a/programmes/views.py
+++ b/programmes/views.py
@@ -7,7 +7,6 @@ from programmes.services import get_or_create_conventions_from_operation_number
 
 @login_required
 def operation_conventions(request, numero_operation):
-
     # Décorator ?
     if not request.user.is_cerbere_user():
         raise PermissionError("this function is available only for CERBERE user")
@@ -33,7 +32,6 @@ def operation_conventions(request, numero_operation):
         {
             "numero_operation": numero_operation,
             "programme": programme,
-            #            "lots": lots,
             "conventions": service,
         },
     )

--- a/siap/siap_client/client.py
+++ b/siap/siap_client/client.py
@@ -1,20 +1,20 @@
-from datetime import datetime, timedelta
 import logging
-import uuid
 import threading
-import requests
-import jwt
+import uuid
+from datetime import datetime, timedelta
 
+import jwt
+import requests
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from tenacity import retry, stop_after_attempt, retry_if_exception_type
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 from core.exceptions.types import (
+    SIAPException,
     TimeoutSIAPException,
     UnauthorizedSIAPException,
     UnavailableServiceSIAPException,
 )
-
 from siap.siap_client.mock_data import (
     config_mock,
     habilitations_mock,
@@ -91,7 +91,6 @@ def _call_siap_api(
 
 
 class SIAPClient:
-
     __singleton_lock = threading.Lock()
     __singleton_instance = None
     __should_update_at = datetime.now() + timedelta(minutes=REFRESH_SIAP_CONFIG)
@@ -99,7 +98,6 @@ class SIAPClient:
     # define the classmethod
     @classmethod
     def get_instance(cls):
-
         # check for the singleton instance
         if not cls.__singleton_instance:
             with cls.__singleton_lock:
@@ -217,7 +215,7 @@ class SIAPClientRemote(SIAPClientInterface):
         )
         if response.status_code >= 200 and response.status_code < 300:
             return response.json()
-        raise Exception(
+        raise SIAPException(
             f"user doesn't have enough rights to display operation {response}"
         )
 

--- a/templates/conventions/actions/edit_numero_galion.html
+++ b/templates/conventions/actions/edit_numero_galion.html
@@ -1,0 +1,46 @@
+<button class="fr-link fr-text--xs" data-fr-opened="false" type="button" aria-controls="fr-modal-update-programme-number">
+    editer le numéro de décision
+</button>
+
+{% if programmeNumberForm.errors %}
+    <input data-fr-opened="true" aria-controls="fr-modal-update-programme-number" type="hidden">
+{% endif %}
+
+<dialog aria-labelledby="fr-modal-update-programme-number-title" id="fr-modal-update-programme-number" data-fr-opened="true" class="fr-modal" role="dialog" open="true">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-link--close fr-link" type="button" aria-controls="fr-modal-update-programme-number">Fermer</button>
+                    </div>
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="fr-modal__content">
+                            <div role="alert" class="fr-alert fr-alert--warning">
+                                <p class="fr-alert__title">Modifier le numéro de décision</p>
+                                <p>la modification de ce numéro de décision peut avoir des conséquences sur le lien avec les dossiers de financement</p>
+                            </div>
+                            {% include "common/form/input_text.html" with form_input=programmeNumberForm.numero_galion editable=True%}
+
+                        </div>
+                        <div class="fr-modal__footer">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-update-programme-number">
+                                        Annuler
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-icon-checkbox-line" name='update_programme_number' value=1>
+                                        Changer le numéro de décision
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/conventions/actions/submit_convention.html
+++ b/templates/conventions/actions/submit_convention.html
@@ -12,14 +12,23 @@
             <p>
                 Si vous avez encore des modifications à apporter au projet {% if convention.is_avenant %}d'avenant{% else %}de convention{% endif %}, vous pouvez y revenir plus tard.
             </p>
-            <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
-                {% csrf_token %}
-                <button name="SubmitConvention" value=True class="fr-btn fr-my-3w">
-                    Soumettre au service instructeur
-                </button>
-            </form>
+            {% with numero_galion=convention.programme.numero_galion %}
+                {% if not numero_galion %}
+                    <div>
+                        <em>le numero d'opération n'est pas défini pour l'opération de cette convention. Merci de le renseigner avant de continuer</em>
+                    </div>
+                    {% include "conventions/actions/edit_numero_galion.html" %}
+                {% endif %}
+                <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
+                    {% csrf_token %}
+                    <button name="SubmitConvention" value=True class="fr-btn fr-my-3w" {% if not numero_galion %}disabled{% endif %}>
+                        Soumettre au service instructeur
+                    </button>
+                </form>
+            {% endwith %}
+
             <p class="fr-text--xs notes">
-                <em>Votre projet de convention est enregistré.Si vous le souhaitez, vous pouvez quitter cette page et y revenir plus tard.</em>
+                <em>Votre projet de convention est enregistré. Si vous le souhaitez, vous pouvez quitter cette page et y revenir plus tard.</em>
             </p>
         </div>
     </div>

--- a/templates/conventions/recapitulatif/operation.html
+++ b/templates/conventions/recapitulatif/operation.html
@@ -27,9 +27,7 @@
                                     <em>Numéro de décision : non renseigné</em>
                                 {% endif %}
                             </p>
-                            <button class="fr-link fr-text--xs" data-fr-opened="false" type="button" aria-controls="fr-modal-update-programme-number">
-                                editer le numéro de décision
-                            </button>
+                            {% include "conventions/actions/edit_numero_galion.html" %}
                         {% else %}
                             {% include "common/display_field_if_exists.html" with label="Numéro de décision" value=programme.numero_galion %}
                         {% endif %}
@@ -104,50 +102,4 @@
             </div>
         </div>
     </div>
-
-
-    {% if programmeNumberForm.errors %}
-        <input data-fr-opened="true" aria-controls="fr-modal-update-programme-number" type="hidden">
-    {% endif %}
-
-    <dialog aria-labelledby="fr-modal-update-programme-number-title" id="fr-modal-update-programme-number" data-fr-opened="true" class="fr-modal" role="dialog" open="true">
-        <div class="fr-container fr-container--fluid fr-container-md">
-            <div class="fr-grid-row fr-grid-row--center">
-                <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                    <div class="fr-modal__body">
-                        <div class="fr-modal__header">
-                            <button class="fr-link--close fr-link" type="button" aria-controls="fr-modal-update-programme-number">Fermer</button>
-                        </div>
-                        <form method="post">
-                            {% csrf_token %}
-                            <div class="fr-modal__content">
-                                <div role="alert" class="fr-alert fr-alert--warning">
-                                    <p class="fr-alert__title">Modifier le numéro de décision</p>
-                                    <p>la modification de ce numéro de décision peut avoir des conséquences sur le lien avec les dossiers de financement</p>
-                                </div>
-                                {% include "common/form/input_text.html" with form_input=programmeNumberForm.numero_galion editable=True%}
-
-                            </div>
-                            <div class="fr-modal__footer">
-                                <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                    <li>
-                                        <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-update-programme-number">
-                                            Annuler
-                                        </button>
-                                    </li>
-                                    <li>
-                                        <button class="fr-btn fr-icon-checkbox-line" name='update_programme_number' value=1>
-                                            Changer le numéro de décision
-                                        </button>
-                                    </li>
-                                </ul>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </dialog>
-
-
 {% endif %}

--- a/templates/conventions/submitted.html
+++ b/templates/conventions/submitted.html
@@ -7,6 +7,15 @@
         {% include "conventions/common/form_header.html"%}
         <div class="fr-container">
             <div class="fr-grid-row fr-grid-row--gutters">
+
+                {% if siap_operation_not_found %}
+                    <div class="fr-col-md-12 fr-mb-5w fr-mt-3w">
+                        <div role="alert" class="fr-alert fr-alert--warning">
+                            <p class="fr-alert__title">L'operation numéro « {{convention.programme.numero_galion}} » n'est pas disponible sur l'espace de financement du SIAP</p>
+                        </div>
+                    </div>
+                {% endif %}
+
                 <div class="fr-col-md-12  fr-my-5w">
                     <h2>Félicitations</h2>
                     <h4 class="fr-mb-3w">Bravo, vous venez de soumettre votre {% if convention.is_avenant %}avenant de {% endif %}convention à l'instruction en date du {{convention.soumis_le}}</h4>

--- a/templates/operations/common/form_header.html
+++ b/templates/operations/common/form_header.html
@@ -7,10 +7,10 @@
                 {% if programme.numero_galion %}
                     Opération n°{{programme.numero_galion}}
                 {% endif %}
-                {% if request|is_instructeur %}
+                {% if request|is_instructeur and programme.bailleur %}
                     (Entreprise bailleur : {{ programme.bailleur }})
                 {% endif %}
-                {% if request|is_bailleur %}
+                {% if request|is_bailleur and programme.administration %}
                     (Service instructeur : {{ programme.administration }})
                 {% endif %}
             </div>

--- a/templates/operations/conventions.html
+++ b/templates/operations/conventions.html
@@ -14,6 +14,14 @@
     <div class="fr-container">
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-my-5w fr-table fr-table--bordered table--layout-fixed">
+                {% if programme is None %}
+                    <div class="fr-col-md-12 fr-mb-5w fr-mt-3w">
+                        <div role="alert" class="fr-alert fr-alert--warning">
+                            <p class="fr-alert__title">L'operation numéro « {{ numero_operation }} » n'est pas disponible sur l'espace de financement du SIAP</p>
+                        </div>
+                    </div>
+                {% endif %}
+
                 {% include "conventions/convention_list.html" with siap_operation=True %}
             </div>
         </div>


### PR DESCRIPTION
disable the submit if numro_galion is None
display link to updatethe numero_galion in such case
display warning when submit a convention with not found numero_galion in SIAP
display warning when display conventions of an operation which doesn't exists in SIAP

change the numero_galion for all convention and its avenant when change the numero galion of the convention or one of its avenant