### PR TITLE
Disable max limit on date fin conventionnement for foyer and residence

### DIFF
--- a/conventions/forms/convention_form_financement.py
+++ b/conventions/forms/convention_form_financement.py
@@ -91,6 +91,12 @@ class ConventionFinancementForm(forms.Form):
                     + f"{min_years}"
                 ),
             )
+        # No control on max date for foyer and residence
+        if (
+            self.convention.programme.is_foyer()
+            or self.convention.programme.is_residence()
+        ):
+            return
         if annee_fin_conventionnement > max_years:
             self.add_error(
                 "annee_fin_conventionnement",


### PR DESCRIPTION
Suppression de la limite de date de fin de convention à 40 ans max en financement PLS pour les type foyer et résidence.