### PR TITLE
Fix - probleme de redirection sur la nouvelle recherche

### DIFF
--- a/conventions/tests/views/test_index_view.py
+++ b/conventions/tests/views/test_index_view.py
@@ -39,15 +39,9 @@ class ConventionIndexViewTests(TestCase):
             response = self.client.get(reverse("conventions:index"))
             self.assertRedirects(response, reverse("conventions:search"))
 
-    def test_feature_flag_redirect(self):
-        self._login()
-
-        response = self.client.get(reverse("conventions:search"))
-        self.assertRedirects(response, reverse("conventions:search_instruction"))
-
-        with override_flag(settings.FLAG_NEW_SEARCH, active=True):
-            response = self.client.get(reverse("conventions:search"))
-            assert response.status_code == 200
+        with override_flag(settings.FLAG_NEW_SEARCH, active=False):
+            response = self.client.get(reverse("conventions:index"))
+            self.assertRedirects(response, reverse("conventions:search_instruction"))
 
     def test_get_list_active(self):
         """

--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -1,11 +1,12 @@
 from django.contrib.auth.decorators import permission_required
 from django.urls import path
-from django.views.generic import RedirectView, TemplateView
+from django.views.generic import TemplateView
 
 from . import views
 from .views import (
     ConventionActivesSearchView,
     ConventionEnInstructionSearchView,
+    ConventionIndexView,
     ConventionSearchView,
     ConventionTermineesSearchView,
     LoyerSimulateurView,
@@ -15,7 +16,7 @@ urlpatterns = [
     # Pages de premier niveau : recherche et calculette de loyer
     path(
         "",
-        RedirectView.as_view(url="/conventions/recherche"),
+        ConventionIndexView.as_view(),
         name="index",
     ),
     path(

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -51,7 +51,9 @@ class UserViewTests(TestCase):
         )
         response = self.client.get(reverse("conventions:index"))
         self.assertRedirects(
-            response, reverse("conventions:search"), fetch_redirect_response=False
+            response,
+            reverse("conventions:search_instruction"),
+            fetch_redirect_response=False,
         )
         response = self.client.get(reverse("conventions:search_active"))
 


### PR DESCRIPTION
Probablement à cause du cache, on a observé avec Camille des problèmes de redirection sur la nouvelle recherch une fois le flag activé.

Cette PR devrait y remédier.
Je fais désormais la redirection au niveau de la page d'index
- si flag activé, redirection vers /conventions/recherche
- sinon, redirection ver /conventions/en-cours

Je garde une protection sur la nouvell page de recherche.
Si le flag n'est pas activé pour lui, l'utilisateur ne pourra pas y accéder en tapant l'url directement.