### PR TITLE
Fix - filtre avenants de la nouvelle recherche des conventions

### DIFF
--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -342,7 +342,7 @@ class ConventionSearchView(ConventionSearchBaseView):
     def get_search_filters_mapping(self) -> list[tuple[str, str]]:
         return [
             ("anru", "anru"),
-            ("avec_avenant", "avec_avenant"),
+            ("avenant_seulement", "avenant_seulement"),
             ("date_signature", "date_signature"),
             ("financement", "financement"),
             ("order_by", "order_by"),

--- a/templates/conventions/convention_list_filters_new.html
+++ b/templates/conventions/convention_list_filters_new.html
@@ -108,7 +108,7 @@
                             <div class="fr-checkbox-group fr-checkbox-group--sm">
                                 <input name="avenant_seulement" id="checkbox-restrict-to-with-avenant" type="checkbox" {% if request.GET.avenant_seulement %}checked{% endif %}>
                                 <label class="fr-label" for="checkbox-restrict-to-with-avenant">
-                                    Afficher uniquement les conventions avec avenant
+                                    Afficher uniquement les avenants
                                 </label>
                             </div>
                         </div>

--- a/templates/conventions/convention_list_filters_new.html
+++ b/templates/conventions/convention_list_filters_new.html
@@ -102,11 +102,11 @@
                         </div>
                     </div>
 
-                    {# Champs avec avenant #}
+                    {# Champs avenant #}
                     <div class="fr-col-12 fr-col-md-12 fr-col-lg-5">
                         <div class="fr-fieldset__element">
                             <div class="fr-checkbox-group fr-checkbox-group--sm">
-                                <input name="avec_avenant" id="checkbox-restrict-to-with-avenant" type="checkbox" {% if request.GET.avec_avenant %}checked{% endif %}>
+                                <input name="avenant_seulement" id="checkbox-restrict-to-with-avenant" type="checkbox" {% if request.GET.avenant_seulement %}checked{% endif %}>
                                 <label class="fr-label" for="checkbox-restrict-to-with-avenant">
                                     Afficher uniquement les conventions avec avenant
                                 </label>


### PR DESCRIPTION
Si la case est cochée, il ne faut afficher que les avenants