### PR TITLE
SIAP route to cancel conventions of an operation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -21,4 +21,4 @@ disable=
 min-similarity-lines=20
 max-args = 10
 max-line-length=120
-max-public-methods=30
+max-public-methods=31

--- a/api/siap/v0/urls.py
+++ b/api/siap/v0/urls.py
@@ -5,9 +5,13 @@ from drf_spectacular.views import (
     SpectacularSwaggerSplitView,
 )
 from rest_framework_simplejwt import views as jwt_views
-from apilos_settings.api.api_views import ApilosConfiguration, ConventionKPI
-from programmes.api.operation_api_views import OperationDetails, OperationClosed
 
+from apilos_settings.api.api_views import ApilosConfiguration, ConventionKPI
+from programmes.api.operation_api_views import (
+    OperationCanceled,
+    OperationClosed,
+    OperationDetails,
+)
 
 urlpatterns = [
     # API authentication
@@ -18,9 +22,11 @@ urlpatterns = [
     path("convention_kpi/", ConventionKPI.as_view()),
     # Operation details route
     path("operation/<str:numero_galion>/", OperationDetails.as_view()),
-    # Operation details route
+    # Operation close route
     path("close_operation/<str:numero_galion>/", OperationClosed.as_view()),
-    # DRF spectacula
+    # Opération cancel route
+    path("cancel_operation/<str:numero_galion>/", OperationCanceled.as_view()),
+    # DRF spectacular
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "schema-ui/",

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -32,21 +32,7 @@ class ConventionRecapitulatifService(ConventionService):
         pass
 
     def cancel_convention(self):
-        if self.convention.statut not in [
-            ConventionStatut.PROJET.label,
-            ConventionStatut.INSTRUCTION.label,
-            ConventionStatut.CORRECTION.label,
-        ]:
-            return {}
-        previous_status = self.convention.statut
-        self.convention.statut = ConventionStatut.ANNULEE.label
-        self.convention.save()
-        ConventionHistory.objects.create(
-            convention=self.convention,
-            statut_convention=ConventionStatut.ANNULEE.label,
-            statut_convention_precedent=previous_status,
-            user=self.request.user,
-        ).save()
+        self.convention.cancel(self.request)
         return {}
 
     def reactive_convention(self):

--- a/conventions/tests/services/test_cancel_service.py
+++ b/conventions/tests/services/test_cancel_service.py
@@ -32,6 +32,7 @@ class ConventionCancelServiceTest(TestCase):
                 ConventionStatut.PROJET.label,
                 ConventionStatut.INSTRUCTION.label,
                 ConventionStatut.CORRECTION.label,
+                ConventionStatut.A_SIGNER.label,
             ]:
                 self.convention.statut = statut
                 self.convention.save()
@@ -40,7 +41,6 @@ class ConventionCancelServiceTest(TestCase):
                 self.assertEqual(self.convention.statut, ConventionStatut.ANNULEE.label)
 
             for statut in [
-                ConventionStatut.A_SIGNER.label,
                 ConventionStatut.SIGNEE.label,
                 ConventionStatut.RESILIEE.label,
                 ConventionStatut.DENONCEE.label,

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -36,10 +36,10 @@ from conventions.services.conventions import convention_post_action, convention_
 from conventions.services.file import ConventionFileService
 from conventions.services.recapitulatif import (
     ConventionRecapitulatifService,
+    convention_denonciation_validate,
     convention_feedback,
     convention_submit,
     convention_validate,
-    convention_denonciation_validate,
 )
 from conventions.services.search import (
     UserConventionActivesSearchService,


### PR DESCRIPTION
Creation d'une route post cancel_operation qui annule toutes les conventions en cours d'instruction appartenant à une opération à condition qu'il n'y ai pas de conventions signées (en cours de validité)