### PR TITLE
Revert "Bump python-docx from 0.8.11 to 1.0.0 (#992)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -548,8 +548,8 @@ python-decouple==3.8 \
     --hash=sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f \
     --hash=sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66
     # via -r requirements.in
-python-docx==1.0.0 \
-    --hash=sha256:496e729ffcf5fc3cf85676f402cedfc48e68475f10a94edfbd06dde2da67ce76
+python-docx==0.8.11 \
+    --hash=sha256:1105d233a0956dd8dd1e710d20b159e2d72ac3c301041b95f4d4ceb3e0ebebc4
     # via
     #   -r requirements.in
     #   docxcompose
@@ -661,7 +661,6 @@ typing-extensions==4.8.0 \
     # via
     #   -r requirements.in
     #   dj-database-url
-    #   python-docx
 tzdata==2023.3 \
     --hash=sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a \
     --hash=sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda


### PR DESCRIPTION
This reverts commit fd8f49bf1fe011bf9aa8396996b963793edbbfa0.