### PR TITLE
Fix pylint config so that it knows pythonpath locally

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,8 @@
 [MASTER]
+# Cf https://stackoverflow.com/a/39207275
+# Pylint needs to be aware of the modules' parent directories to be able to load them
+init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"
 load-plugins=pylint_django
-django-settings-module=core.settings
 ignore-paths=
     core/settings.py,
     bailleurs/migrations,

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -10,3 +10,4 @@ djhtml
 pre-commit
 ptpython
 pylint
+pylint-django

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -255,6 +255,20 @@ pylint==2.15.5 \
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
+    #   pylint-django
+    #   pylint-plugin-utils
+pylint-django==2.5.3 \
+    --hash=sha256:0ac090d106c62fe33782a1d01bda1610b761bb1c9bf5035ced9d5f23a13d8591 \
+    --hash=sha256:56b12b6adf56d548412445bd35483034394a1a94901c3f8571980a13882299d5
+    # via
+    #   -c requirements.txt
+    #   -r dev-requirements.in
+pylint-plugin-utils==0.7 \
+    --hash=sha256:b3d43e85ab74c4f48bb46ae4ce771e39c3a20f8b3d56982ab17aa73b4f98d535 \
+    --hash=sha256:ce48bc0516ae9415dd5c752c940dfe601b18fe0f48aa249f2386adfa95a004dd
+    # via
+    #   -c requirements.txt
+    #   pylint-django
 pyyaml==6.0 \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \


### PR DESCRIPTION
* add init-hook to pylint config 
* add pylint-django dependency 

---
 
upgrade consideration : Run `pip install -r dev-requirements.txt` to install pylint-django locally 