### PR TITLE
[API SIAP] Update and fix OpenAPI doc, add cancel route to config route

### DIFF
--- a/api/siap/v0/urls.py
+++ b/api/siap/v0/urls.py
@@ -25,7 +25,10 @@ urlpatterns = [
     # Operation close route
     path("close_operation/<str:numero_galion>/", OperationClosed.as_view()),
     # Opération cancel route
-    path("cancel_operation/<str:numero_galion>/", OperationCanceled.as_view()),
+    path(
+        "cancel_operation/<str:numero_galion>/",
+        OperationCanceled.as_view(),
+    ),
     # DRF spectacular
     path("schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/apilos_settings/api/api_views.py
+++ b/apilos_settings/api/api_views.py
@@ -37,6 +37,28 @@ class ApilosConfiguration(APIView):
                         max_length=2000,
                         help_text="Racine de l'URL d'accès web à l'application avec son protocole",
                     ),
+                    "url_acces_api_cloture_operation": serializers.CharField(
+                        max_length=2000,
+                        help_text=(
+                            "Route API a appeler lors de la cloture de l'opération"
+                            " en GET pour vérifier qu'il est possible de cloturer"
+                            " en POST pour alerter de la cloture"
+                        ),
+                    ),
+                    "url_acces_api_annulation_operation": serializers.CharField(
+                        max_length=2000,
+                        help_text=(
+                            "Route API a appeler en POST lors de l'annulation de"
+                            " l'opération"
+                        ),
+                    ),
+                    "url_acces_api_conventions_operation": serializers.CharField(
+                        max_length=2000,
+                        help_text=(
+                            "Route API permettant de récupérer les conventions"
+                            " associées à une opération"
+                        ),
+                    ),
                     "url_acces_web_operation": serializers.CharField(
                         max_length=2000,
                         help_text=(
@@ -82,6 +104,9 @@ class ApilosConfiguration(APIView):
                     "url_acces_api_cloture_operation": (
                         "/api-siap/v0/close_operation/{NUMERO_OPERATION_SIAP}/"
                     ),
+                    "url_acces_api_annulation_operation": (
+                        "/api-siap/v0/cancel_operation/{NUMERO_OPERATION_SIAP}/"
+                    ),
                     "url_acces_api_conventions_operation": (
                         "/api-siap/v0/operation/{NUMERO_OPERATION_SIAP}"
                     ),
@@ -109,6 +134,9 @@ class ApilosConfiguration(APIView):
                 "racine_url_acces_web": protocol + request.get_host(),
                 "url_acces_api_cloture_operation": (
                     "/api-siap/v0/close_operation/{NUMERO_OPERATION_SIAP}/"
+                ),
+                "url_acces_api_annulation_operation": (
+                    "/api-siap/v0/cancel_operation/{NUMERO_OPERATION_SIAP}/"
                 ),
                 "url_acces_api_conventions_operation": (
                     "/api-siap/v0/operation/{NUMERO_OPERATION_SIAP}"

--- a/apilos_settings/api/tests/test_apis.py
+++ b/apilos_settings/api/tests/test_apis.py
@@ -36,6 +36,9 @@ class ConfigurationAPITest(APITestCase):
             "url_acces_api_cloture_operation": (
                 "/api-siap/v0/close_operation/{NUMERO_OPERATION_SIAP}/"
             ),
+            "url_acces_api_annulation_operation": (
+                "/api-siap/v0/cancel_operation/{NUMERO_OPERATION_SIAP}/"
+            ),
             "url_acces_api_conventions_operation": (
                 "/api-siap/v0/operation/{NUMERO_OPERATION_SIAP}"
             ),


### PR DESCRIPTION
Using DRF spectacular for documentation : update this doc because sometime it was false

Add OpenAPI documentation for cancel operation API route

Add cancel operation route to config route used by SIAP ngine to communicate with APiLos