### PR TITLE
Prevent redis from running indefinitely

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 5433:5432
   redis:
     image: redis:7.0
-    restart: always
+    restart: unless-stopped
     expose:
       - 6379
     command: redis-server /usr/local/etc/redis/redis.conf


### PR DESCRIPTION
Redis is set to run `always` in the `docker-compose.yml` file at the moment. This causes the container to boot with docker, hence consuming some resources on the local machine even if Apilos is not running. 

Using unless-stopped will ensure that the `redis` container is stopped alongside the rest of the stack when killing `honcho` or `docker-compose` command 