### PR TITLE
fix order by name of the administration

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -485,7 +485,7 @@ def get_available_order_fields(request, url_name=None):
     if is_instructeur(request):
         order_fields = order_fields | {"programme__bailleur__nom": "Bailleur"}
     if display_administration(request):
-        order_fields = order_fields | {"administration__nom": "Instructeur"}
+        order_fields = order_fields | {"programme__administration__nom": "Instructeur"}
     if url_name == "search_instruction":
         order_fields = order_fields | {"programme__nom": "Opération"}
     else:

--- a/conventions/tests/custom_filters/test_convention_list_custom_filters.py
+++ b/conventions/tests/custom_filters/test_convention_list_custom_filters.py
@@ -65,7 +65,7 @@ class TestGetAvailableOrderFieldsFilter(TestCase):
                 self.request, "search_instruction"
             ),
             {
-                "administration__nom": "Instructeur",
+                "programme__administration__nom": "Instructeur",
                 "programme__nom": "Opération",
                 "lot__financement": "Financement",
                 "programme__ville": "Ville",
@@ -77,7 +77,7 @@ class TestGetAvailableOrderFieldsFilter(TestCase):
         self.assertEqual(
             custom_filters.get_available_order_fields(self.request, "other_url_name"),
             {
-                "administration__nom": "Instructeur",
+                "programme__administration__nom": "Instructeur",
                 "numero": "Numéro",
                 "lot__financement": "Financement",
                 "programme__ville": "Ville",


### PR DESCRIPTION
Administration belongs to 'programme', we need to tell it the order parameter

cf. https://sentry.incubateur.net/organizations/betagouv/issues/60425/?environment=production&project=29&query=is%3Aunresolved&referrer=issue-stream