### PR TITLE
be able to search by numero_galion for active and and finished conventions

### DIFF
--- a/conventions/services/search.py
+++ b/conventions/services/search.py
@@ -200,6 +200,7 @@ class UserConventionActivesSearchService(UserConventionSearchService):
             self.extra_filters = (
                 Q(programme__nom__icontains=self.search_input)
                 | Q(programme__code_postal__icontains=self.search_input)
+                | Q(programme__numero_galion__icontains=self.search_input)
                 | Q(numero__icontains=self.search_input)
             )
 
@@ -220,5 +221,6 @@ class UserConventionTermineesSearchService(UserConventionSearchService):
             self.extra_filters = (
                 Q(programme__nom__icontains=self.search_input)
                 | Q(programme__code_postal__icontains=self.search_input)
+                | Q(programme__numero_galion__icontains=self.search_input)
                 | Q(numero__icontains=self.search_input)
             )

--- a/conventions/tests/views/test_index_view.py
+++ b/conventions/tests/views/test_index_view.py
@@ -43,7 +43,9 @@ class ConventionIndexViewTests(TestCase):
 
         self.assertEqual(len(galion_refs), 4)
         self.assertEqual(len(financements), 4)
-        self.assertEqual({r.text.strip() for r in galion_refs}, {"12345", "98765"})
+        self.assertEqual(
+            {r.text.strip() for r in galion_refs}, {"Op. : 12345", "Op. : 98765"}
+        )
         self.assertEqual({f.text.strip() for f in financements}, {"PLAI", "PLUS"})
 
     def test_get_list_active_ordered_by_bailleur(self):
@@ -63,7 +65,9 @@ class ConventionIndexViewTests(TestCase):
             attrs={"data-test-role": "programme-financement-cell"}
         )
 
-        self.assertEqual({r.text.strip() for r in galion_refs}, {"12345", "98765"})
+        self.assertEqual(
+            {r.text.strip() for r in galion_refs}, {"Op. : 12345", "Op. : 98765"}
+        )
         self.assertEqual({f.text.strip() for f in financements}, {"PLUS", "PLAI"})
 
     def test_get_tabs_basic(self):

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -125,7 +125,7 @@
 
                         {# Champs "Libre" (code opération / numéro de convention, code postal ou nom du programme) #}
                         <div class="fr-col-12 fr-col-md-12 fr-col-lg-3 fr-mb-2w">
-                            <input class="fr-input" placeholder="{% if active %}Code{% else %}N° convention{% endif %}, programme ou code postal" type="search" id="search_input" name="search_input" value="{{ search_input }}" />
+                            <input class="fr-input" placeholder="Numéro, nom, code postal…" type="search" id="search_input" name="search_input" value="{{ search_input }}" />
                         </div>
 
                         {# Champs ANRU #}
@@ -258,18 +258,14 @@
                                                     <span class="{% if convention.is_denonciation %}warning-notification {% else %}text-title-blue-france {% endif %} fr-p-1w fr-ml-1w apilos-tag-avenant background-white">{{convention|display_kind|capfirst}}</span>
                                                 {% endif %}
                                             </div>
-                                            {% if url_name == "search_instruction" and convention.programme.numero_galion %}
+                                            {% if convention.programme.numero_galion %}
                                                 <em data-test-role="programme-galion-cell">
-                                                    {{convention.programme.numero_galion|highlight:search_input}}
+                                                    Op. : {{convention.programme.numero_galion|highlight:search_input}}
                                                 </em>
                                             {% endif %}
                                             {% if url_name == "search_active" or url_name == "search_resiliees" %}
                                                 {% if convention.numero %}
-                                                    {% if convention.is_avenant %}
-                                                        <em data-test-role="programme-galion-cell">{{convention.parent.numero|highlight:search_input}} - Avenant n°{{convention.numero}}</em>
-                                                    {% else %}
-                                                        <em data-test-role="programme-galion-cell">{{convention.numero|highlight:search_input}}</em>
-                                                    {% endif %}
+                                                    <em data-test-role="programme-galion-cell">Conv. : {{convention.numero|highlight:search_input}}</em>
                                                 {% endif %}
                                             {% endif %}
                                         </td>

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -259,14 +259,18 @@
                                                 {% endif %}
                                             </div>
                                             {% if convention.programme.numero_galion %}
-                                                <em data-test-role="programme-galion-cell">
-                                                    Op. : {{convention.programme.numero_galion|highlight:search_input}}
-                                                </em>
+                                                <div>
+                                                    <em data-test-role="programme-galion-cell">
+                                                        Op. : {{convention.programme.numero_galion|highlight:search_input}}
+                                                    </em>
+                                                </div>
                                             {% endif %}
                                             {% if url_name == "search_active" or url_name == "search_resiliees" %}
-                                                {% if convention.numero %}
-                                                    <em data-test-role="programme-galion-cell">Conv. : {{convention.numero|highlight:search_input}}</em>
-                                                {% endif %}
+                                                <div>
+                                                    {% if convention.numero %}
+                                                        <em data-test-role="programme-galion-cell">Conv. : {{convention.numero|highlight:search_input}}</em>
+                                                    {% endif %}
+                                                </div>
                                             {% endif %}
                                         </td>
                                         <td data-test-role="programme-financement-cell">{{convention.financement}}</td>


### PR DESCRIPTION
Proposition de modification de recherche et d'affichage des listes de convention:
- possibilité de chercher par numéro d'opération dans les listes de conventions actives et terminées
- Affichage du numéro d'opération et du numéro de convention dans les listes de conventions actives et terminées
- suppression de code mort car on n'affiche plus les avenants dans les listes de conventions actives et terminées
  
![CleanShot 2023-11-07 at 11 23 10@2x](https://github.com/MTES-MCT/apilos/assets/454431/324dd435-1901-4070-9f86-80445e947737)

![CleanShot 2023-11-07 at 11 27 53@2x](https://github.com/MTES-MCT/apilos/assets/454431/1245bbf7-6b8f-4ef3-8bed-24c06ce92e7d)
