### PR TITLE
S926 - mise à jour du numéro de convention et du numéro d'opération en mode expert

### DIFF
--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -67,18 +67,36 @@ class ConventionRecapitulatifService(ConventionService):
             programme_number_form=programme_number_form
         )
 
-    def get_convention_recapitulatif(
-        self, convention_type1_and_2_form=None, programme_number_form=None
-    ):
-        convention_number_form = ConventionNumberForm(
-            initial={
-                "convention_numero": self.convention.get_default_convention_number()
-            }
+    def update_convention_number(self):
+        convention_number_form = ConventionNumberForm(self.request.POST)
+        convention_number_form.convention = self.convention
+        if convention_number_form.is_valid():
+            self.convention.numero = convention_number_form.cleaned_data[
+                "convention_numero"
+            ]
+            self.convention.save()
+        return self.get_convention_recapitulatif(
+            convention_number_form=convention_number_form
         )
+
+    def get_convention_recapitulatif(
+        self,
+        convention_type1_and_2_form=None,
+        programme_number_form=None,
+        convention_number_form=None,
+    ):
+        if convention_number_form is None:
+            convention_number_form = ConventionNumberForm(
+                initial={
+                    "convention_numero": self.convention.get_default_convention_number()
+                }
+            )
+
         if programme_number_form is None:
             programme_number_form = ProgrammeNumberForm(
                 initial={"numero_galion": self.convention.programme.numero_galion}
             )
+
         complete_for_avenant_form = None
         if self.convention.is_incompleted_avenant_parent():
             complete_for_avenant_form = CompleteforavenantForm(

--- a/conventions/tests/services/test_recapitulatif_service.py
+++ b/conventions/tests/services/test_recapitulatif_service.py
@@ -107,6 +107,7 @@ class ConventionRecapitulatifServiceTests(TestCase):
         }
         self.service.update_programme_number()
 
+        self.convention.programme.refresh_from_db()
         self.assertEqual(self.convention.programme.numero_galion, "0" * 255)
 
     def test_update_programme_number_failed(self):
@@ -117,6 +118,25 @@ class ConventionRecapitulatifServiceTests(TestCase):
         result = self.service.update_programme_number()
 
         self.assertFalse(result["conventionNumberForm"].has_error("numero_galion"))
+
+    def test_updateconvention_number_success(self):
+        self.service.request.POST = {
+            "convention_numero": "91-1-11-1988-85.1231.075.078/078",
+            "update_convention_number": "1",
+        }
+        self.service.update_convention_number()
+
+        self.convention.refresh_from_db()
+        self.assertEqual(self.convention.numero, "91-1-11-1988-85.1231.075.078/078")
+
+    def test_updateconvention_number_failed(self):
+        self.service.request.POST = {
+            "convention_numero": "dummy_value",
+            "update_convention_number": "1",
+        }
+        result = self.service.update_convention_number()
+
+        self.assertFalse(result["conventionNumberForm"].has_error("convention_numero"))
 
     def test_convention_submit(self):
         result = recapitulatif.convention_submit(self.request, self.convention)

--- a/conventions/tests/views/test_recapitulatif_view.py
+++ b/conventions/tests/views/test_recapitulatif_view.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -33,3 +35,25 @@ class ConventionRecapitulatifTests(AbstractCreateViewTestCase, TestCase):
             "update_programme_number": "1",
         }
         self.msg_prefix = "[ConventionRecapitulatifTests] "
+
+    def test_post_param_calls_the_correct_service_method(self):
+        self.client.login(username="nicolas", password="12345")
+
+        for post_param, expected in (
+            ("update_programme_number", "update_programme_number"),
+            ("update_convention_number", "update_convention_number"),
+            ("cancel_convention", "cancel_convention"),
+            ("reactive_convention", "reactive_convention"),
+            (None, "save_convention_TypeIandII"),
+        ):
+            with patch(
+                "conventions.views.conventions.ConventionRecapitulatifService",
+                autospec=True,
+            ) as mock_service:
+                response = self.client.post(
+                    self.target_path, data={post_param: "1"} if post_param else {}
+                )
+                self.assertEqual(response.status_code, 200)
+
+            self.assertEqual(len(mock_service.method_calls), 1)
+            self.assertEqual(mock_service.method_calls[0][0], f"().{expected}")

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -104,6 +104,8 @@ class RecapitulatifView(BaseConventionView):
 
         if request.POST.get("update_programme_number"):
             result = service.update_programme_number()
+        elif request.POST.get("update_convention_number"):
+            result = service.update_convention_number()
         elif request.POST.get("cancel_convention"):
             result = service.cancel_convention()
         elif request.POST.get("reactive_convention"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ omit = [
     "programmes/management/commands/import_galion.py",
     # TODO: add tests on the following modules and remove them from this list
     "conventions/services/upload_objects.py",
-    "conventions/services/recapitulatif.py",
 ]
 
 [tool.pytest.ini_options]

--- a/templates/conventions/actions/edit_numero_convention.html
+++ b/templates/conventions/actions/edit_numero_convention.html
@@ -1,0 +1,46 @@
+<button class="fr-btn fr-btn--secondary" data-fr-opened="false" type="button" aria-controls="fr-modal-update-convention-number">
+    Éditer le numéro de convention
+</button>
+
+{% if conventionNumberForm.errors %}
+    <input data-fr-opened="true" aria-controls="fr-modal-update-convention-number" type="hidden">
+{% endif %}
+
+<dialog aria-labelledby="fr-modal-update-convention-number-title" id="fr-modal-update-convention-number" data-fr-opened="true" class="fr-modal" role="dialog" open="true">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-link--close fr-link" type="button" aria-controls="fr-modal-update-convention-number">Fermer</button>
+                    </div>
+                    <form method="post">
+                        {% csrf_token %}
+                        <div class="fr-modal__content">
+                            <div role="alert" class="fr-alert fr-alert--warning">
+                                <p class="fr-alert__title">Modifier le numéro de convention</p>
+                                <p>la modification de ce numéro de décision peut avoir des conséquences ... </p>
+                            </div>
+                            {% include "common/form/input_text.html" with form_input=conventionNumberForm.convention_numero editable=True%}
+
+                        </div>
+                        <div class="fr-modal__footer">
+                            <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary" type="button" aria-controls="fr-modal-update-convention-number">
+                                        Annuler
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-icon-checkbox-line" name='update_convention_number' value=1>
+                                        Changer le numéro de convention
+                                    </button>
+                                </li>
+                            </ul>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -37,6 +37,9 @@
                             {% endif %}
                         </a>
                     </div>
+                    {% if request.session.is_expert %}
+                        {% include "conventions/recapitulatif/convention.html" %}
+                    {% endif %}
                 {% endif %}
                 {% if convention.is_denonciation %}
                     {% include "conventions/recapitulatif/denonciation.html"  with target_url='conventions:denonciation' %}

--- a/templates/conventions/recapitulatif/_card.html
+++ b/templates/conventions/recapitulatif/_card.html
@@ -11,7 +11,9 @@
                             {% endblock title %}
                         </h4>
                     </div>
-                    {% include "conventions/actions/goto.html" %}
+                    {% if target_url %}
+                        {% include "conventions/actions/goto.html" %}
+                    {% endif %}
                 </div>
                 {% block body %}
                 {% endblock body %}

--- a/templates/conventions/recapitulatif/convention.html
+++ b/templates/conventions/recapitulatif/convention.html
@@ -1,0 +1,20 @@
+{% extends "conventions/recapitulatif/_card.html" %}
+{% load custom_filters %}
+
+{% block card_classes %}fr-mt-1w{% endblock card_classes %}
+{% block title %}Convention{% endblock title %}
+
+{% block body %}
+    <div class="table--limited-height">
+        {% if request.user.is_instructeur %}
+            <p class="fr-mt-1w fr-mb-0">
+                <strong>Numéro de convention : {{convention.numero}}</strong>
+            </p>
+            {% if request.session.is_expert %}
+                {% include "conventions/actions/edit_numero_convention.html" %}
+            {% endif %}
+        {% else %}
+            {% include "common/display_field_if_exists.html" with label="Numéro de convention" value=convention.numero %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/conventions/recapitulatif/operation.html
+++ b/templates/conventions/recapitulatif/operation.html
@@ -23,7 +23,9 @@
                                     <em>Numéro de décision : non renseigné</em>
                                 {% endif %}
                             </p>
-                            {% include "conventions/actions/edit_numero_galion.html" %}
+                            {% if request.session.is_expert %}
+                                {% include "conventions/actions/edit_numero_galion.html" %}
+                            {% endif %}
                         {% else %}
                             {% include "common/display_field_if_exists.html" with label="Numéro de décision" value=programme.numero_galion %}
                         {% endif %}


### PR DESCRIPTION
[Lien airtable](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recgL9jREdQSK3JtH?blocks=hide)

- permettre la modification du numéro de la convention en mode expert
- ne permettre la modification du numéro de l'opération que en mode expert

