### PR TITLE
Utiliser la clé étrangère

### DIFF
--- a/conventions/services/annexes.py
+++ b/conventions/services/annexes.py
@@ -11,7 +11,7 @@ class ConventionAnnexesService(ConventionService):
 
     def get(self):
         initial = []
-        annexes = Annexe.objects.filter(logement__lot_id=self.convention.lot.id)
+        annexes = Annexe.objects.filter(logement__lot_id=self.convention.lot_id)
         for annexe in annexes:
             initial.append(
                 {
@@ -70,7 +70,7 @@ class ConventionAnnexesService(ConventionService):
 
                 annexes_by_designation = {}
                 for annexe in Annexe.objects.prefetch_related("logement").filter(
-                    logement__lot_id=self.convention.lot.id
+                    logement__lot_id=self.convention.lot_id
                 ):
                     annexes_by_designation[
                         f"{annexe.logement.designation}_{annexe.typologie}"
@@ -199,7 +199,7 @@ class ConventionAnnexesService(ConventionService):
     def _save_annexes(self):
         obj_uuids1 = list(map(lambda x: x.cleaned_data["uuid"], self.formset))
         obj_uuids = list(filter(None, obj_uuids1))
-        Annexe.objects.filter(logement__lot_id=self.convention.lot.id).exclude(
+        Annexe.objects.filter(logement__lot_id=self.convention.lot_id).exclude(
             uuid__in=obj_uuids
         ).delete()
         for form_annexe in self.formset:

--- a/conventions/services/collectif.py
+++ b/conventions/services/collectif.py
@@ -13,7 +13,7 @@ class ConventionCollectifService(ConventionService):
     def get(self):
         initial = []
         locaux_collectifs = LocauxCollectifs.objects.filter(
-            lot_id=self.convention.lot.id
+            lot_id=self.convention.lot_id
         )
         for type_locaux_collectifs in locaux_collectifs:
             initial.append(
@@ -137,7 +137,7 @@ class ConventionCollectifService(ConventionService):
             for form in self.formset
             if form.cleaned_data["uuid"] is not None
         ]
-        LocauxCollectifs.objects.filter(lot_id=self.convention.lot.id).exclude(
+        LocauxCollectifs.objects.filter(lot_id=self.convention.lot_id).exclude(
             uuid__in=obj_uuids
         ).delete()
         for form_locaux_collectifs in self.formset:

--- a/conventions/services/convention_generator.py
+++ b/conventions/services/convention_generator.py
@@ -90,7 +90,7 @@ def generate_convention_doc(convention: Convention, save_data=False):
     # pylint: disable=R0912,R0914,R0915
     annexes = (
         Annexe.objects.prefetch_related("logement")
-        .filter(logement__lot_id=convention.lot.id)
+        .filter(logement__lot_id=convention.lot_id)
         .all()
     )
 
@@ -233,7 +233,7 @@ def _save_convention_donnees_validees(
 ):
     annexes = (
         Annexe.objects.prefetch_related("logement")
-        .filter(logement__lot_id=convention.lot.id)
+        .filter(logement__lot_id=convention.lot_id)
         .all()
     )
 

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -110,7 +110,7 @@ class ConventionRecapitulatifService(ConventionService):
         return {
             "opened_comments": opened_comments,
             "annexes": Annexe.objects.filter(
-                logement__lot_id=self.convention.lot.id
+                logement__lot_id=self.convention.lot_id
             ).all(),
             "notificationForm": NotificationForm(),
             "conventionNumberForm": convention_number_form,


### PR DESCRIPTION
Utiliser la clé étrangère pour éviter de faire un appel supplémentaire à la base de données.﻿
