### PR TITLE
Add services step to procfile to start docker stack

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
+services: docker compose up
 web: python manage.py runserver 0.0.0.0:8001
 worker: python -m celery -A core.worker worker -l INFO


### PR DESCRIPTION
A tiny PR that adds a step in the Procfile to start the docker stack before web services. 

Note that the procfile might need an update once https://github.com/MTES-MCT/apilos/pull/818/files is merged 