### PR TITLE
Use bailleur name from SIAP in ajout simplifie

### DIFF
--- a/conventions/services/from_operation.py
+++ b/conventions/services/from_operation.py
@@ -42,8 +42,7 @@ class Operation:
             nom=payload["donneesOperation"]["nomOperation"],
             numero=payload["donneesOperation"]["numeroOperation"],
             nature=payload["donneesOperation"]["natureLogement"],
-            # FIXME: use entiteMorale.nom
-            bailleur=payload["gestionnaire"]["code"],
+            bailleur=payload["donneesMo"]["nom"],
             commune=payload["donneesLocalisation"]["adresseComplete"]["commune"],
             siap_payload=payload,
         )

--- a/conventions/tests/services/test_from_operation.py
+++ b/conventions/tests/services/test_from_operation.py
@@ -56,7 +56,7 @@ class TestSelectOperationService(PGTrgmTestMixin, ParametrizedTestCase, TestCase
                     Operation(
                         numero="20220600006",
                         nom="Programme 2",
-                        bailleur="13055",
+                        bailleur="3F",
                         nature="LOO",
                         commune="Marseille",
                         siap_payload=operation_mock,


### PR DESCRIPTION
C'est juste une question d'affichage et ça n'affecte pas l'enregistrement des conventions simplifiés. On affichait l'administration d'une opération SIAP à la place du bailleur, c'est corrigé.