### PR TITLE
Improve the convention admin page

### DIFF
--- a/conventions/admin.py
+++ b/conventions/admin.py
@@ -3,6 +3,7 @@ from typing import Any
 from django import forms
 from django.contrib import admin
 from django.contrib.admin import ChoicesFieldListFilter
+from django.core.exceptions import ValidationError
 
 from admin.admin import ApilosModelAdmin
 from admin.filters import IsCloneFilter
@@ -47,6 +48,14 @@ class ConventionModelForm(forms.ModelForm):
                 initial["statut"] = statut.name
 
         super().__init__(*args, initial=initial, **kwargs)
+
+    def validate_unique(self) -> None:
+        super().validate_unique()
+
+        try:
+            self.instance.validate_constraints()
+        except ValidationError as err:
+            self.add_error(None, err)
 
     def save(self, commit: bool = True) -> Any:
         self.instance.statut = ConventionStatut[self.instance.statut].label

--- a/programmes/admin.py
+++ b/programmes/admin.py
@@ -7,6 +7,7 @@ from django.http import HttpRequest
 from admin.admin import ApilosModelAdmin
 from admin.filters import IsCloneFilter
 from bailleurs.models import Bailleur
+from conventions.models import Convention
 from instructeurs.models import Administration
 from programmes.models import IndiceEvolutionLoyer
 
@@ -18,6 +19,28 @@ from .models import (
     ReferenceCadastrale,
     TypeStationnement,
 )
+
+
+class ConventionInline(admin.StackedInline):
+    model = Convention
+    fields = ("uuid", "get_statut", "financement", "lot")
+    readonly_fields = (
+        "uuid",
+        "get_statut",
+    )
+    show_change_link = True
+    can_delete = False
+    extra = 0
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    @admin.display(description="Statut")
+    def get_statut(self, obj):
+        return obj.statut
 
 
 @admin.register(Programme)
@@ -61,6 +84,8 @@ class ProgrammeAdmin(ApilosModelAdmin):
         "numero_galion",
         "uuid",
     )
+
+    inlines = (ConventionInline,)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "administration":


### PR DESCRIPTION
- ajout d'un message explicite en cas de problèe d'unicité sur la clé `unique_display_name`
- affichage des conventions en "inline" sur la page de détails d'un programme