### PR TITLE
identifier le bailleur dans les mails

### DIFF
--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -335,7 +335,7 @@ def send_email_instruction(
             else EmailTemplateID.B_CONVENTION_A_INSTRUIRE_CONFIRMATION,
         )
         email_service_to_bailleur.send_transactional_email(
-            email_data={
+            email_data=email_data
                 "convention_url": convention_url,
                 "convention": str(convention),
                 "bailleur": str(bailleur),

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -352,7 +352,7 @@ def send_email_instruction(
             else EmailTemplateID.BtoI_CONVENTION_A_INSTRUIRE,
         )
         email_service_to_instructeur.send_transactional_email(
-            email_data={
+            email_data=email_data
                 "convention_url": convention_url,
                 "convention": str(convention),
                 "bailleur": str(bailleur),

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -255,7 +255,6 @@ def convention_submit(request: HttpRequest, convention: Convention):
                 reverse("conventions:recapitulatif", args=[convention.uuid])
             ),
             convention,
-            convention.bailleur.nom,
             request.user,
             instructeur_emails,
         )
@@ -312,12 +311,12 @@ def collect_instructeur_emails(
 
 
 def send_email_instruction(
-    convention_url, convention, bailleur, user, instructeur_emails
+    convention_url, convention, user, instructeur_emails
 ):
   email_data = {
     "convention_url": convention_url,
     "convention": str(convention),
-    "bailleur": str(bailleur),
+    "bailleur": str(convention.bailleur.nom),
     "user": str(user),
   }
     """
@@ -338,7 +337,7 @@ def send_email_instruction(
             email_data=email_data
                 "convention_url": convention_url,
                 "convention": str(convention),
-                "bailleur": str(bailleur),
+                "bailleur": str(convention.bailleur.nom),
                 "user": str(user),
             }
         )
@@ -371,7 +370,6 @@ def convention_feedback(request: HttpRequest, convention: Convention):
             ),
             convention,
             request.user,
-            convention.bailleur.nom,
             cc,
             notification_form.cleaned_data["from_instructeur"],
             notification_form.cleaned_data["comment"],
@@ -405,7 +403,6 @@ def send_email_correction(
     convention_url,
     convention,
     user,
-    bailleur,
     cc,
     from_instructeur,
     comment=None,
@@ -446,7 +443,7 @@ def send_email_correction(
                 "convention_url": convention_url,
                 "convention": str(convention),
                 "user": str(user),
-                "bailleur": str(bailleur),
+                "bailleur": str(convention.bailleur.nom),
                 "commentaire": comment,
             },
         )

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -310,21 +310,19 @@ def collect_instructeur_emails(
     return instructeur_emails, submitted
 
 
-def send_email_instruction(
-    convention_url, convention, user, instructeur_emails
-):
-  email_data = {
-    "convention_url": convention_url,
-    "convention": str(convention),
-    "bailleur": str(convention.bailleur.nom),
-    "user": str(user),
-  }
+def send_email_instruction(convention_url, convention, user, instructeur_emails):
     """
     Send email "convention à instruire" when bailleur submit the convention
     Send an email to the bailleur who click and bailleur TOUS
     Send an email to all instructeur (except the ones who select AUCUN as email preference)
     """
     # Send a confirmation email to bailleur
+    email_data = {
+        "convention_url": convention_url,
+        "convention": str(convention),
+        "bailleur": str(convention.bailleur.nom),
+        "user": str(user),
+    }
 
     if len(destinataires_bailleur := convention.get_email_bailleur_users()) > 0:
         email_service_to_bailleur = EmailService(
@@ -333,14 +331,7 @@ def send_email_instruction(
             if convention.is_avenant()
             else EmailTemplateID.B_CONVENTION_A_INSTRUIRE_CONFIRMATION,
         )
-        email_service_to_bailleur.send_transactional_email(
-            email_data=email_data
-                "convention_url": convention_url,
-                "convention": str(convention),
-                "bailleur": str(convention.bailleur.nom),
-                "user": str(user),
-            }
-        )
+        email_service_to_bailleur.send_transactional_email(email_data=email_data)
 
     # Send a notification email to instructeur
     if len(instructeur_emails) > 0:
@@ -350,14 +341,7 @@ def send_email_instruction(
             if convention.is_avenant()
             else EmailTemplateID.BtoI_CONVENTION_A_INSTRUIRE,
         )
-        email_service_to_instructeur.send_transactional_email(
-            email_data=email_data
-                "convention_url": convention_url,
-                "convention": str(convention),
-                "bailleur": str(bailleur),
-                "user": str(user),
-            },
-        )
+        email_service_to_instructeur.send_transactional_email(email_data=email_data)
 
 
 def convention_feedback(request: HttpRequest, convention: Convention):

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -314,6 +314,12 @@ def collect_instructeur_emails(
 def send_email_instruction(
     convention_url, convention, bailleur, user, instructeur_emails
 ):
+  email_data = {
+    "convention_url": convention_url,
+    "convention": str(convention),
+    "bailleur": str(bailleur),
+    "user": str(user),
+  }
     """
     Send email "convention à instruire" when bailleur submit the convention
     Send an email to the bailleur who click and bailleur TOUS

--- a/core/services.py
+++ b/core/services.py
@@ -22,13 +22,13 @@ class EmailTemplateID(enum.Enum):
     # [PLATEFORME] BAILLEURS - Bienvenu sur la plateforme APiLos
     B_WELCOME = 84
     # [PLATEFORME] BAILLEUR à INSTRUCTEUR - Avenant à instruire
-    BtoI_AVENANT_A_INSTRUIRE = 98
+    BtoI_AVENANT_A_INSTRUIRE = 167
     # [PLATEFORME] BAILLEUR à INSTRUCTEUR - Convention à instruire
-    BtoI_CONVENTION_A_INSTRUIRE = 97
+    BtoI_CONVENTION_A_INSTRUIRE = 166
     # [PLATEFORME] BAILLEUR à INSTRUCTEUR - Corrections faites - avenant à instruire à nouveau
-    BtoI_AVENANT_CORRECTIONS_FAITES = 100
+    BtoI_AVENANT_CORRECTIONS_FAITES = 169
     # [PLATEFORME] BAILLEUR à INSTRUCTEUR - Corrections faites - convention à instruire à nouveau
-    BtoI_CONVENTION_CORRECTIONS_FAITES = 99
+    BtoI_CONVENTION_CORRECTIONS_FAITES = 168
     # [PLATEFORME] INSTRUCTEUR - Bienvenu sur la plateforme APiLos
     I_WELCOME = 96
     # [PLATEFORME] INSTRUCTEUR à BAILLEUR - Avenant validé


### PR DESCRIPTION
Ajout du nom du user et du bailleur dans les mails à destination de l'instructeur.trice : 
ticket S447: Identifier rapidement le nom de l'organisation du bailleur, ainsi que la personne en charge de la convention chez le bailleur, dans le mail automatique reçu par APiLos lors de la réception d'un projet de convention

Exemples de rendu : 

![image](https://github.com/MTES-MCT/apilos/assets/19302155/0a26198f-5eb6-49e7-aa7e-bc3e18750fd8)


![image](https://github.com/MTES-MCT/apilos/assets/19302155/87f65668-0273-4317-b9e9-08103d96d393)
