### PR TITLE
Fix: page admin des annexes

### DIFF
--- a/programmes/admin.py
+++ b/programmes/admin.py
@@ -72,6 +72,7 @@ class LotAdmin(admin.ModelAdmin):
 @admin.register(Annexe)
 class AnnexeAdmin(admin.ModelAdmin):
     list_select_related = ("logement",)
+    readonly_fields = ("logement",)
 
 
 @admin.register(Logement)


### PR DESCRIPTION
Actuellement, on peut avoir un timeout sur la page de détail d'une annexe