### PR TITLE
Mettre à jour la page de vue d'ensemble 

### DIFF
--- a/templates/conventions/actions/update_date_signature.html
+++ b/templates/conventions/actions/update_date_signature.html
@@ -5,7 +5,7 @@
         <div class="block--row-strech-1 fr-mr-6w">
 
             <p>
-                Votre convention a été signée le {{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}.<br/>
+                {% if convention.is_avenant %}Votre avenant a été signé{% else %}Votre convention a été signée{% endif %} le {{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}.<br/>
                 Ce n'est pas la bonne date ?
             </p>
             {% include "common/form/input_date.html" with form_input=updatedate_form.televersement_convention_signee_le editable=True %}

--- a/templates/conventions/avenant_list.html
+++ b/templates/conventions/avenant_list.html
@@ -12,7 +12,7 @@
                 <div class="fr-col-11">
                     <div class="fr-grid-row">
                         <p class="fr-m-0">
-                            Avenant {{convention.numero }} du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>:&nbsp;{% if convention.description_avenant %}
+                            Avenant {{convention.numero|default_if_none:'x' }} {% if convention.televersement_convention_signee_le %}du <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-' }} </strong></span>{% endif %}:&nbsp;{% if convention.description_avenant %}
                                 {{ convention.description_avenant|linebreaksbr }}
                             {% endif %}
                         </p>
@@ -24,14 +24,20 @@
 
                 </div>
             {% else %}
-                <div class="fr-col-11">
-                    <div class="fr-grid-row">
-                        Avenant {{convention.numero }} du <span class="fr-ml-1v"><strong> {{convention.valide_le|date:"d F Y"|default_if_none:'-' }} </strong></span>
-                        <div class="fr-ml-2w"><strong>{% include "conventions/home/statut_tag.html"  %}</strong></div>
+                <div class="fr-grid-row fr-grid-row--middle fr-mb-3w">
+                    <div>
+                        Avenant {{convention.numero|default_if_none:'x'}}
+                        {% if convention.televersement_convention_signee_le %}
+                            du <span class="fr-ml-1v">
+                                <strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-' }} </strong>
+                            </span>
+                        {% endif %}
+                        <div>
+                            <a class="fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}" >Voir l'avenant</a>
+                        </div>
                     </div>
-                    <div class="fr-mb-3w fr-mt-n1v">
-                        <a class="fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}" >Voir l'avenant</a>
-                    </div>
+
+                    <div class="fr-ml-4w"><strong>{% include "conventions/home/statut_tag.html"  %}</strong></div>
                 </div>
             {% endif %}
         </div>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -22,7 +22,7 @@
                     </div>
                     <div class="fr-col-11">
                         {% if convention.televersement_convention_signee_le %}
-                            <div class="fr-grid-row">Convention signée le <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}</strong></span></div>
+                            <div class="fr-grid-row">{% if convention.is_avenant %}Avenant signé {% else %}Convention signée {% endif %}le <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}</strong></span></div>
                         {% else %}
                             <div class="fr-grid-row">Votre convention signée a déjà été déposée</div>
                         {% endif %}
@@ -33,29 +33,31 @@
                 </div>
                 {% include "conventions/avenant_list.html" with conventions=avenants %}
             </div>
-            <div class="fr-col-12 fr-mb-4w">
-                <div role="alert" class="fr-alert fr-alert--info  fr-icon-arrow-right-s-line-double">
-                    <p class="fr-alert__title">
-                        Créer un avenant
-                    </p>
-                    <p>Votre projet a évolué. Vous avez identifié des informations erronées ou caduques ?</p>
-                    <div class="block--row-strech">
-                        {% if convention|display_create_avenant %}
-                            <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
-                                <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
+            {% if not convention.is_avenant %}
+                <div class="fr-col-12 fr-mb-4w">
+                    <div role="alert" class="fr-alert fr-alert--info  fr-icon-arrow-right-s-line-double">
+                        <p class="fr-alert__title">
+                            Créer un avenant
+                        </p>
+                        <p>Votre projet a évolué. Vous avez identifié des informations erronées ou caduques ?</p>
+                        <div class="block--row-strech">
+                            {% if convention|display_create_avenant %}
+                                <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
+                                    <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
+                                </a>
+                            {% else %}
+                                <button class="fr-btn fr-my-1w fr-mr-2w" disabled>
+                                    <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Un avenant est déjà en cours.
+                                </button>
+                            {% endif %}
+                            <a class="fr-my-1w fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
+                                Consulter le récapitulatif
                             </a>
-                        {% else %}
-                            <button class="fr-btn fr-my-1w fr-mr-2w" disabled>
-                                <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Un avenant est déjà en cours.
-                            </button>
-                        {% endif %}
-                        <a class="fr-my-1w fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
-                            Consulter le récapitulatif
-                        </a>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <hr>
+                <hr>
+            {% endif %}
             <div class="fr-col-12">
                 <div class="fr-mb-2w block--row-strech">
                     <div class="block--row-strech-1 fr-my-2w">
@@ -80,10 +82,10 @@
                     <div class="fr-mb-2w block--row-strech">
                         <div class="block--row-strech-1 fr-my-2w">
                             <p class="fr-alert__title">
-                                Déposer à nouveau la convention
+                                Déposer à nouveau {% if convention.is_avenant %}l'avenant{% else %}la convention{% endif %}
                             </p>
                             <p class="fr-mb-0">
-                                Si nécessaire, vous pouvez déposer une nouvelle version de la convention signée ici.
+                                Si nécessaire, vous pouvez déposer une nouvelle version de {% if convention.is_avenant %}l'avenant signé{% else %}la convention signée{% endif %} ici.
                             </p>
                         </div>
                         <form method="post" action="{% url 'conventions:sent' convention_uuid=convention.uuid %}" enctype="multipart/form-data" id="{{upform.file.id_for_label}}_form">
@@ -97,7 +99,7 @@
                             <div class="block--row-strech">
                                 <div>
                                     <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button">
-                                        Déposer la convention signée
+                                        Déposer {% if convention.is_avenant %}l'avenant signé{% else %}la convention signée{% endif %}
                                     </button>
                                     {% for error in upform.file.errors %}
                                         <p id="text-input-error-desc-error" class="fr-error-text">
@@ -147,9 +149,9 @@
                     <div class="fr-mb-5w">
                         <div class="fr-my-2w">
                             <p class="fr-alert__title">
-                                Résiliation/dénonciation de la convention
+                                Résiliation/dénonciation de {% if convention.is_avenant %}l'avenant{% else %}la convention{% endif %}
                             </p>
-                            <p class="fr-mb-2w">Vous pouvez ici procéder à la résiliation/dénonciation de la convention dans APiLos.</p>
+                            <p class="fr-mb-2w">Vous pouvez ici procéder à la résiliation/dénonciation de {% if convention.is_avenant %}l'avenant{% else %}la convention{% endif %} dans APiLos.</p>
 
                             <form method="post" action="" id="{{resiliation_form.date_resiliation.id_for_label}}_validation_form">
                                 {% csrf_token %}
@@ -161,7 +163,7 @@
                                     </div>
 
                                     <button class="fr-btn apilos-btn--secondary--red fr-btn--icon-left fr-icon-delete-line fr-my-2w" data-fr-opened="false" type="button" aria-controls="fr-modal-resiliate-{{convention.uuid}}">
-                                        Résilier/Dénoncer la convention
+                                        Résilier/Dénoncer {% if convention.is_avenant %}l'avenant{% else %}la convention{% endif %}
                                     </button>
                                 </div>
                             </form>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -33,31 +33,29 @@
                 </div>
                 {% include "conventions/avenant_list.html" with conventions=avenants %}
             </div>
-            {% if not convention.is_avenant %}
-                <div class="fr-col-12 fr-mb-4w">
-                    <div role="alert" class="fr-alert fr-alert--info  fr-icon-arrow-right-s-line-double">
-                        <p class="fr-alert__title">
-                            Créer un avenant
-                        </p>
-                        <p>Votre projet a évolué. Vous avez identifié des informations erronées ou caduques ?</p>
-                        <div class="block--row-strech">
-                            {% if convention|display_create_avenant %}
-                                <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
-                                    <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un avenant
-                                </a>
-                            {% else %}
-                                <button class="fr-btn fr-my-1w fr-mr-2w" disabled>
-                                    <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Un avenant est déjà en cours.
-                                </button>
-                            {% endif %}
-                            <a class="fr-my-1w fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
-                                Consulter le récapitulatif
+            <div class="fr-col-12 fr-mb-4w">
+                <div role="alert" class="fr-alert fr-alert--info  fr-icon-arrow-right-s-line-double">
+                    <p class="fr-alert__title">
+                        Créer un {% if convention.is_avenant %}autre {% endif %}avenant
+                    </p>
+                    <p>Votre projet a évolué. Vous avez identifié des informations erronées ou caduques ?</p>
+                    <div class="block--row-strech">
+                        {% if convention.is_avenant and convention.parent|display_create_avenant or not convention.is_avenant and convention|display_create_avenant %}
+                            <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
+                                <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un {% if convention.is_avenant %}autre {% endif %}avenant
                             </a>
-                        </div>
+                        {% else %}
+                            <button class="fr-btn fr-my-1w fr-mr-2w" disabled>
+                                <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Un avenant est déjà en cours.
+                            </button>
+                        {% endif %}
+                        <a class="fr-my-1w fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
+                            Consulter le récapitulatif
+                        </a>
                     </div>
                 </div>
-                <hr>
-            {% endif %}
+            </div>
+            <hr>
             <div class="fr-col-12">
                 <div class="fr-mb-2w block--row-strech">
                     <div class="block--row-strech-1 fr-my-2w">


### PR DESCRIPTION
pour masquer des actions pas cohérentes , notamment la possibilité de créer un avenant d'avenant
pour mettre à jour le texte qui parlait de convention et non d'avenant
pour améliorer l'intégration de la liste des avenants