### PR TITLE
Override cerfa avenants

### DIFF
--- a/conventions/services/finalisation.py
+++ b/conventions/services/finalisation.py
@@ -83,5 +83,4 @@ class FinalisationCerfaService(FinalisationServiceBase):
 
 
 class FinalisationValidationService(FinalisationServiceBase):
-    def __init__(self, convention_uuid: str, request: HttpRequest) -> None:
-        self.convention = Convention.objects.get(uuid=convention_uuid)
+    pass

--- a/conventions/services/finalisation.py
+++ b/conventions/services/finalisation.py
@@ -83,4 +83,5 @@ class FinalisationCerfaService(FinalisationServiceBase):
 
 
 class FinalisationValidationService(FinalisationServiceBase):
-    pass
+    def __init__(self, convention_uuid: str, request: HttpRequest) -> None:
+        self.convention = Convention.objects.get(uuid=convention_uuid)

--- a/conventions/tests/views/test_finalisation.py
+++ b/conventions/tests/views/test_finalisation.py
@@ -4,6 +4,10 @@ from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 from waffle.testutils import override_flag
 
+from conventions.forms.convention_form_finalisation import (
+    FinalisationCerfaForm,
+    FinalisationNumeroForm,
+)
 from conventions.models.choices import ConventionStatut
 from conventions.tests.factories import ConventionFactory
 
@@ -18,6 +22,17 @@ def convention():
     )
 
 
+@pytest.fixture
+def avenant(convention):
+    return ConventionFactory(
+        statut=ConventionStatut.INSTRUCTION.label,
+        numero="3456",
+        parent_id=convention.id,
+        fichier_override_cerfa='{"files": {"705e2175-4a1d-4670-b9d0-de8f3c4a5432": {"uuid": "705e2175-4a1d-4670-b9d0-'
+        'de8f3c4a5432", "size": 345913, "filename": "Cerfa.docx"}}, "text": ""}',
+    )
+
+
 @pytest.mark.django_db
 @override_flag(settings.FLAG_OVERRIDE_CERFA, active=True)
 def test_get_numero(client, convention):
@@ -26,6 +41,26 @@ def test_get_numero(client, convention):
     assert response.status_code == 200
     assertTemplateUsed(response, "conventions/finalisation/numero.html")
     assert "1234" in str(response.content)
+    assert (
+        response.context["form_step"]["current_step"]
+        == "Valider le numéro de la convention"
+    )
+    assert isinstance(response.context["form"], FinalisationNumeroForm)
+
+
+@pytest.mark.django_db
+@override_flag(settings.FLAG_OVERRIDE_CERFA, active=True)
+def test_get_numero_avenant(client, avenant):
+    url = reverse("conventions:finalisation_numero", args=[avenant.uuid])
+    response = client.get(url)
+    assert response.status_code == 200
+    assertTemplateUsed(response, "conventions/finalisation/numero.html")
+    assert "3456" in str(response.content)
+    assert (
+        response.context["form_step"]["current_step"]
+        == "Valider le numéro de l'avenant"
+    )
+    assert isinstance(response.context["form"], FinalisationNumeroForm)
 
 
 @pytest.mark.django_db
@@ -60,6 +95,8 @@ def test_get_cerfa(client, convention):
     response = client.get(url)
     assert response.status_code == 200
     assertTemplateUsed(response, "conventions/finalisation/cerfa.html")
+    assert response.context["form_step"]["current_step"] == "Vérifier le document CERFA"
+    assert isinstance(response.context["form"], FinalisationCerfaForm)
 
 
 @pytest.mark.django_db
@@ -83,3 +120,20 @@ def test_get_validation(client, convention):
     response = client.get(url)
     assert response.status_code == 200
     assertTemplateUsed(response, "conventions/finalisation/validation.html")
+    assert (
+        response.context["form_step"]["current_step"]
+        == "Valider et envoyer la convention pour signature"
+    )
+
+
+@pytest.mark.django_db
+@override_flag(settings.FLAG_OVERRIDE_CERFA, active=True)
+def test_get_validation_avenant(client, avenant):
+    url = reverse("conventions:finalisation_validation", args=[avenant.uuid])
+    response = client.get(url)
+    assert response.status_code == 200
+    assertTemplateUsed(response, "conventions/finalisation/validation.html")
+    assert (
+        response.context["form_step"]["current_step"]
+        == "Valider et envoyer l'avenant pour signature"
+    )

--- a/templates/conventions/actions/instructeur_validation.html
+++ b/templates/conventions/actions/instructeur_validation.html
@@ -5,7 +5,14 @@
 
     <div role="alert" class="fr-alert fr-alert--A_signer fr-icon-arrow-right-s-line-double h-100">
         {% if convention.is_avenant %}
-            {% include "conventions/avenant/complete_form_for_avenants.html" with form=complete_for_avenant_form %}
+            {% flag "override_cerfa" %}
+                <p class="fr-alert__title fr-mb-3w">Finaliser l'avenant en trois étapes</p>
+                <p class="fr-mb-3w">Toutes les corrections sont terminées ?</p>
+                <p class="fr-mb-3w">Nous vous invitons à vérifier le document CERFA de l'avenant avant sa validation finale.</p>
+                <a class="fr-btn fr-btn--primary" href="{% url 'conventions:finalisation_numero' convention_uuid=convention.uuid %}" data-turbo="false">Finaliser l'avenant</a>
+            {% else %}
+                {% include "conventions/avenant/complete_form_for_avenants.html" with form=complete_for_avenant_form %}
+            {% endflag %}
         {% else %}
             {% flag "override_cerfa" %}
                 <p class="fr-alert__title fr-mb-3w">Finaliser la convention en trois étapes</p>

--- a/templates/conventions/finalisation/cerfa.html
+++ b/templates/conventions/finalisation/cerfa.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load display_filters %}
 {% block page_title %}Finalisation - APiLos{% endblock %}
 
 {% load static %}
@@ -18,16 +19,16 @@
 {% block content %}
     {% include "conventions/common/form_header.html"%}
     <div class="fr-container fr-my-5w">
-        <h1>Finaliser la convention</h1>
+        <h1>Finaliser {{convention|display_kind_with_pronom}}</h1>
 
         {% include "../common/stepper.html"%}
-        <p>Vous pouvez relire la convention avant qu'elle ne soit envoyée pour signature.</p>
+        <p>Vous pouvez relire {{convention|display_kind_with_pronom}} avant qu'{{convention|display_personnal_pronom}} ne soit envoyé{{convention|display_gender_terminaison}} pour signature.</p>
 
         <form method="post" action="{% url 'conventions:generate' convention_uuid=convention.uuid %}" data-turbo="false" class="fr-mb-7w">
             {% csrf_token %}
             <input hidden name="without_filigram" value="1">
             <button class="fr-btn fr-btn--primary fr-icon-download-line fr-btn--icon-left">
-                Télécharger le CERFA de la convention
+                Télécharger le CERFA de {{convention|display_kind_with_pronom}}
             </button>
         </form>
 
@@ -36,11 +37,11 @@
         <div class="fr-accordions-group">
             <section class="fr-accordion">
                 <h3 class="fr-accordion__title">
-                    <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-114" type="button">Mode expert : remplacer le document CERFA</button>
+                    <button class="fr-accordion__btn" aria-expanded="{{cerfa_expanded}}" aria-controls="accordion-114" type="button">Mode expert : remplacer le document CERFA</button>
                 </h3>
                 <div class="fr-collapse" id="accordion-114">
                     <div class="fr-alert fr-alert--error fr-mb-5w">
-                        <p>Si vous modifiez des éléments de contenu, mettez bien à jour le formulaire de la convention pour garantir la cohérence des données</p>
+                        <p>Si vous modifiez des éléments de contenu, mettez bien à jour le formulaire de {{convention|display_kind_with_pronom}} pour garantir la cohérence des données</p>
                     </div>
                     <form id="cerfa-form" method="post" action="{% url 'conventions:finalisation_cerfa' convention_uuid=convention.uuid %}" data-turbo="false">
                         {% csrf_token %}

--- a/templates/conventions/finalisation/numero.html
+++ b/templates/conventions/finalisation/numero.html
@@ -1,24 +1,60 @@
 {% extends "layout/base.html" %}
+{% load display_filters %}
 {% block page_title %}Finalisation - APiLos{% endblock %}
 {% block content %}
     {% include "conventions/common/form_header.html"%}
     <div class="fr-container fr-my-5w">
-        <h1>Finaliser la convention</h1>
+        <h1>Finaliser {{convention|display_kind_with_pronom}}</h1>
 
         {% include "../common/stepper.html"%}
         <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12">
-                <form method="post" action="{% url 'conventions:finalisation_numero' convention_uuid=convention.uuid %}">
-                    {% csrf_token %}
-                    <div class="fr-col-6">
-                        {% include "common/form/input_text.html" with form_input=form.numero editable=True object_field="convention_numero__"|add:form.uuid.value%}
-                    </div>
-                    <div class="apilos-align-right fr-mt-3w">
-                        <button class="fr-btn">
-                            Enregistrer et étape suivante
-                        </button>
-                    </div>
-                </form>
+                {% if convention.is_avenant %}
+                    <form method="post" action="{% url 'conventions:finalisation_numero' convention_uuid=convention.uuid %}">
+                        {% csrf_token %}
+                        <div class="fr-col-md-12">
+                            {% if convention.numero and convention.numero != numero_default %}
+                                <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
+                                <p>En fonction du nombre d'avenants répertoriés dans APiLos, il devrait porter le numéro {{numero_default}}</p>
+                            {% else %}
+                                {% if convention.numero %}
+                                    <p class="fr-mb-0">Le bailleur a indiqué qu'il s'agissait de l'avenant numéro <strong>{{ convention.numero }}</strong>.</p>
+                                    <p>Cette déclaration est cohérente avec l'historique connu dans APiLos.</p>
+                                {% else %}
+                                    <p>L'avenant aura le numéro {{numero_default}}.</p>
+                                {% endif %}
+                            {% endif %}
+                            <p class="fr-mb-0">Vous pouvez le valider avec ce numéro ou modifier le numéro ci-dessous avant de valider.</p>
+                            <p><em>N'oubliez pas d'importer les avenants manquants, le cas échéant.</em></p>
+                            <input class="fr-input fr-col-6 fr-my-3w"
+                                   id="numero"
+                                   name="numero"
+                                   {% if convention.numero %}
+                                       value="{{convention.numero}}"
+                                   {% else %}
+                                       value="{{numero_default}}"
+                                   {% endif %}
+                            >
+                        </div>
+                        <div class="apilos-align-right fr-mt-3w">
+                            <button class="fr-btn">
+                                Enregistrer et étape suivante
+                            </button>
+                        </div>
+                    </form>
+                {% else %}
+                    <form method="post" action="{% url 'conventions:finalisation_numero' convention_uuid=convention.uuid %}">
+                        {% csrf_token %}
+                        <div class="fr-col-6">
+                            {% include "common/form/input_text.html" with form_input=form.numero editable=True object_field="convention_numero__"|add:form.uuid.value%}
+                        </div>
+                        <div class="apilos-align-right fr-mt-3w">
+                            <button class="fr-btn">
+                                Enregistrer et étape suivante
+                            </button>
+                        </div>
+                    </form>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/templates/conventions/finalisation/validation.html
+++ b/templates/conventions/finalisation/validation.html
@@ -1,19 +1,20 @@
 {% extends "layout/base.html" %}
+{% load display_filters %}
 {% block page_title %}Finalisation - APiLos{% endblock %}
 {% block content %}
     {% include "conventions/common/form_header.html"%}
     <div class="fr-container fr-my-5w">
-        <h1>Finaliser la convention</h1>
+        <h1>Finaliser {{convention|display_kind_with_pronom}}</h1>
 
         {% include "../common/stepper.html"%}
         <div class="fr-grid-row">
             <div class="fr-col-8 fr-pt-3w">
-                <p>La convention est prête à être transmise au bailleur pour signature !</p>
+                <p>{{convention|display_kind_with_pronom|capfirst}} est prêt{{convention|display_gender_terminaison}} à être transmis{{convention|display_gender_terminaison}} au bailleur pour signature !</p>
                 <form method="post" action="{% url 'conventions:validate' convention_uuid=convention.uuid %}" data-turbo="false">
                     {% csrf_token %}
                     <input id="finalisationform" type="hidden" name="finalisationform" value="true" />
                     <button class="fr-btn">
-                        Valider et envoyer la convention pour signature
+                        Valider et envoyer {{convention|display_kind_with_pronom}} pour signature
                     </button>
                 </form>
             </div>
@@ -22,7 +23,7 @@
                     <form method="post" action="{% url 'conventions:get_or_generate_cerfa' convention_uuid=convention.uuid %}" data-turbo="false">
                         {% csrf_token %}
                         <button class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left fr-mb-2w">
-                            Document CERFA de la convention
+                            Document CERFA de {{convention|display_kind_with_pronom}}
                         </button>
                     </form>
                     <a class="fr-link apilos-no-dsfr-target" target="_blank" rel="noopener" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">Récapitulatif du formulaire</a>


### PR DESCRIPTION
Adaptation du parcours de finalisation pour les avenants. Rien de très différent des conventions, sinon le formulaire de validation de numéro que j'ai adapté de l'existant. Je n'ai pas partagé ce formulaire avec le code existant car il sera supprimé lors du clean du flag.