### PR TITLE
Amélioration de la recherche de type "ecoloweb"

### DIFF
--- a/conventions/services/search.py
+++ b/conventions/services/search.py
@@ -463,7 +463,8 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
 
         if self.search_numero:
             _search_numero_n = self.search_numero.replace("-", "").replace("/", "")
-            if len(_search_numero_n) < 5:
+            _search_numero_s = len(_search_numero_n)
+            if _search_numero_s > 0 and _search_numero_s < 5:
                 if self.avenant_seulement:
                     queryset = queryset.annotate(
                         parent_numero_n=Replace(
@@ -473,12 +474,12 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
                     ).filter(parent_numero_n__endswith=_search_numero_n)
                 else:
                     queryset = queryset.annotate(
-                        parent_numero_n=Replace(
-                            Replace(Replace("parent__numero", Value("/")), Value("-")),
+                        numero_n=Replace(
+                            Replace(Replace("numero", Value("/")), Value("-")),
                             Value(" "),
                         ),
-                        numero_norm=Replace(
-                            Replace(Replace("numero", Value("/")), Value("-")),
+                        parent_numero_n=Replace(
+                            Replace(Replace("parent__numero", Value("/")), Value("-")),
                             Value(" "),
                         ),
                     ).filter(

--- a/conventions/services/search.py
+++ b/conventions/services/search.py
@@ -462,15 +462,28 @@ class UserConventionSmartSearchService(ConventionSearchBaseService):
             )
 
         if self.search_numero:
-            if len(self.search_numero) == 4:
+            _search_numero_n = self.search_numero.replace("-", "").replace("/", "")
+            if len(_search_numero_n) < 5:
                 if self.avenant_seulement:
-                    queryset = queryset.filter(
-                        parent__numero__endswith=self.search_numero
-                    )
+                    queryset = queryset.annotate(
+                        parent_numero_n=Replace(
+                            Replace(Replace("parent__numero", Value("/")), Value("-")),
+                            Value(" "),
+                        )
+                    ).filter(parent_numero_n__endswith=_search_numero_n)
                 else:
-                    queryset = queryset.filter(
-                        Q(numero__endswith=self.search_numero)
-                        | Q(parent__numero__endswith=self.search_numero)
+                    queryset = queryset.annotate(
+                        parent_numero_n=Replace(
+                            Replace(Replace("parent__numero", Value("/")), Value("-")),
+                            Value(" "),
+                        ),
+                        numero_norm=Replace(
+                            Replace(Replace("numero", Value("/")), Value("-")),
+                            Value(" "),
+                        ),
+                    ).filter(
+                        Q(numero_n__endswith=_search_numero_n)
+                        | Q(parent__numero_n__endswith=_search_numero_n)
                     )
             else:
                 if self.avenant_seulement:

--- a/conventions/tests/services/test_search.py
+++ b/conventions/tests/services/test_search.py
@@ -120,7 +120,7 @@ class TestUserConventionSmartSearchService(
 
         ConventionFactory(
             uuid="fbb9890f-171b-402d-a35e-71e1bd791b70",
-            numero="33N611709S700029",
+            numero="33N611709S70002-9",
             statut=ConventionStatut.SIGNEE.label,
             financement=Financement.PLUS,
             televersement_convention_signee_le="2024-01-01",
@@ -338,7 +338,21 @@ class TestUserConventionSmartSearchService(
             param(
                 {"search_numero": "0029"},
                 ["fbb9890f-171b-402d-a35e-71e1bd791b70"],
-                id="numero_convention_derniers_caracteres",
+                id="numero_convention_4_derniers_caracteres",
+            ),
+            param(
+                {"search_numero": "29"},
+                ["fbb9890f-171b-402d-a35e-71e1bd791b70"],
+                id="numero_convention_2_derniers_caracteres",
+            ),
+            param(
+                {"search_numero": "9"},
+                [
+                    "fbb9890f-171b-402d-a35e-71e1bd791b72",
+                    "fbb9890f-171b-402d-a35e-71e1bd791b70",
+                    "a6862260-5afa-4e2c-ae07-a39276c55e46",
+                ],
+                id="numero_convention_dernier_caractere",
             ),
             param(
                 {"search_lieu": "01012"},


### PR DESCRIPTION
- si moins de 5 caractères dans les termes de recherche de numéro, on fait une requête de type "endswith", sinon on fait une requête classique
- on normalise le termes de recherche avant de compter les caractères, afin de ne pas tenir compte des caractères spéciaux