### PR TITLE
Fix - Modification du champ statut de la convention dans l'admin

### DIFF
--- a/conventions/admin.py
+++ b/conventions/admin.py
@@ -1,11 +1,13 @@
 from typing import Any
 
+from django import forms
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.db.models import QuerySet
 from django.http import HttpRequest
 
 from admin.admin import ApilosModelAdmin
+from conventions.models.choices import ConventionStatut
 
 from .models import AvenantType, Convention, Pret
 
@@ -39,6 +41,30 @@ class IsAvenantFilter(SimpleListFilter):
                 return queryset.filter(parent__isnull=True)
             case _:
                 return queryset
+
+
+class ConventionModelForm(forms.ModelForm):
+    statut = forms.ChoiceField(choices=ConventionStatut.choices)
+
+    def __init__(self, *args, **kwargs):
+        initial = kwargs.get("initial", {})
+
+        instance = kwargs.get("instance", None)
+        if instance:
+            statut = ConventionStatut.get_by_label(instance.statut)
+            if statut:
+                initial["statut"] = statut.name
+
+        super().__init__(initial=initial, *args, **kwargs)
+
+    def _post_clean(self):
+        super()._post_clean()
+        statut = self.cleaned_data.get("statut")
+        self.cleaned_data["statut"] = ConventionStatut[statut].label
+
+    class Meta:
+        model = Convention
+        exclude = []
 
 
 @admin.register(Convention)
@@ -100,6 +126,8 @@ class ConventionAdmin(ApilosModelAdmin):
         IsAvenantFilter,
         "cree_le",
     )
+
+    form = ConventionModelForm
 
 
 @admin.register(Pret)

--- a/conventions/admin.py
+++ b/conventions/admin.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from django import forms
 from django.contrib import admin
-from django.contrib.admin import SimpleListFilter
+from django.contrib.admin import ChoicesFieldListFilter, SimpleListFilter
 from django.db.models import QuerySet
 from django.http import HttpRequest
 
@@ -41,6 +41,15 @@ class IsAvenantFilter(SimpleListFilter):
                 return queryset.filter(parent__isnull=True)
             case _:
                 return queryset
+
+
+class StatutFilter(ChoicesFieldListFilter):
+    def __init__(self, field, request, params, model, model_admin, field_path):
+        super().__init__(field, request, params, model, model_admin, field_path)
+        if self.used_parameters and self.lookup_kwarg in self.used_parameters:
+            self.used_parameters[self.lookup_kwarg] = ConventionStatut[
+                self.used_parameters[self.lookup_kwarg]
+            ].label
 
 
 class ConventionModelForm(forms.ModelForm):
@@ -124,6 +133,7 @@ class ConventionAdmin(ApilosModelAdmin):
     )
     list_filter = (
         IsAvenantFilter,
+        ("statut", StatutFilter),
         "cree_le",
     )
 

--- a/conventions/models/choices.py
+++ b/conventions/models/choices.py
@@ -13,12 +13,15 @@ class ReverseEnumMixin:
     _reverse: dict = {}
 
     @classmethod
-    def get_by_label(cls, label: str):
+    def get_by_label(cls, label: str | None) -> Enum | None:
         if not label:
             return None
         if not cls._reverse:
             cls._reverse = {c.label: c for c in cls}
-        return cls._reverse[label]
+        try:
+            return cls._reverse[label]
+        except KeyError:
+            return None
 
 
 class ConventionStatut(ReverseEnumMixin, Enum):


### PR DESCRIPTION
Le champs statut de la convention dans l'admin est désormais corrigé.

J'ai ajouté également un nouveau filtre par type pour m'aider dans les tests notamment
![Screenshot from 2024-01-08 17-01-04](https://github.com/MTES-MCT/apilos/assets/19758404/903861c1-ed1b-4025-9650-61397e5141fb)
