### PR TITLE
Add environment variable for DATA_UPLOAD_MAX_NUMBER_FIELDS

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -564,7 +564,9 @@ CELERY_ACKS_LATE = True
 CELERY_WORKER_MAX_TASKS_PER_CHILD = 5000
 
 # limit reach when an operation has 167 logements
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+DATA_UPLOAD_MAX_NUMBER_FIELDS = int(
+    get_env_variable("DATA_UPLOAD_MAX_NUMBER_FIELDS", default="100000")
+)
 
 # ClamAV configuration
 CLAMAV_SERVICE_URL = get_env_variable("CLAMAV_SERVICE_URL", default=None)


### PR DESCRIPTION
- ajout d'une variable d'env permettant de personnaliser DATA_UPLOAD_MAX_NUMBER_FIELDS 

cf 
> Sur l'avenant rue du [Valibout](https://apilos.beta.gouv.fr/conventions/avenant_logements/211e7ec0-070d-4f8d-9511-10e77676dfa3) dés que je dépose le fichier des logements j'ai une erreur "bad request" (16/10 à 16h12) mais je ne sais pas pourquoi ni à quoi c'est du.