### PR TITLE
:construction:  Sentry issue 75910

### DIFF
--- a/conventions/services/cadastre.py
+++ b/conventions/services/cadastre.py
@@ -193,25 +193,30 @@ class ConventionCadastreService(ConventionService):
         }
         for idx, form_reference_cadastrale in enumerate(self.formset):
             if form_reference_cadastrale["uuid"].value():
-                reference_cadastrale = ReferenceCadastrale.objects.get(
-                    uuid=form_reference_cadastrale["uuid"].value()
-                )
-                initformset = {
-                    **initformset,
-                    f"form-{idx}-uuid": reference_cadastrale.uuid,
-                    f"form-{idx}-section": utils.get_form_value(
-                        form_reference_cadastrale, reference_cadastrale, "section"
-                    ),
-                    f"form-{idx}-numero": utils.get_form_value(
-                        form_reference_cadastrale, reference_cadastrale, "numero"
-                    ),
-                    f"form-{idx}-lieudit": utils.get_form_value(
-                        form_reference_cadastrale, reference_cadastrale, "lieudit"
-                    ),
-                    f"form-{idx}-surface": utils.get_form_value(
-                        form_reference_cadastrale, reference_cadastrale, "surface"
-                    ),
-                }
+                try:
+                    reference_cadastrale = ReferenceCadastrale.objects.get(
+                        uuid=form_reference_cadastrale["uuid"].value()
+                    )
+                except ReferenceCadastrale.DoesNotExist:
+                    form_is_valid = False
+                    # TODO: add errors ?
+                else:
+                    initformset = {
+                        **initformset,
+                        f"form-{idx}-uuid": reference_cadastrale.uuid,
+                        f"form-{idx}-section": utils.get_form_value(
+                            form_reference_cadastrale, reference_cadastrale, "section"
+                        ),
+                        f"form-{idx}-numero": utils.get_form_value(
+                            form_reference_cadastrale, reference_cadastrale, "numero"
+                        ),
+                        f"form-{idx}-lieudit": utils.get_form_value(
+                            form_reference_cadastrale, reference_cadastrale, "lieudit"
+                        ),
+                        f"form-{idx}-surface": utils.get_form_value(
+                            form_reference_cadastrale, reference_cadastrale, "surface"
+                        ),
+                    }
             else:
                 initformset = {
                     **initformset,

--- a/conventions/services/cadastre.py
+++ b/conventions/services/cadastre.py
@@ -199,7 +199,9 @@ class ConventionCadastreService(ConventionService):
                     )
                 except ReferenceCadastrale.DoesNotExist:
                     form_is_valid = False
-                    # TODO: add errors ?
+                    self.form.add_error(
+                        field="uuid", error="Référence cadastrale inconnue"
+                    )
                 else:
                     initformset = {
                         **initformset,

--- a/conventions/services/cadastre.py
+++ b/conventions/services/cadastre.py
@@ -1,3 +1,4 @@
+import logging
 from django.http import HttpRequest
 
 from conventions.forms import (
@@ -9,6 +10,8 @@ from conventions.models import Convention
 from conventions.services import upload_objects, utils
 from conventions.services.conventions import ConventionService
 from programmes.models import ReferenceCadastrale
+
+logger = logging.getLogger(__name__)
 
 
 class ConventionCadastreService(ConventionService):
@@ -200,7 +203,11 @@ class ConventionCadastreService(ConventionService):
                 except ReferenceCadastrale.DoesNotExist:
                     form_is_valid = False
                     self.form.add_error(
-                        field="uuid", error="Référence cadastrale inconnue"
+                        field=None, error="Référence cadastrale inconnue"
+                    )
+                    logger.error(
+                        "Unknown reference cadastrale with uuid %s",
+                        form_reference_cadastrale["uuid"].value(),
                     )
                 else:
                     initformset = {


### PR DESCRIPTION
[Sentry issue](https://sentry.incubateur.net/organizations/betagouv/issues/75910/?alert_rule_id=14&alert_timestamp=1701874347611&alert_type=email&environment=production&project=29&referrer=alert_email)

This fix will prevent error 500, but not address the root cause. We should check how we can have this unknown uuid in the form entries.