### PR TITLE
:construction: pip-tools in pyproject

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip-compile"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "06:00" # UTC
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
       time: "06:00" # UTC
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -180,14 +180,13 @@ Puis compiler (recquiert l'installation de `pip-tools`):
 
 ```sh
 pip install pip-tools
-pip-compile --resolver=backtracking requirements.in --generate-hashes
-pip-compile --resolver=backtracking dev-requirements.in --generate-hashes
+make pip-compile
 ```
 
 Et installer
 
 ```sh
-pip install -r requirements.txt -r dev-requirements.txt
+make pip-install
 ```
 
 ## Manipulations de développement

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 #!make
 
 fmt:
-	pre-commit run --all-files
+	@pre-commit run --all-files
 
 fmt-unstaged:
-	pre-commit run --files $(shell git diff --name-only)
+	@pre-commit run --files $(shell git diff --name-only)
+
+pip-compile:
+	@pip-compile -o requirements.txt pyproject.toml
+	@pip-compile --extra dev -o dev-requirements.txt pyproject.toml
+
+pip-install:
+	@pip install -r requirements.txt -r dev-requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "APiLos"
+requires-python = "3.10.8"
+dynamic = ["dependencies", "optional-dependencies"]
+readme = "README.md"
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.in"] }
+optional-dependencies.dev = { file = ["dev-requirements.in"] }
+
+[tool.pip-tools]
+generate-hashes = true
+resolver = "backtracking"
+
 [tool.darker]
 src = [
     "core",
@@ -27,3 +45,4 @@ omit = [
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "core.settings"
+


### PR DESCRIPTION
Doc:
- [`pip-tools` utilise le standard `pyproject.toml`](https://github.com/jazzband/pip-tools?tab=readme-ov-file#requirements-from-pyprojecttoml)
- [Config du pyproject](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/)