### PR TITLE
Modification du filtre par date dans la recherche des conventions

### DIFF
--- a/conventions/services/search.py
+++ b/conventions/services/search.py
@@ -115,7 +115,7 @@ class UserConventionSearchService(ConventionSearchBaseService):
     statut: ConventionStatut | None = None
     bailleur: Bailleur | None = None
     administration: Administration | None = None
-    date_validation: str | None = None
+    date_signature: str | None = None
 
     def __init__(
         self,
@@ -135,7 +135,7 @@ class UserConventionSearchService(ConventionSearchBaseService):
                 "search_input",
                 "bailleur",
                 "administration",
-                "date_validation",
+                "date_signature",
             ]:
                 setattr(self, name, search_filters.get(name))
             self.statut = ConventionStatut.get_by_label(search_filters.get("statut"))
@@ -167,8 +167,10 @@ class UserConventionSearchService(ConventionSearchBaseService):
         if self.anru:
             self.filters["lot__programme__anru"] = True
 
-        if self.date_validation:
-            self.filters["valide_le__year"] = self.date_validation
+        if self.date_signature:
+            self.filters[
+                "televersement_convention_signee_le__year"
+            ] = self.date_signature
 
     def _get_base_queryset(self) -> QuerySet:
         qs = self.user.conventions()

--- a/conventions/tests/services/test_search.py
+++ b/conventions/tests/services/test_search.py
@@ -82,16 +82,22 @@ class TestUserConventionActivesSearchService(SearchServiceTestBase):
         Convention.objects.all().update(statut=ConventionStatut.SIGNEE.label)
 
     def test_search_date_validation(self):
-        ConventionFactory(statut=ConventionStatut.SIGNEE.label, valide_le="2023-01-01")
-        ConventionFactory(statut=ConventionStatut.SIGNEE.label, valide_le="2020-01-01")
+        ConventionFactory(
+            statut=ConventionStatut.SIGNEE.label,
+            televersement_convention_signee_le="2023-01-01",
+        )
+        ConventionFactory(
+            statut=ConventionStatut.SIGNEE.label,
+            televersement_convention_signee_le="2020-01-01",
+        )
 
         service = self.service_class(
-            user=self.user, search_filters={"date_validation": "2000"}
+            user=self.user, search_filters={"date_signature": "2000"}
         )
         self.assertEqual(service.get_queryset().count(), 0)
 
         service = self.service_class(
-            user=self.user, search_filters={"date_validation": "2023"}
+            user=self.user, search_filters={"date_signature": "2023"}
         )
         self.assertEqual(service.get_queryset().count(), 1)
 

--- a/conventions/tests/views/test_index_view.py
+++ b/conventions/tests/views/test_index_view.py
@@ -113,19 +113,25 @@ class ConventionIndexFiltersViewTests(TestCase):
     def test_filter_date_validation(self):
         self.client.post(reverse("login"), {"username": "nicolas", "password": "12345"})
 
-        ConventionFactory(statut=ConventionStatut.SIGNEE.label, valide_le="2023-01-01")
-        ConventionFactory(statut=ConventionStatut.SIGNEE.label, valide_le="2020-01-01")
+        ConventionFactory(
+            statut=ConventionStatut.SIGNEE.label,
+            televersement_convention_signee_le="2023-01-01",
+        )
+        ConventionFactory(
+            statut=ConventionStatut.SIGNEE.label,
+            televersement_convention_signee_le="2020-01-01",
+        )
 
         response = self.client.get(
-            reverse("conventions:search_active"), data={"date_validation": "2000"}
+            reverse("conventions:search_active"), data={"date_signature": "2000"}
         )
         self.assertEqual(
-            response.context["date_validation_choices"],
+            response.context["date_signature_choices"],
             sorted([str(d) for d in range(2020, date.today().year + 1)], reverse=True),
         )
         self.assertEqual(response.context["filtered_conventions_count"], 0)
 
         response = self.client.get(
-            reverse("conventions:search_active"), data={"date_validation": "2023"}
+            reverse("conventions:search_active"), data={"date_signature": "2023"}
         )
         self.assertEqual(response.context["filtered_conventions_count"], 1)

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -233,17 +233,17 @@ class ConventionSearchView(LoginRequiredMixin, ConventionTabsMixin, View):
             ("administration", "administration"),
         ]
 
-    def _date_validation_choices(self) -> list[str]:
+    def _date_signature_choices(self) -> list[str]:
         validation_year_threshold = 1900
         try:
             earliest = (
                 Convention.objects.filter(
                     statut__in=[s.label for s in self.service_class.statuses],
-                    valide_le__isnull=False,
-                    valide_le__year__gte=validation_year_threshold,
+                    televersement_convention_signee_le__isnull=False,
+                    televersement_convention_signee_le__year__gte=validation_year_threshold,
                 )
-                .earliest("valide_le")
-                .valide_le.year
+                .earliest("televersement_convention_signee_le")
+                .televersement_convention_signee_le.year
             )
         except Convention.DoesNotExist:
             earliest = validation_year_threshold  # fallback value
@@ -262,12 +262,12 @@ class ConventionActivesSearchView(ConventionSearchView):
 
     def get_context(self, request: AuthenticatedHttpRequest) -> dict[str, Any]:
         return super().get_context(request) | {
-            "date_validation_choices": self._date_validation_choices()
+            "date_signature_choices": self._date_signature_choices()
         }
 
     def get_search_filters_mapping(self):
         return super().get_search_filters_mapping() + [
-            ("date_validation", "date_validation")
+            ("date_signature", "date_signature")
         ]
 
 
@@ -277,12 +277,12 @@ class ConventionTermineesSearchView(ConventionSearchView):
 
     def get_context(self, request: AuthenticatedHttpRequest) -> dict[str, Any]:
         return super().get_context(request) | {
-            "date_validation_choices": self._date_validation_choices()
+            "date_signature_choices": self._date_signature_choices()
         }
 
     def get_search_filters_mapping(self):
         return super().get_search_filters_mapping() + [
-            ("date_validation", "date_validation")
+            ("date_signature", "date_signature")
         ]
 
 

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -116,15 +116,15 @@
                             </div>
                         </div>
 
-                        {# Champs annee de validation #}
-                        {% if date_validation_choices %}
+                        {# Champs annee de signature #}
+                        {% if date_signature_choices %}
                             <div class="fr-col-12 fr-col-md-12 fr-col-lg-3 fr-mb-2w">
                                 <div class="">
-                                    <select class="fr-select" name="date_validation">
-                                        <option value="">Année de validation</option>
-                                        {% for value in date_validation_choices %}
+                                    <select class="fr-select" name="date_signature">
+                                        <option value="">Année de signature</option>
+                                        {% for value in date_signature_choices %}
                                             <option value="{{ value }}"
-                                                {% if value == request.GET.date_validation %}selected{% endif %}>
+                                                {% if value == request.GET.date_signature %}selected{% endif %}>
                                                 {{ value }}
                                             </option>
                                         {% endfor %}


### PR DESCRIPTION
On doit plutôt se baser sur la date de signature, à savoir le champ `televersement_convention_signee_le`.
