### PR TITLE
Add write permissions to the coverage workflow for dependabot (#845)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,14 @@ name: "coverage"
 on:
   - pull_request
 
+
+# Explicitely set permissions to allow Dependabot workflow runs to write in the PR
+# for coverage's reporting.
+# By default, these are read-only when the actions are ran by Dependabot
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#changing-github_token-permissions
+permissions:
+  pull-requests: write
+
 jobs:
   coverage:
     name: Test & Coverage


### PR DESCRIPTION
Fix dependabot coverage report not working  
Ref : 
- https://github.com/orgoro/coverage/issues/259 
- https://github.com/MTES-MCT/apilos/actions/runs/5398219719/jobs/9896520270

---

Dependabot has read-only permissions by default, granted by the `GITHUB_TOKEN`.  
These permissions cause the coverage workflow to fail because it can't write the coverage report in the PR. 
This behaviour can be overridden by explicitly setting these permissions in the workflow definition file. 
  
Note : it has not been ran yet and might need to open a few more permissions. This one is based on a guess that this action only need PR write access to report coverage. 