### PR TITLE
Update coverage ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,9 @@ omit = [
     "*/migrations/*",
     "ecoloweb/*",
     "programmes/management/commands/import_galion.py",
-    # TODO: add tests on upload_objects.py and remove it from this list
+    # TODO: add tests on the following modules and remove them from this list
     "conventions/services/upload_objects.py",
+    "conventions/services/recapitulatif.py",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Ajouts dans la liste des modules à ignorer du coverage, le temps qu'on ajoute de nouveaux tests.