### PR TITLE
Amélioration des perf sur les propriétés des conventions

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models import Q
 from django.forms import model_to_dict
 from django.http import HttpRequest
+from django.utils.functional import cached_property
 
 from conventions.models import TypeEvenement
 from conventions.models.avenant_type import AvenantType
@@ -466,12 +467,14 @@ class Convention(models.Model):
     def is_avenant(self):
         return self.parent_id is not None
 
+    @cached_property
     def is_denonciation(self):
         return (
             self.parent_id is not None
             and self.avenant_types.filter(nom="denonciation").exists()
         )
 
+    @cached_property
     def is_resiliation(self) -> bool:
         return (
             self.parent_id is not None
@@ -518,7 +521,7 @@ class Convention(models.Model):
         }
 
     def genderize_desc(self, desc):
-        if self.is_denonciation():
+        if self.is_denonciation:
             return desc.format(pronom="elle", accord="e", article="la", autre="")
         if self.is_avenant():
             return desc.format(pronom="il", accord="", article="le", autre="autre")

--- a/conventions/templatetags/display_filters.py
+++ b/conventions/templatetags/display_filters.py
@@ -5,9 +5,9 @@ register = template.Library()
 
 @register.filter
 def display_kind(convention):
-    if convention.is_denonciation():
+    if convention.is_denonciation:
         return "dénonciation"
-    if convention.is_resiliation():
+    if convention.is_resiliation:
         return "résiliation"
     if convention.is_avenant():
         return "avenant"
@@ -16,9 +16,9 @@ def display_kind(convention):
 
 @register.filter
 def display_kind_with_pronom(convention):
-    if convention.is_denonciation():
+    if convention.is_denonciation:
         return "la dénonciation"
-    if convention.is_resiliation():
+    if convention.is_resiliation:
         return "la résiliation"
     if convention.is_avenant():
         return "l'avenant"
@@ -27,9 +27,9 @@ def display_kind_with_pronom(convention):
 
 @register.filter
 def display_kind_with_demonstratif(convention):
-    if convention.is_denonciation():
+    if convention.is_denonciation:
         return "cette dénonciation"
-    if convention.is_resiliation():
+    if convention.is_resiliation:
         return "cette résiliation"
     if convention.is_avenant():
         return "cet avenant"
@@ -38,9 +38,9 @@ def display_kind_with_demonstratif(convention):
 
 @register.filter
 def display_kind_with_preposition(convention):
-    if convention.is_denonciation():
+    if convention.is_denonciation:
         return "de dénonciation"
-    if convention.is_resiliation():
+    if convention.is_resiliation:
         return "de résiliation"
     if convention.is_avenant():
         return "d'avenant"
@@ -49,7 +49,7 @@ def display_kind_with_preposition(convention):
 
 @register.filter
 def display_pronom(convention):
-    if convention.is_denonciation() or convention.is_resiliation():
+    if convention.is_denonciation or convention.is_resiliation:
         return "la"
     if convention.is_avenant():
         return "le"
@@ -58,7 +58,7 @@ def display_pronom(convention):
 
 @register.filter
 def display_personnal_pronom(convention):
-    if convention.is_denonciation() or convention.is_resiliation():
+    if convention.is_denonciation or convention.is_resiliation:
         return "elle"
     if convention.is_avenant():
         return "il"
@@ -67,7 +67,7 @@ def display_personnal_pronom(convention):
 
 @register.filter
 def display_gender_terminaison(convention):
-    if convention.is_denonciation() or convention.is_resiliation():
+    if convention.is_denonciation or convention.is_resiliation:
         return "e"
     if convention.is_avenant():
         return ""


### PR DESCRIPTION
Utilisation de `cached_property` pour éviter de multiples requêtes en DB inutiles