### PR TITLE
Fix statut "annulée en suivi" pour les avenants

### DIFF
--- a/conventions/models/choices.py
+++ b/conventions/models/choices.py
@@ -157,11 +157,11 @@ class ConventionStatut(ReverseEnumMixin, Enum):
     ANNULEE = Definition(
         "8. Annulée en suivi",
         StatutByRole(
-            "Annulée en suivi",
+            "Annulé{accord} en suivi",
             "Il n'est pas possible d'y apporter des modifications",
         ),
         StatutByRole(
-            "Annulée en suivi",
+            "Annulé{accord} en suivi",
             "Il n'est pas possible d'y apporter des modifications",
         ),
         "close",

--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -503,18 +503,20 @@ class Convention(models.Model):
             "key_statut": self.statut[3:].replace(" ", "_").replace("é", "e"),
         }
 
-    def short_statut_for_bailleur(self):
-        return ConventionStatut.get_by_label(self.statut).bailleur_label
-
-    def short_statut_for_instructeur(self):
-        return ConventionStatut.get_by_label(self.statut).instructeur_label
-
     def genderize_desc(self, desc):
         if self.is_denonciation():
             return desc.format(pronom="elle", accord="e", article="la", autre="")
         if self.is_avenant():
             return desc.format(pronom="il", accord="", article="le", autre="autre")
         return desc.format(pronom="elle", accord="e", article="la", autre="")
+
+    def short_statut_for_bailleur(self):
+        statut = ConventionStatut.get_by_label(self.statut).value.bailleur.label
+        return self.genderize_desc(statut)
+
+    def short_statut_for_instructeur(self):
+        statut = ConventionStatut.get_by_label(self.statut).value.instructeur.label
+        return self.genderize_desc(statut)
 
     def entete_desc_for_bailleur(self):
         desc = ConventionStatut.get_by_label(


### PR DESCRIPTION
correction d'une coquille pour les avenant sur le statut "annulé"

Avant : 
![image](https://github.com/MTES-MCT/apilos/assets/19302155/b2ecb46f-3adb-47d2-bd89-e71d207f47cf)

Après : 
![image](https://github.com/MTES-MCT/apilos/assets/19302155/0d6b65ac-5267-4588-8e1f-5267e5fb8267)
