### PR TITLE
Tri secondaire sur le tableau des logements

### DIFF
--- a/conventions/services/convention_generator.py
+++ b/conventions/services/convention_generator.py
@@ -114,7 +114,9 @@ def generate_convention_doc(convention: Convention, save_data=False):
         "lot": convention.lot,
         "administration": convention.programme.administration,
         "logement_edds": logement_edds,
-        "logements": convention.lot.logements.order_by("typologie").all(),
+        "logements": convention.lot.logements.order_by(
+            "typologie", "designation"
+        ).all(),
         "locaux_collectifs": convention.lot.locaux_collectifs.all(),
         "annexes": annexes,
         "stationnements": convention.lot.type_stationnements.all(),

--- a/conventions/tests/services/test_convention_generator.py
+++ b/conventions/tests/services/test_convention_generator.py
@@ -202,6 +202,20 @@ class ConventionServiceGeneratorTest(TestCase):
 
     def test_generate_convention_doc(self):
         convention = Convention.objects.get(numero="0001")
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T2, designation="Logement 2"
+        )
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T2, designation="Logement 1"
+        )
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T1, designation="Logement 3"
+        )
+        Logement.objects.create(
+            lot=convention.lot,
+            typologie=TypologieLogement.T1BIS,
+            designation="Logement 4",
+        )
         convention.programme.nature_logement = NatureLogement.RESISDENCESOCIALE
 
         with patch(
@@ -214,6 +228,12 @@ class ConventionServiceGeneratorTest(TestCase):
 
             mocked_render.assert_called_once()
             assert set(context.keys()) == convention_context_keys()
+            assert [logement.designation for logement in context["logements"]] == [
+                "Logement 3",
+                "Logement 4",
+                "Logement 1",
+                "Logement 2",
+            ]
 
     def test_get_convention_template_path(self):
         user = User.objects.get(username="fix")


### PR DESCRIPTION
Lien mattermost: https://mattermost.incubateur.net/fabnum-mte/pl/xx7siaa4ojnpbkocb4yxpe6uto

Ajout d'un critère de tri sur la désignation après le tri par typologie sur le tableau des logements.