### PR TITLE
force nature_logement when get_or_create programme

### DIFF
--- a/siap/siap_client/tests/test_siap_client_utils.py
+++ b/siap/siap_client/tests/test_siap_client_utils.py
@@ -1,8 +1,11 @@
 from django.test import TestCase
-from siap.siap_client import utils
+
 from bailleurs.models import Bailleur
+from core.exceptions.types import InconsistentDataSIAPException
 from core.tests import utils_fixtures
 from instructeurs.models import Administration
+from programmes.models.choices import NatureLogement, TypeOperation
+from siap.siap_client import utils
 
 
 class GetAddressFromLocdataTest(TestCase):
@@ -47,7 +50,6 @@ class GetAddressFromLocdataTest(TestCase):
         self.assertEqual(ville, "Vile-sur-fake ok")
 
     def test__get_address_from_locdata_adresse_fallback(self):
-
         adresse, code_postal, ville = utils._get_address_from_locdata(
             {"adresse": "Lorem ipsum dolor sit amet, consectetur adipiscing elit."}
         )
@@ -65,38 +67,62 @@ class GetAddressFromLocdataTest(TestCase):
 
 
 class GetOrCreateProgrammeTest(TestCase):
+    data_from_siap = {
+        "donneesLocalisation": {
+            "region": {"codeInsee": "93", "libelle": None},
+            "departement": {"codeInsee": "13", "libelle": None},
+            "commune": {"codeInsee": "13001", "libelle": "Aix-en-Provence"},
+            "adresse": "10 Avenue du General Koenig 13100 Aix-en-Provence",
+            "adresseComplete": {
+                "adresse": "10 Avenue du General Koenig ",
+                "codePostal": "13100",
+                "commune": "Aix-en-Provence",
+                "codePostalCommune": "13100 Aix-en-Provence",
+            },
+            "zonage123": "02",
+            "zonageABC": "A",
+        },
+        "donneesOperation": {
+            "nomOperation": "Sans travaux 2022-10-07",
+            "numeroOperation": "20221000003",
+            "aides": [],
+            "sousNatureOperation": None,
+            "typeConstruction": None,
+            "natureLogement": None,
+            "sansTravaux": False,
+        },
+    }
+
     def setUp(self):
         utils_fixtures.create_administrations()
         utils_fixtures.create_bailleurs()
 
-    # Test model User
     def test_get_or_create(self):
-        data_from_siap = {
-            "donneesLocalisation": {
-                "region": {"codeInsee": "93", "libelle": None},
-                "departement": {"codeInsee": "13", "libelle": None},
-                "commune": {"codeInsee": "13001", "libelle": "Aix-en-Provence"},
-                "adresse": "10 Avenue du General Koenig 13100 Aix-en-Provence",
-                "adresseComplete": {
-                    "adresse": "10 Avenue du General Koenig ",
-                    "codePostal": "13100",
-                    "commune": "Aix-en-Provence",
-                    "codePostalCommune": "13100 Aix-en-Provence",
-                },
-                "zonage123": "02",
-                "zonageABC": "A",
-            },
-            "donneesOperation": {
-                "nomOperation": "Sans travaux 2022-10-07",
-                "numeroOperation": "20221000003",
-                "aides": [],
-                "sousNatureOperation": None,
-                "typeConstruction": None,
-                "natureLogement": None,
-                "sansTravaux": True,
-            },
-        }
+        self.data_from_siap["donneesOperation"]["natureLogement"] = "LOO"
         programme = utils.get_or_create_programme(
-            data_from_siap, Bailleur.objects.first(), Administration.objects.first()
+            self.data_from_siap,
+            Bailleur.objects.first(),
+            Administration.objects.first(),
         )
         self.assertTrue(programme.uuid)
+        self.assertEqual(programme.nature_logement, NatureLogement.LOGEMENTSORDINAIRES)
+
+    def test_get_or_create_sans_travaux(self):
+        self.data_from_siap["donneesOperation"]["sansTravaux"] = True
+        programme = utils.get_or_create_programme(
+            self.data_from_siap,
+            Bailleur.objects.first(),
+            Administration.objects.first(),
+        )
+        self.assertTrue(programme.uuid)
+        self.assertEqual(programme.type_operation, TypeOperation.SANSTRAVAUX)
+
+    def test_get_or_create_failed(self):
+        self.data_from_siap["donneesOperation"]["natureLogement"] = None
+        self.assertRaises(
+            InconsistentDataSIAPException,
+            utils.get_or_create_programme,
+            self.data_from_siap,
+            Bailleur.objects.first(),
+            Administration.objects.first(),
+        )

--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -308,7 +308,7 @@ def _nature_logement(nature_logement_from_siap: str) -> TypeOperation:
     elif nature_logement_from_siap in ["LOO", NatureLogement.LOGEMENTSORDINAIRES]:
         nature_logement = NatureLogement.LOGEMENTSORDINAIRES
     else:
-        raise InconsistentDataSIAPException("Missing NatureLogement")
+        raise InconsistentDataSIAPException(f"The NatureLogement value coming from SIAP is missing or unexpected : {nature_logement_from_siap}")
     return nature_logement
 
 

--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -156,12 +156,12 @@ def _get_address_from_locdata(loc_data: dict) -> Tuple[str]:
 def get_or_create_programme(
     programme_from_siap: dict, bailleur: Bailleur, administration: Administration
 ) -> Programme:
+    nature_logement = NatureLogement.LOGEMENTSORDINAIRES
     if (
         "sansTravaux" in programme_from_siap["donneesOperation"]
         and programme_from_siap["donneesOperation"]["sansTravaux"]
     ):
         type_operation = TypeOperation.SANSTRAVAUX
-        nature_logement = NatureLogement.LOGEMENTSORDINAIRES
     else:
         type_operation = _type_operation(
             programme_from_siap["donneesOperation"]["sousNatureOperation"]
@@ -197,13 +197,12 @@ def get_or_create_programme(
             "nature_logement": nature_logement,
         },
     )
-    # force type opération = sans travaux
-    if (
-        type_operation == TypeOperation.SANSTRAVAUX
-        and programme.type_operation != TypeOperation.SANSTRAVAUX
-    ):
+    # force nature_logement
+    programme.nature_logement = nature_logement
+    # force type operation if it is sans travaux
+    if type_operation == TypeOperation.SANSTRAVAUX:
         programme.type_operation = TypeOperation.SANSTRAVAUX
-        programme.save()
+    programme.save()
     return programme
 
 
@@ -292,21 +291,24 @@ def _type_operation(type_operation_from_siap: str) -> TypeOperation:
 
 
 def _nature_logement(nature_logement_from_siap: str) -> TypeOperation:
-    nature_logement = NatureLogement.LOGEMENTSORDINAIRES
     if nature_logement_from_siap in ["ALF", NatureLogement.AUTRE]:
         nature_logement = NatureLogement.AUTRE
-    if nature_logement_from_siap in ["HEB", NatureLogement.HEBERGEMENT]:
+    elif nature_logement_from_siap in ["HEB", NatureLogement.HEBERGEMENT]:
         nature_logement = NatureLogement.HEBERGEMENT
-    if nature_logement_from_siap in ["RES", NatureLogement.RESISDENCESOCIALE]:
+    elif nature_logement_from_siap in ["RES", NatureLogement.RESISDENCESOCIALE]:
         nature_logement = NatureLogement.RESISDENCESOCIALE
-    if nature_logement_from_siap in ["PEF", NatureLogement.PENSIONSDEFAMILLE]:
+    elif nature_logement_from_siap in ["PEF", NatureLogement.PENSIONSDEFAMILLE]:
         nature_logement = NatureLogement.PENSIONSDEFAMILLE
-    if nature_logement_from_siap in ["REA", NatureLogement.RESIDENCEDACCUEIL]:
+    elif nature_logement_from_siap in ["REA", NatureLogement.RESIDENCEDACCUEIL]:
         nature_logement = NatureLogement.RESIDENCEDACCUEIL
-    if nature_logement_from_siap in ["REU", NatureLogement.RESIDENCEUNIVERSITAIRE]:
+    elif nature_logement_from_siap in ["REU", NatureLogement.RESIDENCEUNIVERSITAIRE]:
         nature_logement = NatureLogement.RESIDENCEUNIVERSITAIRE
-    if nature_logement_from_siap in ["RHVS", NatureLogement.RHVS]:
+    elif nature_logement_from_siap in ["RHVS", NatureLogement.RHVS]:
         nature_logement = NatureLogement.RHVS
+    elif nature_logement_from_siap in ["LOO", NatureLogement.LOGEMENTSORDINAIRES]:
+        nature_logement = NatureLogement.LOGEMENTSORDINAIRES
+    else:
+        raise InconsistentDataSIAPException("Missing NatureLogement")
     return nature_logement
 
 

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -1,10 +1,10 @@
 from django.db.models.functions import Substr
 from django.test import TestCase
-from bailleurs.models import Bailleur
 
 from apilos_settings.models import Departement
-from instructeurs.models import Administration
+from bailleurs.models import Bailleur
 from conventions.models import Convention, ConventionStatut
+from instructeurs.models import Administration
 from programmes.models import Programme
 from users.models import User
 
@@ -46,7 +46,7 @@ class AdministrationsModelsTest(TestCase):
                 user_instructeur.has_perm(perm, user_instructeur)
                 self.fail(
                     f"has_perm '{perm}' "
-                    + "with non convention object shold raise an Exception"
+                    + "with non convention object should raise an Exception"
                 )
             except Exception:
                 pass

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -46,7 +46,7 @@ class AdministrationsModelsTest(TestCase):
                 user_instructeur.has_perm(perm, user_instructeur)
                 self.fail(
                     f"has_perm '{perm}' "
-                    + "with non convention object should raise an Exception"
+                    "with non convention object should raise an Exception"
                 )
             except Exception:
                 pass


### PR DESCRIPTION
Quand le programme existe déjà en base de donnée via un import Galion et qu'il n'a pas la même nature que le programme sur le SIAP, la nature du programme de l'import galion est conservé.

Pour résoudre le pb quand l'utilisateur vient du SIAP, on force la nature des loogements
Si la nature des logements n'est pas correctement transmise par le SIAP, on lève une erreur