### PR TITLE
Fix adresse in recapitulatif

### DIFF
--- a/templates/conventions/programme.html
+++ b/templates/conventions/programme.html
@@ -35,7 +35,7 @@
                         {% endif %}
                         <div class="fr-my-3w">
                             {% include "common/form/input_textarea.html" with form_input=form.adresse helptext_visible="True" object_field="adresse__"|add:form.uuid.value %}
-                            {% if form.adresse.value is not None %}
+                            {% if form.adresse.value is not None and not convention.adresse %}
                                 <em class=" fr-hint-text">Si ce champs est déjà pré-rempli, c'est que des adresses ont déjà été associées à cette opération. <br/>Vous pouvez le modifier avec les adresses associées à cette convention.</em>
                             {% endif %}
                         </div>

--- a/templates/conventions/recapitulatif/operation.html
+++ b/templates/conventions/recapitulatif/operation.html
@@ -31,7 +31,11 @@
                         {% endif %}
 
                         {% include "common/display_field_if_exists.html" with label="Nom" value=programme.nom object_field="programme__nom__"|add:programme_uuid %}
-                        {% include "common/display_field_if_exists.html" with label="Adresse" value=convention.adresse object_field="programme__adresse__"|add:programme_uuid %}
+                        {% if convention.adresse %}
+                            {% include "common/display_field_if_exists.html" with label="Adresse" value=convention.adresse object_field="convention__adresse__"|add:convention_uuid %}
+                        {% else %}
+                            {% include "common/display_field_if_exists.html" with label="Adresse" value=programme.adresse object_field="programme__adresse__"|add:programme_uuid %}
+                        {% endif %}
                         {% include "common/display_field_if_exists.html" with label="Code postal" value=programme.code_postal object_field="programme__code_postal__"|add:programme_uuid %}
                         {% include "common/display_field_if_exists.html" with label="Ville" value=programme.ville object_field="programme__ville__"|add:programme_uuid %}
                         {% include "common/display_checkbox.html" with label="ANRU" value=programme.anru object_field="programme__anru__"|add:programme_uuid %}


### PR DESCRIPTION
L'adresse de la convention n'est plus visible sur le récapitulatif depuis l'ajout à la convention. https://github.com/MTES-MCT/apilos/pull/1073

Une PR pour la remettre, j'en ai profité pour enlever le message d'aide quand l'adresse est déjà défini dans la convention (à l'édition)