### PR TITLE
Améliorations d'interface et corrections d'erreur sur l'ajout simplifie

### DIFF
--- a/conventions/services/from_operation.py
+++ b/conventions/services/from_operation.py
@@ -98,7 +98,9 @@ class SelectOperationService:
         return self.request.user.programmes()
 
     def _get_apilos_operation(self) -> Operation | None:
-        qs = self._user_programmes().filter(numero_galion=self.numero_operation)
+        qs = self._user_programmes().filter(
+            numero_galion=self.numero_operation, parent_id=None
+        )
         if qs.count() == 1:
             return Operation.from_apilos_programme(programme=qs.first())
         return None
@@ -112,7 +114,10 @@ class SelectOperationService:
                     self.numero_operation.replace("-", "").replace("/", ""),
                 )
             )
-            .filter(numero_operation_trgrm__gt=settings.TRIGRAM_SIMILARITY_THRESHOLD)
+            .filter(
+                numero_operation_trgrm__gt=settings.TRIGRAM_SIMILARITY_THRESHOLD,
+                parent_id=None,
+            )
             .order_by("-numero_operation_trgrm", "-cree_le")
         )
         return [Operation.from_apilos_programme(programme=p) for p in qs[:10]]
@@ -143,7 +148,9 @@ class AddConventionService:
             return Convention.objects.none()
 
         programme = (
-            Programme.objects.filter(numero_galion=self.operation.numero)
+            Programme.objects.filter(
+                numero_galion=self.operation.numero, parent_id=None
+            )
             .order_by("-cree_le")
             .first()
         )
@@ -193,7 +200,7 @@ class AddConventionService:
                     )
                 else:
                     programme = Programme.objects.get(
-                        numero_galion=self.operation.numero
+                        numero_galion=self.operation.numero, parent_id=None
                     )
 
                 lot = self._create_lot(programme=programme)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1102,26 +1102,6 @@ table .apilos-badge {
   display: none;
 }
 
-
-.apilos-notice-background {
-  background-color: #dde5ff;
-}
-.fr-notice .fr-table {
-  background-color: var(--background-default-grey);
-  border-radius: 0.5em;
-}
-.fr-notice .fr-table caption {
-  top: 1.5em;
-}
-.fr-notice .fr-table thead {
-  background-color: #f4f6ff;
-}
-.fr-notice .fr-table tbody {
-  background-color: var(--background-default-grey);
-}
-.fr-notice .fr-table tbody a {
-  background-image: none;
-}
 .apilos-no-dsfr-target[target="_blank"]::after {
   content: none;
 }

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -214,7 +214,7 @@
                                     {% flag "ajout_convention" %}
                                         <div>
                                             <a class="fr-btn fr-icon-add-line fr-btn--icon-left fr-btn--secondary fr-mr-2w" href="{% url 'conventions:from_operation_select' %}">
-                                                Ajouter une convention existante dans le SIAP / Apilos
+                                                Ajouter une convention dans le SIAP / Apilos
                                             </a>
                                         </div>
                                     {% endflag %}

--- a/templates/conventions/from_operation/add_avenants.html
+++ b/templates/conventions/from_operation/add_avenants.html
@@ -15,9 +15,13 @@
 {% block content %}
 
     <div class="fr-container fr-my-5w">
-        <h3>Ajouter une convention existante</h3>
+        <h1>Ajouter une convention</h1>
 
         {% include "./stepper.html"%}
+
+        <div class="fr-alert fr-alert--success">
+            <p>La convention {{ convention }} a bien été ajoutée dans Apilos !</p>
+        </div>
 
         {% if avenants %}
             <div class="fr-grid-row fr-grid-row--gutters">
@@ -82,7 +86,7 @@
                 </div>
                 <div class="fr-col-6">
                     <div class="form-button-footer fr-pt-4w">
-                        <button class="fr-btn fr-icon-add-circle-line fr-btn--icon-left fr-btn--secondary" name="action" value="submit" type="submit">
+                        <button class="fr-btn fr-icon-add-circle-line fr-btn--icon-left fr-btn--primary" name="action" value="submit" type="submit">
                             Ajouter cet avenant
                         </button>
                     </div>
@@ -95,10 +99,9 @@
                 <div class="block--row-strech-1">
                 </div>
                 <div class="form-button-footer">
-                    <a href="{% url 'conventions:post_action' convention_uuid=convention.uuid %}" class="fr-link">
-                        <button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right" name="action">
-                            Passer cette étape
-                        </button>
+                    <a href="{% url 'conventions:post_action' convention_uuid=convention.uuid %}" class="fr-btn fr-btn--tertiary fr-icon-arrow-right-s-line fr-btn--icon-right">
+                        Passer cette étape
+
                     </a>
                 </div>
             </div>

--- a/templates/conventions/from_operation/add_convention.html
+++ b/templates/conventions/from_operation/add_convention.html
@@ -15,7 +15,7 @@
 {% block content %}
 
     <div class="fr-container fr-my-5w">
-        <h3>Ajouter une convention existante</h3>
+        <h1>Ajouter une convention</h1>
 
         {% include "./stepper.html"%}
 
@@ -27,26 +27,27 @@
             </div>
 
         {% else %}
+            <h3 class="fr-pb-2w fr-toggle--border-bottom fr-mb-5w">Opération liée</h3>
 
-            <div class="apilos-notice-background fr-notice fr-notice--info fr-mb-5w fr-mt-1w fr-pt-3w">
-                <div class="fr-container fr-px-5w">
-                    <h3>{{operation.nom}}</h3>
-                    <div class="apilos-input-group--inline">
-                        <div class="fr-grid-row fr-mt-1w apilos-text--black">
-                            <div class="fr-pr-2w fr-text--sm apilos-separator">
-                                <a href="{% url 'programmes:operation_conventions' numero_operation=operation.numero %}">
-                                    Opération n°{{operation.numero}}
-                                </a>
-                            </div>
-                            <div class="fr-px-2w fr-text--sm apilos-separator">{{operation.commune}}</div>
-                            <div class="fr-px-2w fr-text--sm">Bailleur : {{operation.bailleur}}</div>
+            <div class="fr-mb-7w">
+                <h4 class="fr-mb-0">{{operation.nom}}</h4>
+                <div class="apilos-input-group--inline">
+                    <div class="fr-grid-row fr-mt-1w apilos-text--black">
+                        <div class="fr-pr-2w fr-text--sm apilos-separator">
+                            <a href="{% url 'programmes:operation_conventions' numero_operation=operation.numero %}">
+                                Opération n°{{operation.numero}}
+                            </a>
                         </div>
+                        <div class="fr-px-2w fr-text--sm apilos-separator">{{operation.commune}}</div>
+                        <div class="fr-px-2w fr-text--sm">Bailleur : {{operation.bailleur}}</div>
                     </div>
-                    <div class="fr-table fr-table--bordered fr-table--layout-fixed apilos-text--black fr-my-3w fr-p-3w fr-pt-7w">
+                </div>
+                {% if conventions.count > 0 %}
+                    <div class="fr-table fr-table--bordered fr-table--layout-fixed apilos-text--black">
                         <table>
-                            <caption class="fr-text--sm">Convention(s) liée(s) à cette opération et enregistrée(s) dans le SIAP / Apilos</caption>
+                            <caption class="fr-text--sm fr-text--regular">Convention(s) liée(s) à cette opération et enregistrée(s) dans le SIAP / Apilos</caption>
                             <thead>
-                                <tr>
+                                <tr class="th_inline">
                                     <th scope="col">Statut</th>
                                     <th scope="col">Numéro de convention</th>
                                     <th scope="col">Financement</th>
@@ -56,7 +57,7 @@
                             </thead>
                             <tbody>
                                 {% for convention in conventions %}
-                                    <tr>
+                                    <tr class="clickable" id="convention_redirect_{{convention.uuid}}">
                                         <td>
                                             <div class="fr-pr-2w">
                                                 {% include "conventions/home/statut_tag.html"  %}
@@ -66,18 +67,38 @@
                                         <td>{{ convention.lot.financement }}</td>
                                         <td>{{ convention.lot.nb_logements }}</td>
                                         <td>
-                                            <a target="_blank" rel="noopener" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}" class="apilos-no-dsfr-target">
-                                                <span class="fr-icon-eye-line" aria-hidden="true"></span>
-                                            </a>
+                                            <span class="fr-icon-eye-line" aria-hidden="true"></span>
                                         </td>
                                     </tr>
+                                    <script type="text/javascript" nonce="{{request.csp_nonce}}">
+                                        document.addEventListener('DOMContentLoaded', function () {
+                                            document.getElementById('convention_redirect_{{convention.uuid}}').addEventListener('click', function(){
+                                                if (this.classList.contains("sent")) {
+                                                    const url="{% url 'conventions:sent' convention_uuid=convention.uuid %}"
+                                                    window.open(url, "_blank");
+                                                }
+                                                else if (this.classList.contains("signed")) {
+                                                    const url="{% url 'conventions:post_action' convention_uuid=convention.uuid %}"
+                                                    window.open(url, "_blank");
+                                                }
+                                                else if (this.classList.contains("project")) {
+                                                    const url="{% url 'conventions:bailleur' convention_uuid=convention.uuid %}"
+                                                    window.open(url, "_blank");
+                                                }
+                                                else {
+                                                    const url="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}"
+                                                    window.open(url, "_blank");
+                                                }
+                                            });
+                                        });
+                                    </script>
                                 {% endfor %}
                             </tbody>
                         </table>
                     </div>
-                </div>
+                {% endif %}
             </div>
-            <h6>Détails de la convention à ajouter</h6>
+            <h3 class="fr-pb-2w fr-toggle--border-bottom fr-mb-5w">Détails de la convention à ajouter</h3>
             <form method="post" action="" enctype="multipart/form-data">
                 {% csrf_token %}
 

--- a/templates/conventions/from_operation/select_operation.html
+++ b/templates/conventions/from_operation/select_operation.html
@@ -7,7 +7,7 @@
 {% block content %}
 
     <div class="fr-container fr-my-5w">
-        <h3>Ajouter une convention existante</h3>
+        <h1>Ajouter une convention</h1>
 
         {% include "./stepper.html"%}
 
@@ -18,8 +18,8 @@
                     <div class="select-label">Numéro de l'opération</div>
                     <input class="fr-input fr-mt-1w" type="search" id="numero_operation" name="numero_operation" value="{{ request.GET.numero_operation }}" placeholder="Rechercher"/>
                 </div>
-                <div class="fr-col-12 fr-col-lg-6 fr-grid-row fr-grid-row--right">
-                    <button class="fr-btn fr-mt-3w" id="search_btn">
+                <div class="fr-col-12 fr-col-lg-6">
+                    <button class="fr-btn fr-btn--primary fr-mt-4w" id="search_btn">
                         <span class="fr-icon-search-line fr-mr-1w" aria-hidden="true"></span>
                         Rechercher
                     </button>

--- a/templates/conventions/from_operation/select_operation_list.html
+++ b/templates/conventions/from_operation/select_operation_list.html
@@ -4,13 +4,6 @@
     <div class="fr-table fr-table--bordered table--layout-fixed">
         <table aria-label="Operations">
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-2w">
-                <div class="fr-grid-row fr-col-12">
-                    <div class="fr-mr-2w notes">{{ operations|length }} résultat(s)</div>
-                    <a href="{{ request.path }}" class="fr-link">
-                        <span class="fr-icon-close-circle-line fr-mr-1w"></span>
-                        Réinitaliser la recherche
-                    </a>
-                </div>
                 <thead>
                     <tr class="th_inline">
                         <th title="Numéro de l'opération" scope="col">
@@ -41,7 +34,7 @@
                             <td>{{ operation.nature }}</td>
                             <td>{{ operation.commune }}</td>
                             <td>
-                                <button class="fr-btn--tertiary">
+                                <button class="fr-btn fr-btn--tertiary-no-outline">
                                     <span class="fr-icon-arrow-right-line" aria-hidden="true"></span>
                                 </button>
                             </td>
@@ -55,7 +48,7 @@
             {% if exact_match %}
                 <div class="fr-mt-10w"></div>
             {% else %}
-                <div class="fr-col-9">
+                <div class="fr-col-7">
                     <div class="fr-text--lg">Vous ne trouvez pas l'opération liée ?</div>
                     <div>
                         Vérifiez que vous avez saisi un numéro d'opération correct.<br>
@@ -74,7 +67,10 @@
                         </div>
                     </div>
                 </div>
-                <img class="fr-mr-3w" src="/static/icons/not_found.png" alt="not_found">
+
+                <div class="fr-col-5 text--center">
+                    <img src="/static/icons/not_found.png" alt="not_found">
+                </div>
             {% endif %}
         </div>
 
@@ -82,11 +78,10 @@
 
     {% if request.GET.numero_operation %}
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-5w">
-            <div class="fr-col-9">
+            <div class="fr-col-7">
                 <div class="fr-text--lg">Aucune opération trouvée</div>
                 <div>
-                    L'opération portant le numéro {{ request.GET.numero_operation }} n'est pas référencée dans le SIAP / Apilos.<br>
-                    Vérifiez que le numéro est correct, ou contactez notre équipe support.
+                    L'opération portant le numéro {{ request.GET.numero_operation }} n'est pas référencée dans le SIAP / Apilos. Vérifiez que le numéro est correct, ou contactez notre équipe support.
                 </div>
                 <div class="fr-mt-5w fr-ml-1w">
                     <div class="fr-grid-row fr-grid-row--gutters" >
@@ -100,8 +95,17 @@
                     </div>
                 </div>
             </div>
-            <img class="fr-mr-3w" src="/static/icons/not_found.png" alt="not_found">
+            <div class="fr-col-5 text--center">
+                <img src="/static/icons/not_found.png" alt="not_found">
+            </div>
         </div>
+    {% else %}
+        <p class="fr-mt-10w fr-mb-2w">Vous n'avez pas le numéro de l'opération ?</p>
+        {% if siap_assistance_url %}
+            <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary" href="{{ siap_assistance_url }}">
+                Contactez l'assistance
+            </a>
+        {% endif %}
     {% endif %}
 
 

--- a/templates/conventions/from_operation/stepper.html
+++ b/templates/conventions/from_operation/stepper.html
@@ -3,7 +3,7 @@
     <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-stepper fr-col-md-12">
             <h2 class="fr-stepper__title">
-                {{form_step.current_step.title}}
+                {{form_step.current_step}}
                 <span class="fr-stepper__state">Étape {{form_step.number}} sur {{form_step.total}}</span>
             </h2>
             <div class="fr-stepper__steps" data-fr-current-step="{{form_step.number}}" data-fr-steps="{{form_step.total}}"></div>
@@ -12,7 +12,7 @@
                     <div class="fr-col-6">
                         <p class="fr-stepper__details">
                             <span class="fr-text--bold">Etape suivante : </span>
-                            {{form_step.next_step.title}}
+                            {{form_step.next_step}}
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Suite aux retours de Camille :
- Les titres n'ont plus chaque lettre en majuscule dans le stepper
- En étape 1 il y a un texte d'aide avant de chercher
- Un hover sur les tableaux (merci marjo !)
- Une ligne cliquable dans le tableau des conventions
- Une alerte pour le succès de la création de convention est ajoutée en 3ème étape
- Des fixs html/css mineurs