### PR TITLE
Clamav implementation in scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/Scalingo/clamav-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/python-buildpack.git

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -18,6 +18,7 @@ Il est conseillé d'installer un environnment virtuel pour isoler l'environnemen
 - Node >=18.14
 - docker
 - docker-compose
+- clamav (optionnel)
 
 ### Environment virtuel python
 
@@ -107,6 +108,22 @@ Ajout de bailleurs, administrations, programmes et lots de test
 ```sh
 python manage.py load_test_fixtures
 ```
+
+### ClamAV (optionnel)
+
+ClamAV est utilisé pour le scan des fichiers uploadés.
+Il est disponible dans sur la majorité des [systèmes d'exploitation](https://www.clamav.net/downloads).
+
+Sur les systèmes `debian` (ubuntu, Windows Subsystem for Linux) :
+```sh
+apt install clamav
+```
+
+Sur MacOS, la dépendance est disponible via Homebrew :
+```sh
+brew install clamav
+```
+
 
 ## Qualité de code
 

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -124,6 +124,16 @@ Sur MacOS, la dépendance est disponible via Homebrew :
 brew install clamav
 ```
 
+ClamAV requiert une étape de configuration sur certains systèmes d'exploitations.
+Celle-ci consiste à copier des fichier de configuration :
+
+```sh
+# Sur MacOS, avec ClamAV installé via Homebrew
+cp /opt/homebrew/etc/clamav/freshclam.conf.sample /opt/homebrew/etc/clamav/freshclam.conf
+cp /opt/homebrew/etc/clamd/clamd.conf.sample /opt/homebrew/etc/clamd/clamd.conf
+
+```
+
 
 ## Qualité de code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.10
 ENV PYTHONUNBUFFERED=1
 ARG IPYTHON_AUTORELOAD
 
+# clamav is used in celery to scan uploads before after they reach the file system
+RUN apt update
+RUN apt install clamav -y
+
 WORKDIR /code
 COPY requirements.txt .
 COPY dev-requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM python:3.10
 ENV PYTHONUNBUFFERED=1
 ARG IPYTHON_AUTORELOAD
 
-# clamav is used in celery to scan uploads before after they reach the file system
-RUN apt update
-RUN apt install clamav -y
-
 WORKDIR /code
 COPY requirements.txt .
 COPY dev-requirements.txt .

--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from re import IGNORECASE
 from re import compile as rcompile
 from re import escape as rescape
@@ -222,8 +221,11 @@ def without_missing_files(files):
 
     files_as_json = json.loads(files)
     for convention_id, file in files_as_json.items():
-        instance = UploadedFile(uuid=file["convention_id"], filename=file["filename"])
-        if not Path.is_file(Path(instance.filepath(convention_id))):
+        try:
+            UploadedFile.objects.get(
+                uuid=file["convention_id"], filename=file["filename"]
+            )
+        except UploadedFile.DoesNotExist:
             del files_as_json[convention_id]
 
     return files_as_json

--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -217,15 +217,16 @@ def get_files_from_textfiles(field):
 
 @register.filter
 def without_missing_files(files):
-    json_files = json.loads(files)
-    for convention_id, file in json_files.items():
+    if not files:
+        return ""
+
+    files_as_json = json.loads(files)
+    for convention_id, file in files_as_json.items():
         instance = UploadedFile(uuid=file["convention_id"], filename=file["filename"])
         if not Path.is_file(Path(instance.filepath(convention_id))):
-            del json_files[convention_id]
+            del files_as_json[convention_id]
 
-    if not json_files:
-        return ""
-    return files
+    return files_as_json
 
 
 @register.filter

--- a/core/services.py
+++ b/core/services.py
@@ -11,6 +11,8 @@ from django.core.files.storage import default_storage
 logger = logging.getLogger(__name__)
 
 # Using enum class create enumerations
+# These numeric ids match campaign templates ids.
+# They are listed under Brevo dashboard> Campaigns > Templates
 class EmailTemplateID(enum.Enum):
     # [PLATEFORME] BAILLEUR - Avenant à instruire - confirmation
     B_AVENANT_A_INSTRUIRE_CONFIRMATION = 106

--- a/core/services.py
+++ b/core/services.py
@@ -44,6 +44,8 @@ class EmailTemplateID(enum.Enum):
     I_MENSUEL = 151
     # Bailleurs - 5 - ACTIVATION (récapitulatif mensuel)
     B_MENSUEL = 152
+    # Virus - 163 - Warning
+    VIRUS_WARNING = 163
 
 
 class EmailService:
@@ -90,19 +92,5 @@ class EmailService:
                         f.read(),
                         content_type,
                     )
-            if settings.SENDINBLUE_API_KEY:
-                message.send()
-            else:
-                logger.warning(
-                    """
-    Email message:
-        to: %s
-        cc: %s
-        template_id: %s
-        data: %s
-                """,
-                    message.to,
-                    message.cc,
-                    message.template_id,
-                    message.merge_global_data,
-                )
+
+            message.send()

--- a/templates/common/display_files.html
+++ b/templates/common/display_files.html
@@ -1,3 +1,4 @@
+{% load custom_filters %}
 {% for file in file_list %}
     <div class="content__fileblock">
         <div class='fr-mx-1w dz-image'>

--- a/templates/common/form/input_upload.html
+++ b/templates/common/form/input_upload.html
@@ -1,6 +1,4 @@
-{% load static %}
-
-{% load custom_filters %}
+{% load static custom_filters %}
 
 <div class="fr-input-group {% if form_input.errors %}fr-select-group--error{% endif %}" id="{{form_input.id_for_label}}_group">
     <div class="fr-mb-2w">
@@ -75,7 +73,9 @@
                 type="hidden"
                 id="{{form_input_files.id_for_label}}"
                 name="{{form_input_files.html_name}}"
-                value="{{form_input_files.value}}" />
+                value="{{form_input_files.value|without_missing_files}}"
+            />
+
             <div id="{{form_input_files.id_for_label}}_errors"></div>
             <input
                 type="hidden"

--- a/upload/models.py
+++ b/upload/models.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from django.db import models
 
+
 # Create your models here.
 class UploadedFile(models.Model):
     id = models.AutoField(primary_key=True)

--- a/upload/models.py
+++ b/upload/models.py
@@ -1,7 +1,9 @@
 import uuid
+from pathlib import Path
 
 from rest_framework import serializers
 
+from django.conf import settings
 from django.db import models
 
 # Create your models here.

--- a/upload/models.py
+++ b/upload/models.py
@@ -1,9 +1,7 @@
 import uuid
-from pathlib import Path
 
 from rest_framework import serializers
 
-from django.conf import settings
 from django.db import models
 
 # Create your models here.

--- a/upload/services.py
+++ b/upload/services.py
@@ -65,6 +65,10 @@ class UploadService:
                 "rb",
             )
         return default_storage.open(
-            f"{self.convention_dirpath}/{self.filename}",
+            self.path,
             "rb",
         )
+
+    @property
+    def path(self):
+        return f"{self.convention_dirpath}/{self.filename}"

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -1,14 +1,15 @@
 from celery import shared_task
+from django.conf import settings
+from pathlib import Path
 import subprocess
 from upload.models import UploadedFile, UploadedFileSerializer
 
 
 @shared_task()
-def scan_uploaded_files(files_ids):
+def scan_uploaded_files(paths_to_scan):
     # refresh the database on demand before the scan starts
     subprocess.run("freshclam", shell=True, check=True)
-    files = UploadedFile.objects.filter(id__in=files_ids)
-    paths = [file.filepath for file in files]
-    for path in paths:
-        print("SCAN", path)
-        subprocess.run(["clamscan", path], shell=True, check=True)
+
+    for path in paths_to_scan:
+        path = Path(settings.MEDIA_ROOT / path).resolve()
+        subprocess.run(f"clamscan {path}", shell=True, check=True)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -20,7 +20,7 @@ def scan_uploaded_files(paths_to_scan, authenticated_user_id):
     for path, uploaded_file_id in paths_to_scan:
         path = Path(settings.MEDIA_ROOT / path).resolve()
         output = subprocess.run(
-            ["clamscan", path], capture_output=True, text=True, check=True
+            ["clamscan", path], capture_output=True, text=True, check=False
         )
 
         if (

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -1,0 +1,14 @@
+from celery import shared_task
+import subprocess
+from upload.models import UploadedFile, UploadedFileSerializer
+
+
+@shared_task()
+def scan_uploaded_files(files_ids):
+    # refresh the database on demand before the scan starts
+    subprocess.run("freshclam", shell=True, check=True)
+    files = UploadedFile.objects.filter(id__in=files_ids)
+    paths = [file.filepath for file in files]
+    for path in paths:
+        print("SCAN", path)
+        subprocess.run(["clamscan", path], shell=True, check=True)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -1,15 +1,43 @@
+import subprocess
+import logging
+from pathlib import Path
+
 from celery import shared_task
 from django.conf import settings
-from pathlib import Path
-import subprocess
+
+from core.services import EmailService, EmailTemplateID
 from upload.models import UploadedFile, UploadedFileSerializer
+from users.models import User
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task()
-def scan_uploaded_files(paths_to_scan):
+def scan_uploaded_files(paths_to_scan, authenticated_user_id):
     # refresh the database on demand before the scan starts
     subprocess.run("freshclam", shell=True, check=True)
 
     for path in paths_to_scan:
         path = Path(settings.MEDIA_ROOT / path).resolve()
-        subprocess.run(f"clamscan {path}", shell=True, check=True)
+        output = subprocess.run(["clamscan", path], capture_output=True, text=True)
+
+        if (
+            "Infected files" in output.stdout
+            and "Infected files: 0" not in output.stdout
+        ):
+            user = User.objects.get(id=authenticated_user_id)
+            EmailService(
+                to_emails=[user.email],
+                email_template_id=EmailTemplateID.VIRUS_WARNING,
+            ).send_transactional_email(
+                email_data={
+                    "firstname": user.first_name,
+                    "lastname": user.last_name,
+                    "filename": path.name,
+                }
+            )
+            path.unlink()
+            logger.warning(
+                "An infected file has been detected. The user has been warned by email and the file has succesfully been removed. | File location : %s"
+                % path
+            )

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -40,6 +40,7 @@ def scan_uploaded_files(paths_to_scan, authenticated_user_id):
             )
             path.unlink()
             UploadedFile.objects.get(id=uploaded_file_id).delete()
+
             logger.warning(
                 "An infected file has been detected."
                 "The user has been warned by email "

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -6,7 +6,6 @@ from celery import shared_task
 from django.conf import settings
 
 from core.services import EmailService, EmailTemplateID
-from upload.models import UploadedFile, UploadedFileSerializer
 from users.models import User
 
 logger = logging.getLogger(__name__)

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -17,9 +17,11 @@ def scan_uploaded_files(paths_to_scan, authenticated_user_id):
     # refresh the database on demand before the scan starts
     subprocess.run("freshclam", shell=True, check=True)
 
-    for (path, uploaded_file_id) in paths_to_scan:
+    for path, uploaded_file_id in paths_to_scan:
         path = Path(settings.MEDIA_ROOT / path).resolve()
-        output = subprocess.run(["clamscan", path], capture_output=True, text=True)
+        output = subprocess.run(
+            ["clamscan", path], capture_output=True, text=True, check=True
+        )
 
         if (
             "Infected files" in output.stdout
@@ -37,8 +39,10 @@ def scan_uploaded_files(paths_to_scan, authenticated_user_id):
                 }
             )
             path.unlink()
-            UploadedFile.objects.get(id=id).delete()
+            UploadedFile.objects.get(id=uploaded_file_id).delete()
             logger.warning(
-                "An infected file has been detected. The user has been warned by email and the file has succesfully been removed. | File location : %s"
-                % path
+                "An infected file has been detected."
+                "The user has been warned by email "
+                "and the file has succesfully been removed. | File location : %s",
+                path,
             )

--- a/upload/tests/test_tasks.py
+++ b/upload/tests/test_tasks.py
@@ -1,0 +1,58 @@
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from core.services import EmailTemplateID
+from upload.tasks import scan_uploaded_files
+from users.models import User
+
+
+class SampleOutput:
+    stdout = ""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+@override_settings(EMAIL_BACKEND="anymail.backends.test.EmailBackend")
+@override_settings(SENDINBLUE_API_KEY="fake_sendinblue_api_key")
+class VirusDetection(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            "very_dangerous_user", "hackerman@wanadoo.fr", "p@ssw0rd"
+        )
+        self.user.first_name = "Mr"
+        self.user.last_name = "Hacker"
+        self.user.save()
+
+    @mock.patch("subprocess.run")
+    def test_clamav_email_sending(self, mock_subprocess_run):
+        self.client.login(username="very_dangerous_user", password="p@ssw0rd")
+        mock_subprocess_run.return_value = SampleOutput("Infected files: 0")
+
+        with tempfile.NamedTemporaryFile(dir="media", delete=False) as virus:
+            scan_uploaded_files([virus.name], self.user.id)
+
+            self.assertTrue(mock_subprocess_run.called)
+            self.assertEqual(len(mail.outbox), 0)
+
+            mock_subprocess_run.return_value = SampleOutput("Infected files: 1")
+            scan_uploaded_files([virus.name], self.user.id)
+            self.assertEqual(len(mail.outbox), 1)
+            self.assertEqual(
+                mail.outbox[0].anymail_test_params["template_id"],
+                EmailTemplateID.VIRUS_WARNING.value,
+            )
+            self.assertDictEqual(
+                mail.outbox[0].anymail_test_params["merge_global_data"],
+                {
+                    "firstname": self.user.first_name,
+                    "lastname": self.user.last_name,
+                    "filename": Path(virus.name).name,
+                },
+            )
+            with self.assertRaises(FileNotFoundError):
+                scan_uploaded_files([virus.name], self.user.id)

--- a/upload/tests/test_tasks.py
+++ b/upload/tests/test_tasks.py
@@ -6,6 +6,7 @@ from django.core import mail
 from django.test import TestCase, override_settings
 
 from core.services import EmailTemplateID
+from upload.models import UploadedFile
 from upload.tasks import scan_uploaded_files
 from users.models import User
 
@@ -27,6 +28,8 @@ class VirusDetection(TestCase):
         self.user.first_name = "Mr"
         self.user.last_name = "Hacker"
         self.user.save()
+        self.sample_file = UploadedFile()
+        self.sample_file.save()
 
     @mock.patch("subprocess.run")
     def test_clamav_email_sending(self, mock_subprocess_run):
@@ -34,13 +37,13 @@ class VirusDetection(TestCase):
         mock_subprocess_run.return_value = SampleOutput("Infected files: 0")
 
         with tempfile.NamedTemporaryFile(dir="media", delete=False) as virus:
-            scan_uploaded_files([virus.name], self.user.id)
+            scan_uploaded_files([(virus.name, self.sample_file.pk)], self.user.id)
 
             self.assertTrue(mock_subprocess_run.called)
             self.assertEqual(len(mail.outbox), 0)
 
             mock_subprocess_run.return_value = SampleOutput("Infected files: 1")
-            scan_uploaded_files([virus.name], self.user.id)
+            scan_uploaded_files([(virus.name, self.sample_file.pk)], self.user.id)
             self.assertEqual(len(mail.outbox), 1)
             self.assertEqual(
                 mail.outbox[0].anymail_test_params["template_id"],
@@ -54,5 +57,6 @@ class VirusDetection(TestCase):
                     "filename": Path(virus.name).name,
                 },
             )
+            self.assertEqual(UploadedFile.objects.all().count(), 0)
             with self.assertRaises(FileNotFoundError):
-                scan_uploaded_files([virus.name], self.user.id)
+                scan_uploaded_files([(virus.name, self.sample_file)], self.user.id)

--- a/upload/views.py
+++ b/upload/views.py
@@ -44,6 +44,7 @@ def display_file(request, convention_uuid, uploaded_file_uuid):
 def upload_file(request):
     files = request.FILES
     uploaded_files = []
+    paths_to_scan = []
     dirpath = _compute_dirpath(request)
 
     for file in files.values():
@@ -62,7 +63,8 @@ def upload_file(request):
         upload_service.upload_file(file)
 
         uploaded_file.save()
+        paths_to_scan.append(upload_service.path)
         uploaded_files.append(UploadedFileSerializer(uploaded_file).data)
 
-    scan_uploaded_files.delay([file.id for file in uploaded_files])
+    scan_uploaded_files.delay(paths_to_scan)
     return JsonResponse({"success": "true", "uploaded_file": uploaded_files})

--- a/upload/views.py
+++ b/upload/views.py
@@ -63,7 +63,7 @@ def upload_file(request):
         upload_service.upload_file(file)
 
         uploaded_file.save()
-        paths_to_scan.append(upload_service.path)
+        paths_to_scan.append((upload_service.path, uploaded_file.pk))
         uploaded_files.append(UploadedFileSerializer(uploaded_file).data)
 
     scan_uploaded_files.delay(paths_to_scan, request.user.id)

--- a/upload/views.py
+++ b/upload/views.py
@@ -5,6 +5,7 @@ from programmes.models import Lot, Programme
 
 from upload.services import UploadService
 from upload.models import UploadedFile, UploadedFileSerializer
+from upload.tasks import scan_uploaded_files
 
 
 def _compute_dirpath(request):
@@ -62,4 +63,6 @@ def upload_file(request):
 
         uploaded_file.save()
         uploaded_files.append(UploadedFileSerializer(uploaded_file).data)
+
+    scan_uploaded_files.delay([file.id for file in uploaded_files])
     return JsonResponse({"success": "true", "uploaded_file": uploaded_files})

--- a/upload/views.py
+++ b/upload/views.py
@@ -66,5 +66,5 @@ def upload_file(request):
         paths_to_scan.append(upload_service.path)
         uploaded_files.append(UploadedFileSerializer(uploaded_file).data)
 
-    scan_uploaded_files.delay(paths_to_scan)
+    scan_uploaded_files.delay(paths_to_scan, request.user.id)
     return JsonResponse({"success": "true", "uploaded_file": uploaded_files})


### PR DESCRIPTION
* add clamav to Scalingo buildpack
* trigger a celery task right after a file has been uploaded
* disable by default all daemons usually run by clamav on scalingo to reduce memory usage on production (done directly in scalingo dashboard)
* refresh virus signatures/database before each execution
* remove file if it poses a threat
* alert the user who uploaded the file if a threat is detected
* remove a conditionnal in `services` that is already done when switching the email backend in django settings

it takes a few seconds to run so the threat should not live a long time on the server. 

ref  https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwhG4jAQK4JhrSZz/recGd0Ngi4Af0PWRi?blocks=hide 

---

Environment variables set in Scalingo
```
CLAMD_DISABLE_CONCURRENT_RELOAD=1
CLAMD_DISABLE_DAEMON=1
FRESHCLAM_DISABLE_DAEMON=1
```

---

A [new brevo template](https://my.brevo.com/camp/template/163/message-setup) has been created

--- 

False positive file to test the feature (it is safe, this is just a .svg with a special string)

![false_positive](https://github.com/MTES-MCT/apilos/assets/1702255/6e5df52d-3f3f-4c19-bbc0-ea8f9aa943cf)
*right click > download file*

