### PR TITLE
Refacto test avenants service

### DIFF
--- a/conventions/services/avenants.py
+++ b/conventions/services/avenants.py
@@ -11,10 +11,14 @@ from conventions.forms.avenant import AvenantForm
 from conventions.models import AvenantType, Convention, ConventionStatut
 from conventions.services import utils
 from conventions.services.search import AvenantListSearchService
-from siap.exceptions import OngoingAvenantSIAPException
 from upload.services import UploadService
 
 logger = logging.getLogger(__name__)
+
+
+class OngoingAvenantError(Exception):
+    def __init__(self):
+        super().__init__("Ongoing avenant already exists")
 
 
 def create_avenant(request: HttpRequest, convention_uuid: UUID) -> dict[str, Any]:
@@ -118,7 +122,7 @@ def _get_last_avenant(convention: Convention) -> Convention:
         ConventionStatut.INSTRUCTION.label,
         ConventionStatut.CORRECTION.label,
     } & avenants_status:
-        raise OngoingAvenantSIAPException()
+        raise OngoingAvenantError()
     ordered_avenants = convention.avenants.order_by("-cree_le")
     return ordered_avenants[0] if ordered_avenants else convention
 

--- a/conventions/services/avenants.py
+++ b/conventions/services/avenants.py
@@ -11,6 +11,7 @@ from conventions.forms.avenant import AvenantForm
 from conventions.models import AvenantType, Convention, ConventionStatut
 from conventions.services import utils
 from conventions.services.search import AvenantListSearchService
+from siap.exceptions import OngoingAvenantSIAPException
 from upload.services import UploadService
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,7 @@ def _get_last_avenant(convention: Convention) -> Convention:
         ConventionStatut.INSTRUCTION.label,
         ConventionStatut.CORRECTION.label,
     } & avenants_status:
-        raise Exception("Ongoing avenant already exists")
+        raise OngoingAvenantSIAPException()
     ordered_avenants = convention.avenants.order_by("-cree_le")
     return ordered_avenants[0] if ordered_avenants else convention
 

--- a/conventions/tests/services/test_avenants_service.py
+++ b/conventions/tests/services/test_avenants_service.py
@@ -3,12 +3,12 @@ from django.test import TestCase
 
 from conventions.models import Convention, ConventionStatut
 from conventions.services.avenants import (  # complete_avenants_for_avenant,
+    OngoingAvenantError,
     _get_last_avenant,
     create_avenant,
     upload_avenants_for_avenant,
 )
 from conventions.services.utils import ReturnStatus
-from siap.exceptions import OngoingAvenantSIAPException
 from users.models import User
 
 
@@ -121,7 +121,7 @@ class ConventionAvenantsServiceTests(TestCase):
         last_avenant.statut = ConventionStatut.PROJET.label
         last_avenant.save()
 
-        with self.assertRaises(OngoingAvenantSIAPException) as exc:
+        with self.assertRaises(OngoingAvenantError) as exc:
             _get_last_avenant(self.convention)
             assert exc.message == "Ongoing avenant already exists"
 

--- a/conventions/tests/services/test_avenants_service.py
+++ b/conventions/tests/services/test_avenants_service.py
@@ -8,6 +8,7 @@ from conventions.services.avenants import (  # complete_avenants_for_avenant,
     upload_avenants_for_avenant,
 )
 from conventions.services.utils import ReturnStatus
+from siap.exceptions import OngoingAvenantSIAPException
 from users.models import User
 
 
@@ -120,8 +121,9 @@ class ConventionAvenantsServiceTests(TestCase):
         last_avenant.statut = ConventionStatut.PROJET.label
         last_avenant.save()
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(OngoingAvenantSIAPException) as exc:
             _get_last_avenant(self.convention)
+            assert exc.message == "Ongoing avenant already exists"
 
     def test_get_last_avenant_without_avenants(self):
         self.assertEqual(_get_last_avenant(self.convention), self.convention)

--- a/conventions/tests/services/test_avenants_service.py
+++ b/conventions/tests/services/test_avenants_service.py
@@ -43,14 +43,18 @@ class ConventionAvenantsServiceTests(TestCase):
         self.user = User.objects.get(username="nicolas")
         self.request.user = self.user
 
-    def _create_avenant(self):
+    def _create_avenant(self, statut=None):
         request = DummyRequest(
             "POST",
             {"avenant_type": "bailleur"},
             self.user,
         )
-        avenant = create_avenant(request, self.convention.uuid)
-        return avenant["convention"]
+        result = create_avenant(request, self.convention.uuid)
+        avenant = result["convention"]
+        if statut:
+            avenant.statut = statut.label
+            avenant.save()
+        return avenant
 
     def test_create_avenant_basic(self):
         request = DummyRequest(
@@ -100,26 +104,18 @@ class ConventionAvenantsServiceTests(TestCase):
         self.assertEqual(result["convention"].champ_libre_avenant, "Coucou")
         self.assertNotEqual(self.convention.champ_libre_avenant, "Coucou")
 
-    def _get_last_avenant_basic(self):
-        self._create_avenant()
+    def test_get_last_avenant_basic(self):
+        self._create_avenant(statut=ConventionStatut.SIGNEE)
+        last_avenant = self._create_avenant(statut=ConventionStatut.SIGNEE)
 
+        assert _get_last_avenant(self.convention) == last_avenant
+
+    def test_get_last_avenant_ongoing(self):
         request = DummyRequest(
             "POST",
-            {"uuid": self.convention.uuid, "avenant_type": "bailleur"},
+            {"avenant_type": "bailleur"},
             self.user,
         )
-
-        last_avenant = create_avenant(request, self.convention.uuid)["convention"]
-
-        self.assertEqual(_get_last_avenant(self.convention), last_avenant)
-
-    def _get_last_avenant_ongoing(self):
-        request = DummyRequest(
-            "POST",
-            {"uuid": self.convention.uuid, "avenant_type": "bailleur"},
-            self.user,
-        )
-
         last_avenant = create_avenant(request, self.convention.uuid)["convention"]
         last_avenant.statut = ConventionStatut.PROJET.label
         last_avenant.save()
@@ -127,5 +123,5 @@ class ConventionAvenantsServiceTests(TestCase):
         with self.assertRaises(Exception):
             _get_last_avenant(self.convention)
 
-    def _get_last_avenant_without_avenants(self):
+    def test_get_last_avenant_without_avenants(self):
         self.assertEqual(_get_last_avenant(self.convention), self.convention)

--- a/siap/exceptions.py
+++ b/siap/exceptions.py
@@ -57,3 +57,8 @@ class ConflictedOperationSIAPException(SIAPException):
         self.numero_operation = numero_operation
         self.diff = diff
         super().__init__(f"L'opération {numero_operation} est en doublon")
+
+
+class OngoingAvenantSIAPException(SIAPException):
+    def __init__(self):
+        super().__init__("Ongoing avenant already exists")

--- a/siap/exceptions.py
+++ b/siap/exceptions.py
@@ -57,8 +57,3 @@ class ConflictedOperationSIAPException(SIAPException):
         self.numero_operation = numero_operation
         self.diff = diff
         super().__init__(f"L'opération {numero_operation} est en doublon")
-
-
-class OngoingAvenantSIAPException(SIAPException):
-    def __init__(self):
-        super().__init__("Ongoing avenant already exists")


### PR DESCRIPTION
Des tests n'étaient pas exécutés dans ce fichier. En les renommant, ils se lancent mais les assertions failent. J'ai changé le payload de la requête en supprimant uuid, ce qui force la création de l'avenant et permet de passer les assertions. 