### PR TITLE
Allow next and save button to be outside the form it targets

### DIFF
--- a/conventions/forms/convention_form_administration.py
+++ b/conventions/forms/convention_form_administration.py
@@ -1,9 +1,10 @@
 from django import forms
 from django.core.validators import RegexValidator
+
 from instructeurs.models import Administration
 
 
-class UpdateConventionAdministrationForm(forms.Form):
+class ChangeAdministrationForm(forms.Form):
     def __init__(self, *args, **kwargs):
         administrations_queryset = kwargs.pop("administrations_queryset")
         super().__init__(*args, **kwargs)

--- a/conventions/services/bailleurs.py
+++ b/conventions/services/bailleurs.py
@@ -16,6 +16,7 @@ class ConventionBailleurService(ConventionService):
     extra_forms: dict[
         str, ChangeBailleurForm | UpdateConventionAdministrationForm | None
     ] = {"bailleur_form": None, "administration_form": None}
+    upform: ChangeBailleurForm | None
 
     def should_add_sirens(self, habilitation):
         if (
@@ -57,6 +58,8 @@ class ConventionBailleurService(ConventionService):
             administrations_queryset=self.request.user.administrations(),
             initial={"administration": self.convention.administration},
         )
+        self.upform = self.extra_forms["bailleur_form"]
+
         self.form = ConventionBailleurForm(
             initial={
                 "uuid": bailleur.uuid,

--- a/conventions/services/cadastre.py
+++ b/conventions/services/cadastre.py
@@ -1,18 +1,14 @@
 from django.http import HttpRequest
 
-from conventions.services.conventions import ConventionService
-from conventions.services import utils, upload_objects
-from conventions.models import Convention
 from conventions.forms import (
-    UploadForm,
     ProgrammeCadastralForm,
     ReferenceCadastraleFormSet,
+    UploadForm,
 )
+from conventions.models import Convention
+from conventions.services import upload_objects, utils
+from conventions.services.conventions import ConventionService
 from programmes.models import ReferenceCadastrale
-
-
-def _get_choices_from_object(object_list):
-    return [(instance.uuid, str(instance)) for instance in object_list]
 
 
 class ConventionCadastreService(ConventionService):
@@ -239,7 +235,6 @@ class ConventionCadastreService(ConventionService):
             self.return_status = utils.ReturnStatus.SUCCESS
 
     def _save_programme_cadastrale(self):
-
         for field in [
             "permis_construire",
             "date_acte_notarie",

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import List
+
 from django.forms import Form
 
 from conventions.forms import UploadForm
@@ -21,7 +22,7 @@ class ConventionService(ABC):
     editable_after_upload: bool = False
     form: Form | None = None
     formset = None
-    upform: Form | None
+    upform: Form | None = None
     extra_forms: dict[str, Form | None] | None = None
 
     def __init__(

--- a/conventions/views/convention_form.py
+++ b/conventions/views/convention_form.py
@@ -365,6 +365,7 @@ class ConventionView(ABC, BaseConventionView):
                 **({"form": service.form} if service.form else {}),
                 **({"extra_forms": service.extra_forms} if service.extra_forms else {}),
                 **({"formset": service.formset} if service.formset else {}),
+                "upform": service.upform,  # obsolète, pourra être supprimé après rédaction de tests unitaires sur extra_forms
                 "form_step": self.steps.get_form_step(),
                 "editable_after_upload": (
                     editable_convention(request, self.convention)

--- a/conventions/views/convention_form_bailleur.py
+++ b/conventions/views/convention_form_bailleur.py
@@ -12,8 +12,8 @@ class ConventionBailleurView(ConventionView):
         if bool(self.request.POST.get("change_bailleur")):
             self.service.change_bailleur()
         elif bool(self.request.POST.get("change_administration")):
-            self.redirect_on_success = "conventions:search_instruction"
             self.service.change_administration()
+            self.redirect_on_success = "conventions:search_instruction"
         else:
             self.service.update_bailleur()
 

--- a/templates/common/button/next_and_save.html
+++ b/templates/common/button/next_and_save.html
@@ -1,3 +1,3 @@
-<button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right">
+<button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right" {% if targetted_form %}form="{{ targetted_form }}"{% endif %}>
     Enregistrer et Suivant
 </button>

--- a/templates/conventions/_bailleur_administration.html
+++ b/templates/conventions/_bailleur_administration.html
@@ -19,26 +19,22 @@
                             cette opération est irréversible et vous fera perdre l'accès à cette convention.
                         </p>
                     </div>
-                    <details {% if form.errors %}open{% endif %} class="fr-mt-3w fr-col-12 fr-col-md-5">
+                    <details {% if form.errors %}open=""{% endif %} class="fr-mt-3w fr-col-12 fr-col-md-5">
                         <summary>
                             <div class="fr-btn fr-mt-auto fr-ml-auto fr-mb-1w">Changer l'administration</div>
                         </summary>
-                        <form method="post" action="">
-                            {{ form.errors }}
-                            {% csrf_token %}
-                            {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
-                                {% url 'users:search_administration' as search_administration_url %}
-                                {% include "common/form/input_search_select.html" with form_input=form.administration url=search_administration_url %}
-                            {% endwith %}
+                        {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
+                            {% url 'users:search_administration' as search_administration_url %}
+                            {% include "common/form/input_search_select.html" with form_input=form.administration url=search_administration_url %}
+                        {% endwith %}
 
-                            <button
-                                name="change_administration"
-                                value="True"
-                                class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-warning-line" type="submit"
-                            >
-                                Valider le changement d'administration
-                            </button>
-                        </form>
+                        <button
+                            name="change_administration"
+                            value="True"
+                            class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-warning-line" type="submit"
+                        >
+                            Valider le changement d'administration
+                        </button>
                     </details>
                 </div>
             </div>

--- a/templates/conventions/_bailleur_entreprise.html
+++ b/templates/conventions/_bailleur_entreprise.html
@@ -38,14 +38,11 @@
                                 <div class="fr-btn">Changer le bailleur de cette convention et de son opération</div>
                             </summary>
                             <div>
-                                <form method="post" action="">
-                                    {% csrf_token %}
-                                    {% url 'users:search_bailleur' as search_bailleur_url %}
-                                    {% include "common/form/input_search_select.html" with form_input=form.bailleur url=search_bailleur_url %}
-                                    <button class="fr-btn" name="change_bailleur" value="True">
-                                        Changer le bailleur
-                                    </button>
-                                </form>
+                                {% url 'users:search_bailleur' as search_bailleur_url %}
+                                {% include "common/form/input_search_select.html" with form_input=form.bailleur url=search_bailleur_url %}
+                                <button class="fr-btn" name="change_bailleur" value="True">
+                                    Changer le bailleur
+                                </button>
                             </div>
                         </details>
                     </div>

--- a/templates/conventions/_bailleur_signataire.html
+++ b/templates/conventions/_bailleur_signataire.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="fr-col-12">
-        <form method="post" action="">
+        <form method="post" action="" id="bailleur_signataire">
             {% csrf_token %}
 
             {% include "common/form/input_text.html" with form_input=form.signataire_nom object_field="bailleur__signataire_nom__"|add:form.uuid.value %}

--- a/templates/conventions/_bailleur_signataire.html
+++ b/templates/conventions/_bailleur_signataire.html
@@ -6,47 +6,43 @@
 
 {% block content %}
     <div class="fr-col-12">
-        <form method="post" action="" id="bailleur_signataire">
-            {% csrf_token %}
+        {% include "common/form/input_text.html" with form_input=form.signataire_nom object_field="bailleur__signataire_nom__"|add:form.uuid.value %}
 
-            {% include "common/form/input_text.html" with form_input=form.signataire_nom object_field="bailleur__signataire_nom__"|add:form.uuid.value %}
-
-            <div class="fr-mb-2w">
-                <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
-                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                        {% include "common/form/input_text.html" with form_input=form.signataire_fonction object_field="bailleur__signataire_fonction__"|add:form.uuid.value %}
-                    </div>
-                    <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
-                        {% include "common/form/input_date.html" with form_input=form.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:form.uuid.value %}
-                    </div>
+        <div class="fr-mb-2w">
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
+                <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
+                    {% include "common/form/input_text.html" with form_input=form.signataire_fonction object_field="bailleur__signataire_fonction__"|add:form.uuid.value %}
+                </div>
+                <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
+                    {% include "common/form/input_date.html" with form_input=form.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:form.uuid.value %}
                 </div>
             </div>
+        </div>
 
-            <div class="fr-mb-2w">
-                {% include "common/form/input_text.html" with form_input=form.signataire_bloc_signature object_field="bailleur__signataire_bloc_signature__"|add:form.uuid.value %}
-            </div>
+        <div class="fr-mb-2w">
+            {% include "common/form/input_text.html" with form_input=form.signataire_bloc_signature object_field="bailleur__signataire_bloc_signature__"|add:form.uuid.value %}
+        </div>
 
-            {% if convention.programme.is_foyer or convention.programme.is_residence %}
-                <h4>Gestionnaire des logments conventionnés</h4>
-                {% with convention_uuid=convention.uuid|slugify %}
+        {% if convention.programme.is_foyer or convention.programme.is_residence %}
+            <h4>Gestionnaire des logments conventionnés</h4>
+            {% with convention_uuid=convention.uuid|slugify %}
 
-                    {% include "common/form/input_text.html" with form_input=form.gestionnaire object_field="convention__gestionnaire__"|add:convention_uuid %}
+                {% include "common/form/input_text.html" with form_input=form.gestionnaire object_field="convention__gestionnaire__"|add:convention_uuid %}
 
-                    {% include "common/form/input_text.html" with form_input=form.gestionnaire_signataire_nom object_field="convention__gestionnaire_signataire_nom__"|add:convention_uuid %}
+                {% include "common/form/input_text.html" with form_input=form.gestionnaire_signataire_nom object_field="convention__gestionnaire_signataire_nom__"|add:convention_uuid %}
 
-                    <div class="fr-mb-2w">
-                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
-                            <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                {% include "common/form/input_text.html" with form_input=form.gestionnaire_signataire_fonction object_field="convention__gestionnaire_signataire_fonction__"|add:convention_uuid %}
-                            </div>
-                            <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
-                                {% include "common/form/input_date.html" with form_input=form.gestionnaire_signataire_date_deliberation object_field="convention__gestionnaire_signataire_date_deliberation__"|add:convention_uuid %}
-                            </div>
+                <div class="fr-mb-2w">
+                    <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
+                        <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
+                            {% include "common/form/input_text.html" with form_input=form.gestionnaire_signataire_fonction object_field="convention__gestionnaire_signataire_fonction__"|add:convention_uuid %}
+                        </div>
+                        <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-pl-md-1w fr-mb-2w">
+                            {% include "common/form/input_date.html" with form_input=form.gestionnaire_signataire_date_deliberation object_field="convention__gestionnaire_signataire_date_deliberation__"|add:convention_uuid %}
                         </div>
                     </div>
-                {% endwith %}
-            {% endif %}
-        </form>
+                </div>
+            {% endwith %}
+        {% endif %}
     </div>
     {% include "common/required_fields_info.html" %}
 {% endblock content %}

--- a/templates/conventions/bailleur.html
+++ b/templates/conventions/bailleur.html
@@ -17,9 +17,12 @@
     {% include "conventions/common/form_header.html"%}
     {% include "common/step_progressbar.html"%}
     <div class="fr-container">
-        {% include "conventions/_bailleur_entreprise.html" %}
-        {% include "conventions/_bailleur_signataire.html" %}
-        {% include "conventions/_bailleur_administration.html" %}
-        {% include "conventions/common/form_footer_button.html" with targetted_form="bailleur_signataire" %}
+        <form method="post" action="">
+            {% csrf_token %}
+            {% include "conventions/_bailleur_entreprise.html" %}
+            {% include "conventions/_bailleur_signataire.html" %}
+            {% include "conventions/_bailleur_administration.html" %}
+            {% include "conventions/common/form_footer_button.html" %}
+        </form>
     </div>
 {% endblock %}

--- a/templates/conventions/bailleur.html
+++ b/templates/conventions/bailleur.html
@@ -20,6 +20,6 @@
         {% include "conventions/_bailleur_entreprise.html" %}
         {% include "conventions/_bailleur_signataire.html" %}
         {% include "conventions/_bailleur_administration.html" %}
-        {% include "conventions/common/form_footer_button.html" %}
+        {% include "conventions/common/form_footer_button.html" with targetted_form="bailleur_signataire" %}
     </div>
 {% endblock %}

--- a/users/models.py
+++ b/users/models.py
@@ -254,6 +254,10 @@ class User(AbstractUser):
         if self.is_superuser:
             return {}
 
+        # instructeur from cerbere has access to all administrations
+        if self.is_cerbere_user() and self.is_instructeur():
+            return {}
+
         # to do : manage programme related to geo for instructeur
         if self.is_instructeur():
             if (administration_ids := self.administration_ids()) is not None:


### PR DESCRIPTION
Suite à la régression du formulaire de modification du bailleur : 
- Ajout d'un paramètre au composant button form (next_and_save), qui permet d'ajouter un attribut sur le bouton pour cibler le formulaire dans la page qui va être soumis au clic sur ce bouton 🥵 
- ajout de l'id sur le formulaire signataire et sur l'include du bouton correspondant
- Rajout de upform dans le contexte pour éviter les régression sur les formulaires d'upload 