### PR TITLE
Recherche des conventions - scoring

### DIFF
--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -330,6 +330,7 @@ class ConventionSearchView(ConventionSearchBaseView):
             "search_input": self._get_non_empty_query_param("search_input", ""),
             "total_conventions": request.user.conventions().count(),
             "order_by": self._get_non_empty_query_param("order_by", ""),
+            "debug_search_scoring": settings.DEBUG_SEARCH_SCORING,
         }
 
     def get(self, request: AuthenticatedHttpRequest) -> HttpResponse:

--- a/core/settings.py
+++ b/core/settings.py
@@ -585,6 +585,9 @@ CLAMAV_SERVICE_PASSWORD = get_env_variable("CLAMAV_SERVICE_PASSWORD")
 TRIGRAM_SIMILARITY_THRESHOLD = get_env_variable(
     "TRIGRAM_SIMILARITY_THRESHOLD", float, default=0.3
 )
+DEBUG_SEARCH_SCORING = get_env_variable(
+    "DEBUG_SEARCH_SCORING", cast=bool, default=False
+)
 
 # Waffle
 FLAG_NEW_SEARCH = "nouvelle_recherche"

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -43,6 +43,13 @@
                             {% endif %}
                             <thead>
                                 <tr class="th_inline">
+
+                                    {% if debug_search_scoring %}
+                                        <th title="Scoring" scope="col">
+                                            >> Debug scoring >>>>>>>>>>>>>>
+                                        </th>
+                                    {% endif %}
+
                                     <th title="Statut de la convention" scope="col">
                                         Statut
                                     </th>
@@ -78,6 +85,33 @@
                             <tbody>
                                 {% for convention in conventions %}
                                     <tr id="convention_redirect_{{convention.uuid}}" class="clickable {% if convention|display_redirect_project and not convention.is_avenant %}project{% elif convention|display_redirect_sent %}sent{% elif convention|display_redirect_post_action and not convention.is_avenant %}signed{% endif %}">
+
+                                        {% if debug_search_scoring %}
+                                            <td>
+                                                <div>
+                                                    <b>score: {{ convention.score }}</b>
+                                                </div>
+                                                <div>
+                                                    programme nom: {{ convention.programme_nom_similarity }}
+                                                </div>
+                                                <div>
+                                                    programme ville: {{ convention.programme_ville_similarity }}
+                                                </div>
+                                                <div>
+                                                    programme numero: {{ convention.programme_numero_similarity }}
+                                                </div>
+                                                <div>
+                                                    bailleur nom: {{ convention.bailleur_nom_similarity }}
+                                                </div>
+                                                <div>
+                                                    bailleur siret: {{ convention.bailleur_siret_similarity }}
+                                                </div>
+                                                <div>
+                                                    conv numero: {{ convention.conv_numero_similarity }}
+                                                </div>
+                                            </td>
+                                        {% endif %}
+
                                         <td title="{{convention.statut_for_template.statut_display}}">
                                             {% include "conventions/home/statut_tag.html"  %}
                                             <script type="text/javascript" nonce="{{request.csp_nonce}}">


### PR DESCRIPTION
Optimisations sur la nouvelle recherche des conventions
- tester l'utilisation des trigrammes vs vector pour le nom et l'adresse du programme, ainsi que pour le nom du bailleur
- écrire une fonction de scoring, afin de pouvoir définir un score unique calculé en fonction des indices de similarité des trigrammes et / ou des rank des vector, et trier la liste des résultats avec ce score
- ajouter un outil de debug dans le template, pour aider pendant les tests
