### PR TITLE
display user only once even with multiple habilitations on entity

### DIFF
--- a/apilos_settings/services/services_view.py
+++ b/apilos_settings/services/services_view.py
@@ -186,7 +186,9 @@ def edit_administration(request, administration_uuid):
         search_input=request.GET.get("search_input", ""),
         order_by=request.GET.get("order_by", "username"),
         page=request.GET.get("page", 1),
-        my_user_list=User.objects.filter(roles__in=administration.roles.all()),
+        my_user_list=User.objects.filter(
+            roles__in=administration.roles.all()
+        ).distinct(),
     )
     user_list_service.paginate()
 
@@ -290,7 +292,7 @@ def edit_bailleur(request, bailleur_uuid):
         search_input=request.GET.get("search_input", ""),
         order_by=request.GET.get("order_by", "username"),
         page=request.GET.get("page", 1),
-        my_user_list=User.objects.filter(roles__in=bailleur.roles.all()),
+        my_user_list=User.objects.filter(roles__in=bailleur.roles.all()).distinct(),
     )
     user_list_service.paginate()
 


### PR DESCRIPTION
when display users of bailleur or administration, they are displayed more than once when they have multiple habilitation for the same entity : 

![CleanShot 2023-10-17 at 08 37 16@2x](https://github.com/MTES-MCT/apilos/assets/454431/a5902ff0-0a6e-4b9c-9d01-00fd85aa8a13)

This PR will display user only once in that list