### PR TITLE
Filtre par plusieurs statuts dans la nouvelle recherche

### DIFF
--- a/conventions/services/search.py
+++ b/conventions/services/search.py
@@ -319,7 +319,7 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
     date_signature: str | None = None
     financement: str | None = None
     nature_logement: str | None = None
-    statut: ConventionStatut | None = None
+    statuts: list[ConventionStatut] | None = None
 
     search_input: str | None = None
     search_input_numbers: str | None = None
@@ -329,11 +329,16 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
         self.user = user
         self.anru = False
         self.avenant_seulement = False
+        self.statuts = None
 
         if search_filters:
             self.anru = search_filters.get("anru") is not None
             self.avenant_seulement = search_filters.get("avenant_seulement") is not None
-            self.statut = ConventionStatut.get_by_label(search_filters.get("statut"))
+            if search_filters.get("statuts"):
+                self.statuts = [
+                    ConventionStatut.get_by_label(s)
+                    for s in search_filters.get("statuts").split(",")
+                ]
             for name in (
                 "date_signature",
                 "financement",
@@ -352,8 +357,8 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
         return self.user.conventions()
 
     def _build_filters(self, queryset: QuerySet) -> QuerySet:
-        if self.statut:
-            queryset = queryset.filter(statut=self.statut.label)
+        if self.statuts:
+            queryset = queryset.filter(statut__in=[s.label for s in self.statuts])
 
         if self.anru:
             queryset = queryset.filter(programme__anru=True)

--- a/conventions/tests/services/test_search.py
+++ b/conventions/tests/services/test_search.py
@@ -198,9 +198,19 @@ class TestUserConventionSmartSearchService(ParametrizedTestCase, TestCase):
                 id="anru",
             ),
             param(
-                {"statut": ConventionStatut.PROJET.label},
+                {"statuts": ConventionStatut.PROJET.label},
                 ["fbb9890f-171b-402d-a35e-71e1bd791b71"],
-                id="statut",
+                id="statuts_unique",
+            ),
+            param(
+                {
+                    "statuts": f"{ConventionStatut.PROJET.label},{ConventionStatut.INSTRUCTION.label}"
+                },
+                [
+                    "fbb9890f-171b-402d-a35e-71e1bd791b72",
+                    "fbb9890f-171b-402d-a35e-71e1bd791b71",
+                ],
+                id="statuts_multiples",
             ),
             param(
                 {"financement": Financement.PLAI},

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -347,7 +347,7 @@ class ConventionSearchView(ConventionSearchBaseView):
             ("financement", "financement"),
             ("order_by", "order_by"),
             ("search_input", "search_input"),
-            ("statut", "cstatut"),
+            ("statuts", "cstatut"),
             ("nature_logement", "nature_logement"),
         ]
 

--- a/templates/conventions/convention_list_filters_new.html
+++ b/templates/conventions/convention_list_filters_new.html
@@ -31,16 +31,27 @@
                     {# Champs statut #}
                     <div class="fr-col-12 fr-col-lg-3 fr-mb-2w search-select">
                         <div class="select-label">Statut de la convention</div>
-                        <select class="fr-select fr-mt-1w" id="cstatut" name="cstatut">
-                            <option value="">Sélectionner une option</option>
+                        <select
+                            multiple
+                            class="fr-select fr-mt-1w"
+                            id="cstatut"
+                            name="cstatut">
                             {% for value, label in statut_choices %}
                                 <option value="{{ label }}"
-                                    {% if label == request.GET.cstatut %}selected{% endif %}>
+                                    {% if label in request.GET.cstatut %}selected{% endif %}>
                                     {{ label }}
                                 </option>
                             {% endfor %}
                         </select>
                     </div>
+                    <script type="text/javascript" nonce="{{request.csp_nonce}}">
+                        VirtualSelect.init({
+                            ele: '#cstatut',
+                            optionsCount: 5,
+                            search: false,
+                            multiple: true
+                        });
+                    </script>
 
                     {# Champs financement #}
                     <div class="fr-col-12 fr-col-lg-3 fr-mb-2w search-select">


### PR DESCRIPTION
[Airtable ticket](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwhG4jAQK4JhrSZz/rec9n8mNOqMdS0lE2?blocks=hide)

<img width="784" alt="Capture d’écran 2024-02-08 à 08 43 46" src="https://github.com/MTES-MCT/apilos/assets/26469767/0e64d47a-8e72-45a4-b031-ce8b320de24c">

J'ai utilisé le sélecteur multiple existant, qui est loin d'être parfait : il affiche des textes en anglais, et il change de hauteur selon s'il est sélectionné ou non.