### PR TITLE
Save numéro d'opération at first step

### DIFF
--- a/conventions/services/selection.py
+++ b/conventions/services/selection.py
@@ -83,6 +83,7 @@ class ConventionSelectionService:
                     == Financement.SANS_FINANCEMENT
                     else TypeOperation.NEUF
                 ),
+                numero_galion=self.form.cleaned_data["numero_galion"],
                 # default ANRU when it is SIAP version
                 anru=bool(settings.CERBERE_AUTH),
             )

--- a/conventions/tests/services/test_selection_service.py
+++ b/conventions/tests/services/test_selection_service.py
@@ -102,6 +102,7 @@ class ConventionSelectionServiceForInstructeurTests(TestCase):
                 programme__nom="Programme de test", financement=Financement.PLUS
             ),
         )
+        self.assertEqual(self.service.convention.programme.numero_galion, "123456789")
 
     def test_post_for_avenant_success(self):
         bailleur = Bailleur.objects.get(siret="987654321")


### PR DESCRIPTION
Le numéro d'opération n'était pas enregistré dans le programme alors qu'il était demandé à l'utilisateur.