### PR TITLE
Mise à jour de l'UX/UI de soumission à l'instruction :

### DIFF
--- a/templates/conventions/actions/edit_numero_galion.html
+++ b/templates/conventions/actions/edit_numero_galion.html
@@ -1,5 +1,5 @@
-<button class="fr-link fr-text--xs" data-fr-opened="false" type="button" aria-controls="fr-modal-update-programme-number">
-    editer le numéro de décision
+<button class="fr-btn fr-btn--secondary" data-fr-opened="false" type="button" aria-controls="fr-modal-update-programme-number">
+    Éditer le numéro de décision
 </button>
 
 {% if programmeNumberForm.errors %}

--- a/templates/conventions/actions/submit_convention.html
+++ b/templates/conventions/actions/submit_convention.html
@@ -27,7 +27,7 @@
                 <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
                     {% csrf_token %}
                     <button name="SubmitConvention" value=True class="fr-btn fr-my-3w" {% if not numero_galion %}disabled{% endif %}>
-                        {% if not numero_galion %}Veuillez définir le numéro d'opération avant de {% endif %}Soumettre au service instructeur
+                        {% if not numero_galion %}Veuillez définir le numéro d'opération avant de soumettre{% else %}Soumettre{% endif %} au service instructeur
                     </button>
                 </form>
             {% endwith %}

--- a/templates/conventions/actions/submit_convention.html
+++ b/templates/conventions/actions/submit_convention.html
@@ -14,15 +14,20 @@
             </p>
             {% with numero_galion=convention.programme.numero_galion %}
                 {% if not numero_galion %}
-                    <div>
-                        <em>le numero d'opération n'est pas défini pour l'opération de cette convention. Merci de le renseigner avant de continuer</em>
+                    <div class="fr-grid-row fr-my-2w">
+                        <div class="fr-icon-warning-line fr-mr-2w"></div>
+                        <div class="fr-col-11">
+                            <div class="fr-mb-2w">
+                                <strong>Le numéro d'opération n'est pas défini pour l'opération de cette convention. Merci de le renseigner avant de continuer.</strong>
+                            </div>
+                            {% include "conventions/actions/edit_numero_galion.html" %}
+                        </div>
                     </div>
-                    {% include "conventions/actions/edit_numero_galion.html" %}
                 {% endif %}
                 <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
                     {% csrf_token %}
                     <button name="SubmitConvention" value=True class="fr-btn fr-my-3w" {% if not numero_galion %}disabled{% endif %}>
-                        Soumettre au service instructeur
+                        {% if not numero_galion %}Veuillez définir le numéro d'opération avant de {% endif %}Soumettre au service instructeur
                     </button>
                 </form>
             {% endwith %}


### PR DESCRIPTION
Dans le cas où on n'a pas de numéro d'opération, il est nécessaire clarifier l'obligation de reporter le numéro d'opération avant de pouvoir soumettre l'avenant ou la convention à l'instruction

cf ticket https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recOG728sUi4uVKIt?blocks=hide

**AVANT**

![image](https://github.com/MTES-MCT/apilos/assets/19302155/51dd566f-b091-4752-9581-c98ffd736729)


**APRES**

![image](https://github.com/MTES-MCT/apilos/assets/19302155/4c247306-6039-42d4-91fb-b240bd075b34)
