### PR TITLE
Use cp --recursive instead of sync for s3 synchronisation

### DIFF
--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -8,7 +8,7 @@ on:
     - cron: '27 1 * * 1'
 
 env:
-  S3_HOST: s3.fr-par.scw.cloud
+  S3_HOST: https://s3.fr-par.scw.cloud
   S3_BUCKET: s3://apilos-prod
   BACKUP_NAME: s3_production
 
@@ -20,11 +20,19 @@ jobs:
     steps:
       - name: Backup
         run: |
-          pip install s3cmd
+          pip install awscli
+          pip install awscli-plugin-endpoint
+          aws configure set plugins.endpoint awscli_plugin_endpoint
+          aws configure set s3.endpoint_url ${{ env.S3_HOST }}
+          aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
+          pip install awscli-plugin-endpoint
           mkdir ${{ env.BACKUP_NAME }}
-          echo 's3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} cp --recursive --dry-run ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}'
-          s3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+          aws s3 cp --recursive --dry-run ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+          aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
           tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
       - name: Upload Backup as Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -2,6 +2,7 @@ name: Backup S3 Production Bucket
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     # At 01:27 UTC every Monday
     - cron: '27 1 * * 1'

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -9,7 +9,8 @@ on:
 
 env:
   S3_HOST: https://s3.fr-par.scw.cloud
-  S3_BUCKET: s3://apilos-prod
+  S3_BUCKET_SOURCE: s3://apilos-prod
+  S3_BUCKET_DESTINATION: s3://apilos-glacier
   BACKUP_NAME: s3_production
 
 jobs:
@@ -38,7 +39,7 @@ jobs:
       #     mkdir ${{ env.BACKUP_NAME }}
       #     aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
       - name: Backup
-        run: aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+        run: aws s3 cp --recursive ${{ env.S3_BUCKET_SOURCE }} ${{ env.S3_BUCKET_DESTINATION }} --storage-class GLACIER
       - name: Compress backup
         run: tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
       - name: Upload Backup as Artifact

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -34,9 +34,5 @@ jobs:
           aws configure set s3.max_queue_size 1000
           aws configure set s3.multipart_threshold '50 MB'
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
-      # - name: Backup in dry run mode
-      #   run: |
-      #     mkdir ${{ env.BACKUP_NAME }}
-      #     aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
       - name: Backup
-        run: aws s3 cp --recursive ${{ env.S3_BUCKET_SOURCE }} ${{ env.S3_BUCKET_DESTINATION }} --storage-class GLACIER
+        run: aws s3 sync --quiet ${{ env.S3_BUCKET_SOURCE }} ${{ env.S3_BUCKET_DESTINATION }} --storage-class GLACIER

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -27,7 +27,7 @@ jobs:
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
           pip install awscli-plugin-endpoint
           mkdir ${{ env.BACKUP_NAME }}
-          aws s3 cp --recursive --dry-run ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+          aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
           aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
           tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
         env:

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -23,9 +23,12 @@ jobs:
           pip install awscli
           pip install awscli-plugin-endpoint
       - name: configure AWS CLI for Scaleway
-        run: |
+        run: | # Source : https://www.scaleway.com/en/docs/storage/object/api-cli/object-storage-aws-cli/
           aws configure set plugins.endpoint awscli_plugin_endpoint
           aws configure set s3.endpoint_url ${{ env.S3_HOST }}
+          aws configure set s3.max_concurrent_requests 100
+          aws configure set s3.max_queue_size 1000
+          aws configure set s3.multipart_threshold '50 MB'
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -2,7 +2,6 @@ name: Backup S3 Production Bucket
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     # At 01:27 UTC every Monday
     - cron: '27 1 * * 1'

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -40,10 +40,3 @@ jobs:
       #     aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
       - name: Backup
         run: aws s3 cp --recursive ${{ env.S3_BUCKET_SOURCE }} ${{ env.S3_BUCKET_DESTINATION }} --storage-class GLACIER
-      - name: Compress backup
-        run: tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
-      - name: Upload Backup as Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.BACKUP_NAME }}
-          path: ${{ env.BACKUP_NAME }}.tar.gz

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -10,16 +10,14 @@ env:
   S3_HOST: https://s3.fr-par.scw.cloud
   S3_BUCKET_SOURCE: s3://apilos-prod
   S3_BUCKET_DESTINATION: s3://apilos-glacier
+  AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
   BACKUP_NAME: s3_production
 
 jobs:
   backup-production:
     name: Backup S3 in Production environment
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
-
     steps:
       - name: Install AWS CLI dependencies
         run: |

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -33,10 +33,10 @@ jobs:
           aws configure set s3.max_queue_size 1000
           aws configure set s3.multipart_threshold '50 MB'
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
-      - name: Backup in dry run mode
-        run: |
-          mkdir ${{ env.BACKUP_NAME }}
-          aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+      # - name: Backup in dry run mode
+      #   run: |
+      #     mkdir ${{ env.BACKUP_NAME }}
+      #     aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
       - name: Backup
         run: aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
       - name: Compress backup

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -18,21 +18,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Backup
+      - name: Install AWS CLI dependencies
         run: |
           pip install awscli
           pip install awscli-plugin-endpoint
+      - name: configure AWS CLI for Scaleway
+        run: |
           aws configure set plugins.endpoint awscli_plugin_endpoint
           aws configure set s3.endpoint_url ${{ env.S3_HOST }}
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
-          pip install awscli-plugin-endpoint
-          mkdir ${{ env.BACKUP_NAME }}
-          aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
-          aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
-          tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
+      - name: Backup in dry run mode
+        run: |
+          mkdir ${{ env.BACKUP_NAME }}
+          aws s3 cp --recursive --dryrun ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+      - name: Backup
+        run: aws s3 cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+      - name: Compress backup
+        run: tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
       - name: Upload Backup as Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -1,6 +1,7 @@
 name: Backup S3 Production Bucket
 
 on:
+  workflow_dispatch:
   schedule:
     # At 01:27 UTC every Monday
     - cron: '27 1 * * 1'
@@ -20,8 +21,8 @@ jobs:
         run: |
           pip install s3cmd
           mkdir ${{ env.BACKUP_NAME }}
-          echo 's3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} sync --dry-run ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}'
-          s3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} sync ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
+          echo 's3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} cp --recursive --dry-run ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}'
+          s3cmd --host=${{ env.S3_HOST }} --host-bucket= --access_key=${{ secrets.S3_ACCESS_KEY }} --secret_key=${{ secrets.S3_SECRET_KEY }} cp --recursive ${{ env.S3_BUCKET }} ${{ env.BACKUP_NAME }}
           tar cfz ${{ env.BACKUP_NAME }}.tar.gz ${{ env.BACKUP_NAME }}
       - name: Upload Backup as Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/s3_backup.yml
+++ b/.github/workflows/s3_backup.yml
@@ -16,6 +16,9 @@ jobs:
   backup-production:
     name: Backup S3 in Production environment
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
 
     steps:
       - name: Install AWS CLI dependencies
@@ -30,9 +33,6 @@ jobs:
           aws configure set s3.max_queue_size 1000
           aws configure set s3.multipart_threshold '50 MB'
           aws configure set s3api.endpoint_url ${{ env.S3_HOST }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}
       - name: Backup in dry run mode
         run: |
           mkdir ${{ env.BACKUP_NAME }}


### PR DESCRIPTION
* remove s3cmd as it might not be needed here (and provides fewer options than the officiel awscli)
* use recommended s3 options from scaleway documentation 
* sync the bucket to another bucket with glacier storage class for strong storage security
* add a manual workflow dispatch allowing a manual backup of the bucket


ref https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwhG4jAQK4JhrSZz/recavIzEgNmrkjC1J?blocks=hide 

---

Ci-dessous historique de mes réflexions (ça pourra re-servir plus tard). 

---

`aws sync` a besoin de faire un diff des fichiers entre avant et après la copie, c'est pourquoi avec autant de fichier le listage prend un temps fou. 
Comme on a pas besoin de faire un diff mais une copie "brute" du bucket, on peut se contenter d'un `cp --recursive`. 

J'en ai profité pour diviser le fichier en plus d'étapes pour mieux suivre les timings de chaque étape


---
`s3cmd` ne supporte pas la commande `cp` entre un s3 et un répertoire local.  
Pour pallier à cette limitation je suis passé par le cli AWS officiel, et ai ajouté la configuration requise pour atteindre le bucket Scaleway. 
  
--- 
Note 1 : J'ai temporairement ajouté des trigger pour l'action GitHub histoire de tester le backup avant de merge. 
Note 2 : J'ai tenté de créer un bucket glacier scaleway comme évoqué mais la documentation est un peu obscure sur la manière de créer un bucket glacier, cf https://www.scaleway.com/en/docs/storage/object/how-to/edit-storage-class/ je n'ai pas trouvé l'option pour définir la classe de stockage à `GLACIER` pour l'intégralité d'un bucket. 
À creuser. 