### PR TITLE
Passe 2 UI de l'entête des conventions

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -164,7 +164,6 @@ class Convention(models.Model):
     donnees_validees = models.TextField(null=True, blank=True)
     nom_fichier_signe = models.CharField(max_length=255, null=True, blank=True)
     televersement_convention_signee_le = models.DateField(null=True, blank=True)
-    date_resiliation = models.DateField(null=True, blank=True)
     desc_avenant = models.TextField(null=True, blank=True)
 
     historique_financement_public = models.CharField(
@@ -477,12 +476,20 @@ class Convention(models.Model):
             and self.avenant_types.filter(nom="denonciation").exists()
         )
 
+    @property
+    def is_denonciation_due(self):
+        return date.today() > self.date_denonciation
+
     @cached_property
     def is_resiliation(self) -> bool:
         return (
             self.parent_id is not None
             and self.avenant_types.filter(nom="resiliation").exists()
         )
+
+    @property
+    def is_resiliation_due(self):
+        return date.today() > self.date_resiliation
 
     def is_incompleted_avenant_parent(self):
         if self.is_avenant() and (

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -818,7 +818,7 @@ button:not(:disabled).apilos-btn--secondary--red:hover {
 [class*="apilos-badge-"] {
   display:inline;
 }
-.apilos-badge {
+table .apilos-badge {
   min-width: 155px;
 }
 .apilos-badge-Projet {
@@ -916,7 +916,19 @@ button:not(:disabled).apilos-btn--secondary--red:hover {
   top: 0;
 }
 .apilos-sticky-2 {
-  top: 160px;
+  top: 176px;
+}
+.fr-container-fluid:has(.apilos-notice--warning) .apilos-sticky-2 {
+  top: 248px;
+}
+.recapitulatif .recapitulatif-link {
+  display: none;
+}
+.apilos-notice--warning {
+  background-color: var(--background-contrast-warning);
+}
+.apilos-notice--warning p {
+  color: var(--text-default-warning)
 }
 
 /*

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -710,6 +710,7 @@ table.fullwidth {
 .apilos-link {
   display: inline !important;
   text-decoration: none !important;
+  background-image: none;
 }
 /*  */
 .apilos-multiselect {

--- a/templates/conventions/common/form_header.html
+++ b/templates/conventions/common/form_header.html
@@ -3,9 +3,9 @@
 {% load display_filters %}
 
 {% if convention %}
-    <div class="apilos-sticky fr-pt-2w {% if convention|display_convention_form_progressbar %}no_navbar{% endif %}">
+    <div class="apilos-sticky {% if convention|display_convention_form_progressbar %}no_navbar{% endif %}">
         <div class="fr-notice fr-notice--info">
-            <div class="fr-container">
+            <div class="fr-container fr-py-2w">
                 <div class="block--row-strech">
                     <div class="block--row-strech-1 fr-mr-2w apilos--overflow_ellipsis">
                         <div class="fr-btn--icon-left fr-icon-arrow-go-back-fill fr-text--xs notes fr-pb-2w">
@@ -21,30 +21,39 @@
                             </div>
                         {% else %}
                             <div class="fr-grid-row fr-mt-2w apilos-text--black">
-                                <div class="fr-pr-1w apilos-separator">{% include "conventions/home/statut_tag.html"  %}</div>
+                                <div class="fr-pr-2w apilos-separator">{% include "conventions/home/statut_tag.html"  %}</div>
                                 {% if convention.programme.numero_galion %}
-                                    <div class="fr-px-1w apilos-separator">
+                                    <div class="fr-px-2w fr-text--sm apilos-separator">
                                         <a href="{% url 'programmes:operation_conventions' numero_operation=convention.programme.numero_galion %}">
                                             Opération n°{{convention.programme.numero_galion}}
                                         </a>
                                     </div>
                                 {% endif %}
-                                <div class="fr-px-1w apilos-separator">{{ convention.programme.ville|default_if_none:'-' }}</div>
-                                <div class="fr-px-1w apilos-separator">{{ convention.lot.nb_logements|default_if_none:'-' }} logement{{ convention.lot.nb_logements|pluralize }}</div>
-                                <div class="fr-px-1w apilos-separator">{{ convention.programme.get_nature_logement_display }}</div>
-                                <div class="fr-pl-1w">{{ convention.lot.financement|default_if_none:'' }}</div>
+                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.ville|default_if_none:'-' }}</div>
+                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.lot.nb_logements|default_if_none:'-' }} logement{{ convention.lot.nb_logements|pluralize }}</div>
+                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.get_nature_logement_display }}</div>
+                                <div class="fr-pl-2w fr-text--sm">{{ convention.lot.financement|default_if_none:'' }}</div>
+                                <div class="recapitulatif-link fr-pl-3w">
+                                    <a class="fr-link fr-text--sm" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
+                                        Voir le récapitulatif<span class="fr-pl-2w fr-icon-arrow-right-line fr-icon--sm" aria-hidden="true"></span>
+                                    </a>
+                                </div>
                             </div>
                         {% endif %}
                     </div>
-                    {% if request.session.is_expert and convention.statut == CONVENTION_STATUT.SIGNEE %}
-                        <div class="fr-alert fr-alert--warning">
-                            <h3 class="fr-alert__title">Mode expert - Les modifications sont sous votre responsabilité.</h3>
-                            <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}">Sortir du mode expert</a>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
         </div>
+        {% if request.session.is_expert and convention.statut == CONVENTION_STATUT.SIGNEE %}
+            <div class="fr-notice apilos-notice--warning">
+                <div class="fr-container">
+                    <div class="apilos-input-group--inline">
+                        <p><strong><span class="fr-icon-warning-fill fr-mr-2w"></span>Mode expert : vous modifiez une convention au statut valide </strong></p>
+                        <a class="fr-btn" href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}">Sortir du mode expert</a>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
     </div>
     {% if convention.ecolo_reference %}
         <div class="fr-container fr-pt-2w">

--- a/templates/conventions/common/form_header.html
+++ b/templates/conventions/common/form_header.html
@@ -7,38 +7,87 @@
         <div class="fr-notice fr-notice--info">
             <div class="fr-container fr-py-2w">
                 <div class="block--row-strech">
-                    <div class="block--row-strech-1 fr-mr-2w apilos--overflow_ellipsis">
+                    <div class="block--row-strech-1 apilos--overflow_ellipsis">
                         <div class="fr-btn--icon-left fr-icon-arrow-go-back-fill fr-text--xs notes fr-pb-2w">
                             <a href="{% url 'conventions:index' %}">
                                 Liste des conventions
                             </a>
                         </div>
-                        <h1 class="fr-h3 apilos-d-inline">{{convention.programme.nom}}</h1>
                         {% if convention.is_avenant %}
-                            <span class="apilos-h2-thin"> - {{convention|display_kind|capfirst}}{% if convention.numero %} n°{{ convention.numero }}{% endif %}</span>
-                            <div class="fr-py-3w">
-                                <a class='fr-link apilos-link' href="{% url 'conventions:post_action' convention_uuid=convention.parent.uuid %}">Consulter la convention originale</a>
-                            </div>
-                        {% else %}
-                            <div class="fr-grid-row fr-mt-2w apilos-text--black">
-                                <div class="fr-pr-2w apilos-separator">{% include "conventions/home/statut_tag.html"  %}</div>
-                                {% if convention.programme.numero_galion %}
-                                    <div class="fr-px-2w fr-text--sm apilos-separator">
-                                        <a href="{% url 'programmes:operation_conventions' numero_operation=convention.programme.numero_galion %}">
-                                            Opération n°{{convention.programme.numero_galion}}
-                                        </a>
+                            <span class="apilos-h2-thin apilos-text--black">{{convention|display_kind|capfirst}}{% if convention.numero %} n°{{ convention.numero }}{% endif %} - </span>
+                            <h1 class="fr-h3 apilos-d-inline">{{convention.programme.nom}}</h1>
+                            <div class="fr-grid-row fr-mt-2w fr-text--sm apilos-text--black">
+                                {% if convention.statut != CONVENTION_STATUT.RESILIEE and convention.statut != CONVENTION_STATUT.DENONCEE %}
+                                    <div class="fr-pr-2w">{% include "conventions/home/statut_tag.html"  %}</div>
+                                {% endif %}
+                                {% if convention.statut == CONVENTION_STATUT.RESILIEE and convention.date_resiliation %}
+                                    <div class="fr-pr-2w">
+                                        {% if convention.is_resiliation_due %}
+                                            Convention résiliée depuis le {{ convention.date_resiliation }}
+                                        {% else %}
+                                            Résiliation de la convention prévue le {{ convention.date_resiliation }}
+                                        {% endif %}
                                     </div>
                                 {% endif %}
-                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.ville|default_if_none:'-' }}</div>
-                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.lot.nb_logements|default_if_none:'-' }} logement{{ convention.lot.nb_logements|pluralize }}</div>
-                                <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.get_nature_logement_display }}</div>
-                                <div class="fr-pl-2w fr-text--sm">{{ convention.lot.financement|default_if_none:'' }}</div>
-                                <div class="recapitulatif-link fr-pl-3w">
-                                    <a class="fr-link fr-text--sm" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
-                                        Voir le récapitulatif<span class="fr-pl-2w fr-icon-arrow-right-line fr-icon--sm" aria-hidden="true"></span>
-                                    </a>
-                                </div>
+                                {% if convention.statut == CONVENTION_STATUT.DENONCEE and convention.date_denonciation %}
+                                    <div class="fr-pr-2w">
+                                        {% if convention.is_denonciation_due %}
+                                            Convention dénoncée depuis le {{ convention.date_denonciation }}
+                                        {% else %}
+                                            Dénonciation de la convention prévue le {{ convention.date_denonciation }}
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                                <a class='fr-link apilos-link fr-text--sm' href="{% url 'conventions:post_action' convention_uuid=convention.parent.uuid %}">Consulter la convention originale n°{{convention.parent.numero}} <span class="fr-pl-2w fr-icon-arrow-right-line fr-icon--sm" aria-hidden="true"></span></a>
                             </div>
+                        {% else %}
+                            {% if convention.statut == CONVENTION_STATUT.RESILIEE and convention.is_resiliation_due %}
+                                <span class="apilos-h2-thin apilos-text--black">Résiliation - </span>
+                            {% elif convention.statut == CONVENTION_STATUT.DENONCEE and convention.is_denonciation_due %}
+                                <span class="apilos-h2-thin apilos-text--black">Dénonciation - </span>
+                            {% endif %}
+                            <h1 class="fr-h3 apilos-d-inline">{{convention.programme.nom}}</h1>
+                            {% if convention.statut != CONVENTION_STATUT.RESILIEE and convention.statut != CONVENTION_STATUT.DENONCEE %}
+                                <div class="apilos-input-group--inline">
+                                    <div class="fr-grid-row fr-mt-2w apilos-text--black">
+                                        <div class="fr-pr-2w apilos-separator">{% include "conventions/home/statut_tag.html"  %}</div>
+                                        {% if convention.programme.numero_galion %}
+                                            <div class="fr-px-2w fr-text--sm apilos-separator">
+                                                <a href="{% url 'programmes:operation_conventions' numero_operation=convention.programme.numero_galion %}">
+                                                    Opération n°{{convention.programme.numero_galion}}
+                                                </a>
+                                            </div>
+                                        {% endif %}
+                                        <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.ville|default_if_none:'-' }}</div>
+                                        <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.lot.nb_logements|default_if_none:'-' }} logement{{ convention.lot.nb_logements|pluralize }}</div>
+                                        <div class="fr-px-2w fr-text--sm apilos-separator">{{ convention.programme.get_nature_logement_display }}</div>
+                                        <div class="fr-pl-2w fr-text--sm">{{ convention.lot.financement|default_if_none:'' }}</div>
+                                    </div>
+                                    <div class="recapitulatif-link fr-pl-3w">
+                                        <a class="fr-link apilos-link fr-text--sm" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
+                                            Voir le récapitulatif<span class="fr-pl-2w fr-icon-arrow-right-line fr-icon--sm" aria-hidden="true"></span>
+                                        </a>
+                                    </div>
+                                </div>
+                            {% endif %}
+                            {% if convention.statut == CONVENTION_STATUT.RESILIEE and convention.date_resiliation %}
+                                <div class="fr-mt-2w fr-text--sm apilos-text--black">
+                                    {% if convention.is_resiliation_due %}
+                                        Convention résiliée depuis le {{ convention.date_resiliation }}
+                                    {% else %}
+                                        Résiliation de la convention prévue le {{ convention.date_resiliation }}
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                            {% if convention.statut == CONVENTION_STATUT.DENONCEE and convention.date_denonciation %}
+                                <div class="fr-mt-2w fr-text--sm apilos-text--black">
+                                    {% if convention.is_denonciation_due %}
+                                        Convention dénoncée depuis le {{ convention.date_denonciation }}
+                                    {% else %}
+                                        Dénonciation de la convention prévue le {{ convention.date_denonciation }}
+                                    {% endif %}
+                                </div>
+                            {% endif %}
                         {% endif %}
                     </div>
                 </div>

--- a/templates/conventions/home/statut_tag.html
+++ b/templates/conventions/home/statut_tag.html
@@ -1,3 +1,11 @@
 <div class="apilos-badge">
-    <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}} fr-text--xs">{{convention.short_statut_neutre}}</div>
+    <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}} fr-text--xs">
+        {% if convention.statut == CONVENTION_STATUT.RESILIEE and not convention.is_resiliation_due %}
+            à résilier
+        {% elif convention.statut == CONVENTION_STATUT.DENONCEE and not convention.is_denonciation_due %}
+            à dénoncer
+        {% else %}
+            {{convention.short_statut_neutre}}
+        {% endif %}
+    </div>
 </div>

--- a/templates/conventions/home/statut_tag.html
+++ b/templates/conventions/home/statut_tag.html
@@ -1,11 +1,19 @@
 <div class="apilos-badge">
-    <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}} fr-text--xs">
-        {% if convention.statut == CONVENTION_STATUT.RESILIEE and not convention.is_resiliation_due %}
-            à résilier
-        {% elif convention.statut == CONVENTION_STATUT.DENONCEE and not convention.is_denonciation_due %}
-            à dénoncer
-        {% else %}
+    {% if convention.statut == CONVENTION_STATUT.RESILIEE and not convention.is_resiliation_due or convention.statut == CONVENTION_STATUT.DENONCEE and not convention.is_denonciation_due %}
+        <div class="fr-badge apilos-badge-Signee fr-icon-success-fill fr-badge--icon-success fr-text--xs">
+            Valide
+        </div>
+        <div class="fr-text--xs notes">
+            {% if convention.statut == CONVENTION_STATUT.RESILIEE and not convention.is_resiliation_due %}
+                Résiliation programmée
+            {% elif convention.statut == CONVENTION_STATUT.DENONCEE and not convention.is_denonciation_due %}
+                Dénonciation programmée
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}} fr-text--xs">
+
             {{convention.short_statut_neutre}}
-        {% endif %}
-    </div>
+        </div>
+    {% endif %}
 </div>

--- a/templates/conventions/home/statut_tag.html
+++ b/templates/conventions/home/statut_tag.html
@@ -1,3 +1,3 @@
 <div class="apilos-badge">
-    <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}}">{{convention.short_statut_neutre}}</div>
+    <div class="fr-badge apilos-badge-{{convention.statut_for_template.key_statut}} fr-icon-{{convention.statut_icone}}-fill fr-badge--icon-{{convention.statut_icone}} fr-text--xs">{{convention.short_statut_neutre}}</div>
 </div>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -24,7 +24,9 @@
                         </div>
                         <div class="fr-col-11">
                             {% if convention.televersement_convention_signee_le %}
-                                <div class="fr-grid-row">{{convention|display_kind|capfirst}} signé{{convention|display_gender_terminaison}} le <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}</strong></span></div>
+                                <div class="fr-grid-row">
+                                    {{convention|display_kind|capfirst}} n° <span class="fr-mr-1v"><strong>{{ convention.numero|default_if_none:'-' }}</strong></span> signé{{convention|display_gender_terminaison}} le <span class="fr-ml-1v">{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}</span>
+                                </div>
                             {% else %}
                                 <div class="fr-grid-row">Votre convention signée a déjà été déposée</div>
                             {% endif %}

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -11,7 +11,7 @@
 {% block content %}
     {% with programme_uuid=convention.programme.uuid|slugify convention_uuid=convention.uuid|slugify lot_uuid=convention.lot.uuid|slugify ecolo_ref=convention.ecolo_reference %}
         <input type="hidden" id="convention_uuid" value="{{ convention.uuid }}">
-        <div class="fr-container-fluid ds_banner">
+        <div class="fr-container-fluid ds_banner recapitulatif">
             {% include "conventions/common/form_header.html" %}
             {% include "common/nav_bar.html"  with nav_bar_step="recapitulatif" %}
             <div class="fr-container fr-mt-5w">

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% block page_title %}Recapitulatif - APiLos{% endblock %}
 {% load static %}
+{% load display_filters %}
 {% load custom_filters %}
 {% block javascript_extras %}
     <script src="{% static "js/comment-factory.js" %}" nonce="{{request.csp_nonce}}"></script>
@@ -15,6 +16,11 @@
             {% include "conventions/common/form_header.html" %}
             {% include "common/nav_bar.html"  with nav_bar_step="recapitulatif" %}
             <div class="fr-container fr-mt-5w">
+                {% if convention.statut == CONVENTION_STATUT.SIGNEE %}
+                    <div class="fr-px-2w">
+                        Convention n°<strong>{{ convention.numero|default_if_none:'-' }}</strong> signé{{convention|display_gender_terminaison}} le <span class="fr-ml-1v">{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-'}}</span>
+                    </div>
+                {% endif %}
                 {% csrf_token %}
                 {% if not convention.is_avenant %}
                     {% include "conventions/recapitulatif/alert_convention.html" %}


### PR DESCRIPTION
Amélioration de l'entête des conventions :
-  ajout bandeau Mode expert 
- taille des polices + espaces
- gestion des cas de dénonciation, résiliation

![image](https://github.com/MTES-MCT/apilos/assets/19302155/00fa27df-af8d-4e50-b3c9-077a858326ae)

![image](https://github.com/MTES-MCT/apilos/assets/19302155/fbd8532e-f134-4934-8681-ee117f1ddd00)

![image](https://github.com/MTES-MCT/apilos/assets/19302155/8ed52c36-3a4d-48c3-9f99-209ee99bce4d)

![image](https://github.com/MTES-MCT/apilos/assets/19302155/7e1857d2-7554-4b60-8def-be92a274a68c)

