### PR TITLE
Fix: erreur 404 au lieu de 500 si la convention n'est pas trouvée

### DIFF
--- a/conventions/views/convention_form.py
+++ b/conventions/views/convention_form.py
@@ -2,6 +2,8 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import List
 
+from django.shortcuts import get_object_or_404
+
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import render
@@ -314,7 +316,7 @@ class BaseConventionView(LoginRequiredMixin, View):
     convention: Convention
 
     def _get_convention(self, convention_uuid):
-        return Convention.objects.get(uuid=convention_uuid)
+        return get_object_or_404(Convention, uuid=convention_uuid)
 
     def setup(self, request, *args, **kwargs):
         self.convention = self._get_convention(kwargs.get("convention_uuid"))
@@ -365,7 +367,8 @@ class ConventionView(ABC, BaseConventionView):
                 **({"form": service.form} if service.form else {}),
                 **({"extra_forms": service.extra_forms} if service.extra_forms else {}),
                 **({"formset": service.formset} if service.formset else {}),
-                "upform": service.upform,  # obsolète, pourra être supprimé après rédaction de tests unitaires sur extra_forms
+                # obsolète, pourra être supprimé après rédaction de tests unitaires sur extra_forms
+                "upform": service.upform,
                 "form_step": self.steps.get_form_step(),
                 "editable_after_upload": (
                     editable_convention(request, self.convention)

--- a/conventions/views/convention_form_annexes.py
+++ b/conventions/views/convention_form_annexes.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.annexes import ConventionAnnexesService
 from conventions.views.convention_form import (
@@ -12,10 +14,11 @@ class ConventionAnnexesView(ConventionView):
     service_class = ConventionAnnexesService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("lot")
-            .prefetch_related("lot__logements__annexes")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("lot").prefetch_related(
+                "lot__logements__annexes"
+            ),
+            uuid=convention_uuid,
         )
 
 

--- a/conventions/views/convention_form_cadastre.py
+++ b/conventions/views/convention_form_cadastre.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.cadastre import ConventionCadastreService
 from conventions.views.convention_form import ConventionView
@@ -8,8 +10,9 @@ class ConventionCadastreView(ConventionView):
     service_class = ConventionCadastreService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("programme")
-            .prefetch_related("programme__referencecadastrales")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("programme").prefetch_related(
+                "programme__referencecadastrales"
+            ),
+            uuid=convention_uuid,
         )

--- a/conventions/views/convention_form_champ_libre.py
+++ b/conventions/views/convention_form_champ_libre.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.champ_libre import ConventionChampLibreService
 from conventions.views.convention_form import ConventionView, avenant_champ_libre_step
@@ -9,4 +11,4 @@ class AvenantChampLibreView(ConventionView):
     form_steps = [avenant_champ_libre_step]
 
     def _get_convention(self, convention_uuid):
-        return Convention.objects.get(uuid=convention_uuid)
+        return get_object_or_404(Convention, uuid=convention_uuid)

--- a/conventions/views/convention_form_collectif.py
+++ b/conventions/views/convention_form_collectif.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.collectif import ConventionCollectifService
 from conventions.views.convention_form import (
@@ -12,10 +14,11 @@ class ConventionCollectifView(ConventionView):
     service_class = ConventionCollectifService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("lot")
-            .prefetch_related("lot__logements__annexes")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("lot").prefetch_related(
+                "lot__logements__annexes"
+            ),
+            uuid=convention_uuid,
         )
 
 

--- a/conventions/views/convention_form_denonciation.py
+++ b/conventions/views/convention_form_denonciation.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.denonciation import ConventionDenonciationService
 from conventions.views.convention_form import ConventionView, avenant_denonciation_step
@@ -9,4 +11,4 @@ class DenonciationView(ConventionView):
     form_steps = [avenant_denonciation_step]
 
     def _get_convention(self, convention_uuid):
-        return Convention.objects.get(uuid=convention_uuid)
+        return get_object_or_404(Convention, uuid=convention_uuid)

--- a/conventions/views/convention_form_edd.py
+++ b/conventions/views/convention_form_edd.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.edd import ConventionEDDService
 from conventions.views.convention_form import ConventionView
@@ -8,9 +10,9 @@ class ConventionEDDView(ConventionView):
     service_class = ConventionEDDService
 
     def _get_convention(self, convention_uuid):
-        return (
+        return get_object_or_404(
             Convention.objects.prefetch_related("programme")
             .prefetch_related("lot")
-            .prefetch_related("programme__logementedds")
-            .get(uuid=convention_uuid)
+            .prefetch_related("programme__logementedds"),
+            uuid=convention_uuid,
         )

--- a/conventions/views/convention_form_financement.py
+++ b/conventions/views/convention_form_financement.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.financement import ConventionFinancementService
 from conventions.views.convention_form import ConventionView, avenant_financement_step
@@ -8,7 +10,10 @@ class ConventionFinancementView(ConventionView):
     service_class = ConventionFinancementService
 
     def _get_convention(self, convention_uuid):
-        return Convention.objects.prefetch_related("prets").get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("prets"),
+            uuid=convention_uuid,
+        )
 
 
 class AvenantFinancementView(ConventionFinancementView):

--- a/conventions/views/convention_form_foyer_residence_logements.py
+++ b/conventions/views/convention_form_foyer_residence_logements.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.logements import ConventionFoyerResidenceLogementsService
 from conventions.views.convention_form import (
@@ -12,10 +14,11 @@ class ConventionFoyerResidenceLogementsView(ConventionView):
     service_class = ConventionFoyerResidenceLogementsService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("lot")
-            .prefetch_related("lot__logements")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("lot").prefetch_related(
+                "lot__logements"
+            ),
+            uuid=convention_uuid,
         )
 
 

--- a/conventions/views/convention_form_logements.py
+++ b/conventions/views/convention_form_logements.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.logements import ConventionLogementsService
 from conventions.views.convention_form import (
@@ -12,10 +14,11 @@ class ConventionLogementsView(ConventionView):
     service_class = ConventionLogementsService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("lot")
-            .prefetch_related("lot__logements")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("lot").prefetch_related(
+                "lot__logements"
+            ),
+            uuid=convention_uuid,
         )
 
 

--- a/conventions/views/convention_form_programme.py
+++ b/conventions/views/convention_form_programme.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.services_programmes import ConventionProgrammeService
 from conventions.views.convention_form import ConventionView, avenant_programme_step
@@ -8,10 +10,9 @@ class ConventionProgrammeView(ConventionView):
     service_class = ConventionProgrammeService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("programme")
-            .prefetch_related("lot")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("programme").prefetch_related("lot"),
+            uuid=convention_uuid,
         )
 
 

--- a/conventions/views/convention_form_type_stationnement.py
+++ b/conventions/views/convention_form_type_stationnement.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from conventions.models import Convention
 from conventions.services.type_stationnement import ConventionTypeStationnementService
 from conventions.views.convention_form import ConventionView
@@ -8,8 +10,9 @@ class ConventionTypeStationnementView(ConventionView):
     service_class = ConventionTypeStationnementService
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("lot")
-            .prefetch_related("lot__type_stationnements")
-            .get(uuid=convention_uuid)
+        return get_object_or_404(
+            Convention.objects.prefetch_related("lot").prefetch_related(
+                "lot__type_stationnements"
+            ),
+            uuid=convention_uuid,
         )

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -21,6 +21,7 @@ from django.shortcuts import render
 from django.urls import resolve, reverse
 from django.views import View
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
+from django.shortcuts import get_object_or_404
 
 from conventions.forms.convention_form_simulateur_loyer import LoyerSimulateurForm
 from conventions.forms.evenement import EvenementForm
@@ -60,17 +61,16 @@ class RecapitulatifView(BaseConventionView):
     forms: dict
 
     def _get_convention(self, convention_uuid):
-        return (
-            Convention.objects.prefetch_related("programme")
-            .prefetch_related(
+        return get_object_or_404(
+            Convention.objects.prefetch_related("programme").prefetch_related(
                 "programme__referencecadastrales",
                 "programme__logementedds",
                 "lot",
                 "lot__type_stationnements",
                 "lot__logements",
                 "programme__administration",
-            )
-            .get(uuid=convention_uuid)
+            ),
+            uuid=convention_uuid,
         )
 
     @has_campaign_permission("convention.view_convention")


### PR DESCRIPTION

Avant (500):
![Screenshot from 2023-12-12 14-51-11](https://github.com/MTES-MCT/apilos/assets/19758404/2bd9926f-6e7f-4e33-b1b1-2ebd9dd263e4)

Après (404):
![Screenshot from 2023-12-12 14-51-33](https://github.com/MTES-MCT/apilos/assets/19758404/aa416216-0484-4a7d-8240-51e3a50fed5a)
