### PR TITLE
Correctif des indices de loyer

### DIFF
--- a/ecoloweb/management/commands/ecoloweb_import_loyers_indices.py
+++ b/ecoloweb/management/commands/ecoloweb_import_loyers_indices.py
@@ -65,8 +65,14 @@ where coalesce(il.irl2evol, il.irl1evol, il.iccaugmentation) is not null
 select
     distinct on (ir.annee, ir.nature_logement)
     ir.annee,
-    make_date(ir.annee, 1, 1) as date_debut,
-    make_date(ir.annee, 12, 31) as date_fin,
+    case
+        when ir.annee > 2010 then make_date(ir.annee - 1, 1, 1)
+        else make_date(ir.annee - 1, 7, 1)
+    end as date_debut,
+    case
+        when ir.annee >= 2010 then make_date(ir.annee - 1, 12, 31)
+        else make_date(ir.annee, 6, 30)
+    end as date_fin,
     false as is_loyer,
     ir.nature_logement,
     ir.evolution

--- a/programmes/services.py
+++ b/programmes/services.py
@@ -47,9 +47,6 @@ class LoyerRedevanceUpdateComputer:
                 |
                 # Soit la date initiale est située sur la période
                 Q(date_debut__lte=date_initiale, date_fin__gte=date_initiale)
-                |
-                # Soit la date d'actualisation est située sur la période
-                Q(date_debut__lte=date_actualisation, date_fin__gte=date_actualisation)
             )
             .order_by("date_debut")
         )

--- a/programmes/tests/test_services.py
+++ b/programmes/tests/test_services.py
@@ -155,7 +155,7 @@ class LoyerRedevanceUpdateComputerTest(TestCase):
             date_initiale=date.fromisoformat("2013-07-12"),
             date_actualisation=date.fromisoformat("2014-03-18"),
         )
-        self.assertAlmostEqual(400 * 1.012 * 1.0057, update, places=2)
+        self.assertAlmostEqual(400 * 1.012, update, places=2)
 
         update = LoyerRedevanceUpdateComputer.compute_loyer_update(
             montant_initial=100,
@@ -180,7 +180,7 @@ class LoyerRedevanceUpdateComputerTest(TestCase):
             date_initiale=date.fromisoformat("2013-07-12"),
             date_actualisation=date.fromisoformat("2014-03-18"),
         )
-        self.assertAlmostEqual(400 * 1.012 * 1.0057, update, places=2)
+        self.assertAlmostEqual(400 * 1.012, update, places=2)
 
         update = LoyerRedevanceUpdateComputer.compute_loyer_update(
             montant_initial=100,
@@ -204,7 +204,7 @@ class LoyerRedevanceUpdateComputerTest(TestCase):
             date_initiale=date.fromisoformat("2013-07-12"),
             date_actualisation=date.fromisoformat("2014-03-18"),
         )
-        self.assertAlmostEqual(400 * 1.012 * 1.0057, update, places=2)
+        self.assertAlmostEqual(400 * 1.012, update, places=2)
 
         update = LoyerRedevanceUpdateComputer.compute_loyer_update(
             montant_initial=100,


### PR DESCRIPTION
# Correctif des indices de loyer

Suite au retour de Sabine, j'ai observé que lorsque la date de fin n'était pas la date du jour, Apilos intégrait toujours une année de trop (la valeur obtenue était celle calculée par Ecolo à date N-1).

J'ai donc simplement adapté la logique d'extraction des évolutions successives sur la périodes pour retirer le dernier indice (== "pas applicable si seule la date de mise à jour est incluse sur la période"). 

J'en profite pour en corriger un autre: les indices de loyer des résidences et foyers suivent les mêmes périodes applicables que les logements ordinaires (1 juil -> 30 juin puis 1er janv -> 31 déc à partir de 2008).

Lors du déploiement:
* `truncate programmes_indiceevolutionloyer`
* relancer `./managae.py ecoloweb_import_loyer_indices`