### PR TITLE
remove default DB_READONLY value to avoid security alert

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
       - image: circleci/python:3.10
         environment:
           DATABASE_URL: postgres://root:password@localhost/apilos_test
+          DB_READONLY: postgres://root:password@localhost/apilos_test
           SECRET_KEY: secret-key
           DEBUG: False
       - image: circleci/postgres:12.2-postgis

--- a/core/settings.py
+++ b/core/settings.py
@@ -251,9 +251,7 @@ except decouple.UndefinedValueError:
 # from https://django-sql-explorer.readthedocs.io/en/latest/install.html
 # The readonly access is configured with fake access when DB_READONLY env
 # variable is not set.
-DB_READONLY = config(
-    "DB_READONLY", default="postgres://fakeusername:fakepassword@postgres:5432/database"
-)
+DB_READONLY = config("DB_READONLY")
 readonly_settings = dj_database_url.parse(DB_READONLY)
 
 DATABASES = {"default": default_settings, "readonly": readonly_settings}


### PR DESCRIPTION
to avoid this security feedback : https://github.com/MTES-MCT/apilos/security/code-scanning/36