### PR TITLE
Ensure slash do not break programme urls

### DIFF
--- a/programmes/urls.py
+++ b/programmes/urls.py
@@ -3,6 +3,8 @@ from . import views
 
 urlpatterns = [
     path(
-        "<numero_operation>", views.operation_conventions, name="operation_conventions"
+        "<path:numero_operation>",
+        views.operation_conventions,
+        name="operation_conventions",
     ),
 ]


### PR DESCRIPTION
ref https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwhG4jAQK4JhrSZz/recS0HmsyoSnYtAAV?blocks=hide 

Testé en local 
1. Hardcoder `coucou/youpi` dans une url de programme 
1. Exemple   
```jinja
<a href="{% url 'programmes:operation_conventions' numero_operation='coucou/youpi' %}">
  Opération n°{{convention.programme.numero_galion}}
</a>&nbsp;-&nbsp;
```
3. Résultat : plus d'erreur 🥳 