### PR TITLE
Handle specific error for bailleur privé

### DIFF
--- a/core/exceptions/handler.py
+++ b/core/exceptions/handler.py
@@ -34,8 +34,6 @@ def handle_error_500(request):
                 },
                 status=500,
             )
-        print(exception_type)
-        print(exception_type == NotHandledBailleurPriveSIAPException)
         if exception_type == NotHandledBailleurPriveSIAPException:
             return render(
                 request,

--- a/core/exceptions/handler.py
+++ b/core/exceptions/handler.py
@@ -1,15 +1,16 @@
 import sys
-from django.http import JsonResponse
 
+from django.http import JsonResponse
 from django.shortcuts import render
 
 from core.exceptions.types import (
+    AssociationHLMSIAPException,
+    HabilitationSIAPException,
+    InconsistentDataSIAPException,
+    NotHandledBailleurPriveSIAPException,
     TimeoutSIAPException,
     UnauthorizedSIAPException,
     UnavailableServiceSIAPException,
-    AssociationHLMSIAPException,
-    InconsistentDataSIAPException,
-    HabilitationSIAPException,
 )
 
 
@@ -23,6 +24,7 @@ def handle_error_500(request):
         AssociationHLMSIAPException,
         InconsistentDataSIAPException,
         HabilitationSIAPException,
+        NotHandledBailleurPriveSIAPException,
     ]:
         if request.path.startswith("/api-siap"):
             return JsonResponse(
@@ -32,17 +34,23 @@ def handle_error_500(request):
                 },
                 status=500,
             )
+        print(exception_type)
+        print(exception_type == NotHandledBailleurPriveSIAPException)
+        if exception_type == NotHandledBailleurPriveSIAPException:
+            return render(
+                request,
+                "500.html",
+                {
+                    "specific_error": "not_handled_bailleur_prive",
+                },
+                status=500,
+            )
         if exception_type == AssociationHLMSIAPException:
             return render(
                 request,
                 "500.html",
                 {
-                    "specific_error": """
-                        <p class="fr-mb-3w">
-                            Le module de conventionnement n'est pas accessible avec
-                              l'habilitation « Association HLM ».
-                        </p>
-                    """,
+                    "specific_error": "not_handled_association_hlm",
                 },
                 status=500,
             )

--- a/core/exceptions/types.py
+++ b/core/exceptions/types.py
@@ -24,3 +24,7 @@ class UnavailableServiceSIAPException(Exception):
 
 class InconsistentDataSIAPException(Exception):
     pass
+
+
+class NotHandledBailleurPriveSIAPException(Exception):
+    pass

--- a/siap/siap_client/client.py
+++ b/siap/siap_client/client.py
@@ -50,7 +50,11 @@ def build_jwt(user_login: str = "", habilitation_id: int = 0) -> str:
     )
 
 
-@retry(retry=retry_if_exception_type(TimeoutSIAPException), stop=stop_after_attempt(3))
+@retry(
+    retry=retry_if_exception_type(TimeoutSIAPException),
+    stop=stop_after_attempt(3),
+    reraise=True,
+)
 def _call_siap_api(
     route: str,
     base_route: str = "",

--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -3,7 +3,10 @@ from typing import Tuple
 
 from bailleurs.models import Bailleur, NatureBailleur
 from conventions.models import Convention
-from core.exceptions.types import InconsistentDataSIAPException
+from core.exceptions.types import (
+    InconsistentDataSIAPException,
+    NotHandledBailleurPriveSIAPException,
+)
 from instructeurs.models import Administration
 from programmes.models import (
     Financement,
@@ -77,6 +80,13 @@ def get_or_create_bailleur(bailleur_from_siap: dict):
         if "siren" in bailleur_from_siap
         else None
     ):
+        if bailleur_from_siap["codeFamilleMO"] in [
+            "Bailleurs privés",
+            NatureBailleur.PRIVES,
+        ]:
+            raise NotHandledBailleurPriveSIAPException(
+                "The « Bailleur privée » type of bailleur is not handled yet"
+            )
         raise InconsistentDataSIAPException(
             "Missing Bailleur siren (can't be empty or null), bailleur can't be get or created"
         )

--- a/templates/500.html
+++ b/templates/500.html
@@ -12,7 +12,7 @@
                             Nos équipes techniques travaillent actuellement à la mise en place de cette fonctionnalité.
                         </p>
                         <p class="fr-mb-3w">
-                            Nous vous prions de nous excuser pour la gène occasionnée. Si votre besoin est urgent, merci decontacter notre assistance à l'adresse suivante : <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">contact@apilos.beta.gouv.fr</a>.
+                            Nous vous prions de nous excuser pour la gène occasionnée. Si votre besoin est urgent, merci de contacter notre assistance à l'adresse suivante : <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">contact@apilos.beta.gouv.fr</a>.
                         </p>
                     {% elif specific_error == 'not_handled_association_hlm' %}
                         <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Votre habilitation n'est pas prise en charge par le module conventionnement du SIAP (APiLos).</h2>

--- a/templates/500.html
+++ b/templates/500.html
@@ -4,17 +4,33 @@
         <div class="fr-container">
             <div class="fr-grid-row fr-grid-row--gutters">
                 <div class="fr-col-lg-11 fr-col-offset-lg-1 fr-mb-2w">
-                    <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Erreur serveur</h2>
-                    <p class="fr-mb-3w">
-                        Une erreur est survenue. Nous vous prions de nous excuser.
-                    </p>
-                    {{ specific_error|safe }}
+
+                    {% if specific_error == 'not_handled_bailleur_prive' %}
+                        <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Cet fonctionnalité n'est pas encore prise en charge par la plateforme SIAP-APiLos</h2>
+                        <p class="fr-mb-3w">
+                            Le conventionnement des opérations portées par des bailleurs privés (personnes physiques sans SIREN) n'est pas pris en charge actuellement par la plateforme SIAP-APiLos.<br>
+                            Nos équipes techniques travaillent actuellement à la mise en place de cette fonctionnalité.
+                        </p>
+                        <p class="fr-mb-3w">
+                            Nous vous prions de nous excuser pour la gène occasionnée. Si votre besoin est urgent, merci decontacter notre assistance à l'adresse suivante : <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">contact@apilos.beta.gouv.fr</a>.
+                        </p>
+                    {% elif specific_error == 'not_handled_association_hlm' %}
+                        <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Votre habilitation n'est pas prise en charge par le module conventionnement du SIAP (APiLos).</h2>
+                        <p class="fr-mb-3w">
+                            Le module de conventionnement n'est pas accessible avec l'habilitation « Association HLM ».
+                        </p>
+                    {% else %}
+                        <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Erreur serveur</h2>
+                        <p class="fr-mb-3w">
+                            Une erreur est survenue. Nous vous prions de nous excuser.
+                        </p>
+                        <p class="fr-mb-3w">
+                            Si le problème persiste merci de contacter l'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a>
+                        </p>
+                    {% endif %}
                     {% if CERBERE_AUTH %}
                         <a class="fr-btn fr-btn--secondary fr-mb-3w" value="Retour à l'accueil" href="{{SIAP_CLIENT_HOST}}/tableau-bord">Retourner au tableau de bord</a>
                     {% endif %}
-                    <p class="fr-mb-3w">
-                        Si le problème persiste merci de contacter l'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a>
-                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Manage specific error `NotHandledBailleurPriveSIAPException` to display specific error and reduce email to support
reraise error when retry, avoid RetryError in Sentry