### PR TITLE
Avenants bailleurs: changements de visibilité en correction

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -123,6 +123,7 @@ class User(AbstractUser):
                     Convention.objects.filter(
                         parent_id=Coalesce(obj.parent_id, obj.id),
                         statut__in=[
+                            ConventionStatut.CORRECTION.label,
                             ConventionStatut.A_SIGNER.label,
                             ConventionStatut.SIGNEE.label,
                         ],
@@ -472,6 +473,7 @@ class User(AbstractUser):
                     convs.filter(
                         parent_id=Coalesce(OuterRef("parent_id"), OuterRef("id")),
                         statut__in=[
+                            ConventionStatut.CORRECTION.label,
                             ConventionStatut.A_SIGNER.label,
                             ConventionStatut.SIGNEE.label,
                         ],

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -626,8 +626,7 @@ def test_conventions_visibility_bailleur_avenant(db):
     assert not user2.has_object_permission(avenant1)
     assert not user2.has_object_permission(avenant2)
 
-    # Change avenant statut to SIGNEE
-    avenant2.statut = ConventionStatut.SIGNEE.label
+    avenant2.statut = ConventionStatut.CORRECTION.label
     avenant2.save()
 
     assert user1.conventions().count() == 1


### PR DESCRIPTION
Discuté en sprint plan ce matin, on veut rendre le changement de bailleur effectif dès qu'un avenant est en statut en correction. 