### PR TITLE
Mise en place du mode expert

### DIFF
--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -226,4 +226,9 @@ urlpatterns = [
         views.form_avenants_for_avenant,
         name="form_avenants_for_avenant",
     ),
+    path(
+        "expert_mode/<convention_uuid>",
+        views.expert_mode,
+        name="expert_mode",
+    ),
 ]

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -613,3 +613,16 @@ def piece_jointe_promote(request, piece_jointe_uuid):
     return HttpResponseRedirect(
         reverse("conventions:preview", args=[piece_jointe.convention.uuid])
     )
+
+
+@login_required
+@permission_required("convention.add_convention")
+def expert_mode(request, convention_uuid):
+    if request.user.is_instructeur():
+        if request.session["is_expert"] is True:
+            request.session["is_expert"] = False
+        else:
+            request.session["is_expert"] = True
+    return HttpResponseRedirect(
+        reverse("conventions:recapitulatif", args=[convention_uuid])
+    )

--- a/templates/comments/opened_comments.html
+++ b/templates/comments/opened_comments.html
@@ -1,49 +1,51 @@
 {% load custom_filters %}
 
-{% if convention|display_comments_summary and opened_comments.count %}
-    <div role="alert" class="fr-alert fr-alert--info fr-my-3w">
-        <div class="block--row-strech" id="{{object_field}}_div">
-            <div class="block--row-strech-1">
-                <p class="fr-alert__title">
-                    {{opened_comments.count}} Commentaire{{ opened_comments|pluralize }} Ouvert{{ opened_comments|pluralize }} (Non-résolu{{ opened_comments|pluralize }})
-                </p>
+{% if convention|display_comments_summary %}
+    {% if opened_comments.count %}
+        <div role="alert" class="fr-alert fr-alert--info fr-my-3w">
+            <div class="block--row-strech" id="{{object_field}}_div">
+                <div class="block--row-strech-1">
+                    <p class="fr-alert__title">
+                        {{opened_comments.count}} Commentaire{{ opened_comments|pluralize }} Ouvert{{ opened_comments|pluralize }} (Non-résolu{{ opened_comments|pluralize }})
+                    </p>
+                </div>
+                <a class="fr-link fr-mb-1w" href='{% url "conventions:recapitulatif" convention_uuid=convention.uuid %}' id="refresh_opened_comments">
+                    <span class="fr-icon-refresh-line" aria-hidden="true">Rafraichir</span>
+                </a>
             </div>
-            <a class="fr-link fr-mb-1w" href='{% url "conventions:recapitulatif" convention_uuid=convention.uuid %}' id="refresh_opened_comments">
-                <span class="fr-icon-refresh-line" aria-hidden="true">Rafraichir</span>
-            </a>
-        </div>
 
-        <div class="fr-table  fr-table--bordered table--layout-fixed table--limited-height fr-table--no-caption">
-            <table>
-                <caption>Commentaires ouverts liés à la convention</caption>
-                <thead>
-                    <tr>
-                        <th scope="col" class="col__width--150">Élements de la convention commentés </th>
-                        <th scope="col">Message</th>
-                        <th scope="col" class="col__width--150">Créé le</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for opened_comment in opened_comments %}
+            <div class="fr-table  fr-table--bordered table--layout-fixed table--limited-height fr-table--no-caption">
+                <table>
+                    <caption>Commentaires ouverts liés à la convention</caption>
+                    <thead>
                         <tr>
-                            <td>
-                                {{opened_comment.object_detail}}
-                            </td>
-                            <td>
-                                {{opened_comment.message}}
-                            </td>
-                            <td>
-                                {{ opened_comment.cree_le|date:"d/m/Y" }} {{ opened_comment.cree_le|time:"H:i" }}
-                            </td>
+                            <th scope="col" class="col__width--150">Élements de la convention commentés </th>
+                            <th scope="col">Message</th>
+                            <th scope="col" class="col__width--150">Créé le</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                        {% for opened_comment in opened_comments %}
+                            <tr>
+                                <td>
+                                    {{opened_comment.object_detail}}
+                                </td>
+                                <td>
+                                    {{opened_comment.message}}
+                                </td>
+                                <td>
+                                    {{ opened_comment.cree_le|date:"d/m/Y" }} {{ opened_comment.cree_le|time:"H:i" }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
 
-    </div>
-{% else %}
-    <a class="fr-link fr-mb-1w" href='{% url "conventions:recapitulatif" convention_uuid=convention.uuid %}' id="refresh_opened_comments" hidden>
-        <span class="fr-icon-refresh-line" aria-hidden="true">Rafraichir</span>
-    </a>
+        </div>
+    {% else %}
+        <a class="fr-link fr-mb-1w" href='{% url "conventions:recapitulatif" convention_uuid=convention.uuid %}' id="refresh_opened_comments" hidden>
+            <span class="fr-icon-refresh-line" aria-hidden="true">Rafraichir</span>
+        </a>
+    {% endif %}
 {% endif %}

--- a/templates/common/form/disable_form_input.html
+++ b/templates/common/form/disable_form_input.html
@@ -1,9 +1,9 @@
 {% load custom_filters %}
 
 {% if comments and parent_object_field %}
-    {% if not editable and comments|hasnt_active_comments:parent_object_field %}disabled{% endif %}
+    {% if not editable and not request.session.is_expert and comments|hasnt_active_comments:parent_object_field %}disabled{% endif %}
 {% elif comments and object_field %}
-    {% if not editable and comments|hasnt_active_comments:object_field %}disabled{% endif %}
+    {% if not editable and not request.session.is_expert and comments|hasnt_active_comments:object_field %}disabled{% endif %}
 {% else %}
-    {% if not editable %}disabled{% endif %}
+    {% if not editable and not request.session.is_expert %}disabled{% endif %}
 {% endif %}

--- a/templates/conventions/actions/goto.html
+++ b/templates/conventions/actions/goto.html
@@ -1,4 +1,4 @@
-{% if convention|display_convention_form_progressbar %}
+{% if convention|display_convention_form_progressbar or request.session.is_expert %}
     <a class="fr-link fr-mb-1w" href="{% url target_url convention_uuid=convention.uuid %}" >
         <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
     </a>

--- a/templates/conventions/common/form_header.html
+++ b/templates/conventions/common/form_header.html
@@ -3,8 +3,8 @@
 
 {% if convention %}
     <div class="apilos-sticky fr-container fr-pt-2w {% if convention|display_convention_form_progressbar %}no_navbar{% endif %}">
-        <div class="fr-grid-row fr-grid-row--gutters">
-            <div class="fr-col-12 fr-py-3w">
+        <div class="fr-grid-row fr-grid-row--gutters block--row-strech">
+            <div class="block--row-strech-1 fr-py-3w fr-mr-2w apilos--overflow_ellipsis">
                 <h1 class="fr-h2 apilos-d-inline">{{convention.programme.nom}}</h1>
                 {% if convention.is_avenant %}
                     <span class="apilos-h2-thin"> - Avenant{% if convention.numero %} n°{{ convention.numero }}{% endif %}</span>
@@ -25,6 +25,12 @@
                     </div>
                 {% endif %}
             </div>
+            {% if request.session.is_expert %}
+                <div class="fr-alert fr-alert--warning">
+                    <h3 class="fr-alert__title">Mode expert - Les modifications sont sous votre responsabilité.</h3>
+                    <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}">Sortir du mode expert</a>
+                </div>
+            {% endif %}
         </div>
     </div>
     <div>

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -31,6 +31,19 @@
                         {% include "comments/opened_comments.html" %}
                     </turbo-frame>
                 {% endif %}
+                {% if convention.statut == CONVENTION_STATUT.SIGNEE and request|is_instructeur %}
+                    <div class="fr-grid-row fr-grid-row--right">
+                        <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}" class="fr-btn fr-btn--secondary">
+                            {% if request.session.is_expert %}
+                                <span class="fr-icon-close-circle-line fr-mr-1w"></span>
+                                Sortir du mode expert
+                            {% else %}
+                                <span class="fr-icon-ball-pen-line fr-mr-1w"></span>
+                                Passer en mode expert
+                            {% endif %}
+                        </a>
+                    </div>
+                {% endif %}
                 {% if convention.is_avenant %}
                     {% if 'bailleur' in avenant_list %}
                         {% include "conventions/recapitulatif/bailleur.html" with target_url='conventions:avenant_bailleur' bailleur=convention.bailleur %}

--- a/templates/conventions/recapitulatif/edd.html
+++ b/templates/conventions/recapitulatif/edd.html
@@ -11,7 +11,7 @@
                                 Opération - EDD
                             </h4>
                         </div>
-                        {% if convention|display_convention_form_progressbar %}
+                        {% if convention|display_convention_form_progressbar  or request.session.is_expert %}
                             <a class="fr-link fr-mb-1w" href="{% url 'conventions:edd' convention_uuid=convention.uuid %}" >
                                 <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
                             </a>

--- a/templates/conventions/recapitulatif/operation.html
+++ b/templates/conventions/recapitulatif/operation.html
@@ -11,7 +11,7 @@
                                 Opération
                             </h4>
                         </div>
-                        {% if convention|display_convention_form_progressbar %}
+                        {% if convention|display_convention_form_progressbar  or request.session.is_expert %}
                             <a class="fr-link fr-mb-1w" href="{% url 'conventions:programme' convention_uuid=convention.uuid %}" >
                                 <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
                             </a>
@@ -55,7 +55,7 @@
                                 Opération - informations cadastrales
                             </h4>
                         </div>
-                        {% if convention|display_convention_form_progressbar %}
+                        {% if convention|display_convention_form_progressbar  or request.session.is_expert %}
                             <a class="fr-link fr-mb-1w" href="{% url 'conventions:cadastre' convention_uuid=convention.uuid %}" >
                                 <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
                             </a>

--- a/templates/conventions/recapitulatif/references_cadastrales.html
+++ b/templates/conventions/recapitulatif/references_cadastrales.html
@@ -11,7 +11,7 @@
                                 Références cadastrales et effet relatif
                             </h4>
                         </div>
-                        {% if convention|display_convention_form_progressbar %}
+                        {% if convention|display_convention_form_progressbar  or request.session.is_expert %}
                             <a class="fr-link fr-mb-1w" href="{% url 'conventions:cadastre' convention_uuid=convention.uuid %}#id_reference_cadastrale_div" >
                                 <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
                             </a>

--- a/templates/conventions/recapitulatif/stationnements.html
+++ b/templates/conventions/recapitulatif/stationnements.html
@@ -11,7 +11,7 @@
                                 Stationnements
                             </h4>
                         </div>
-                        {% if convention|display_convention_form_progressbar %}
+                        {% if convention|display_convention_form_progressbar  or request.session.is_expert %}
                             <a class="fr-link fr-mb-1w" href="{% url 'conventions:stationnements' convention_uuid=convention.uuid %}" >
                                 <span class="fr-icon-edit-line" aria-hidden="true">Aller à cette étape</span>
                             </a>


### PR DESCRIPTION
sur la page du récapitulatif, pour les conventions au statut signé, mise en place d'un bouton de bascule vers le mode expert (pour les instructeurs)
![image](https://github.com/MTES-MCT/apilos/assets/19302155/2d561f46-49c2-463e-bac7-9039b43c44cb)

Une fois le mode expert activé, un bandeau de warning se positionne dans l'en-tête sticky avec la possibilité de désactiver le mode, un bouton pour désactiver le mode est également présent sur la page de récapitulatif, les pages du formulaire sont de nouveau accessible via le récapitulatif et sont éditables.
![image](https://github.com/MTES-MCT/apilos/assets/19302155/f1d47f0f-ade0-4d1a-a4a9-3decbcafc9f4)
