### PR TITLE
Fix search filter annee pagination

### DIFF
--- a/templates/conventions/convention_list_filters_new.html
+++ b/templates/conventions/convention_list_filters_new.html
@@ -130,7 +130,7 @@
                                 <option value="">Sélectionner une période</option>
                                 {% for value, label in date_signature_choices %}
                                     <option value="{{ value }}"
-                                            {% if value == request.GET.date_signature %}selected{% endif %}>
+                                            {% if label == request.GET.date_signature %}selected{% endif %}>
                                         {{ label }}
                                     </option>
                                 {% endfor %}


### PR DESCRIPTION
Escalade sur mattermost: https://mattermost.incubateur.net/fabnum-mte/pl/uajcqe7nf7fo5ge5pxpd4en9ma

Ce fix suffit à corriger la pagination. En fait le dropdown d'année ne prenait pas en compte la valeur en query param dans l'url.