### PR TITLE
download CERFA without filigram in Finalisation steps

### DIFF
--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -547,6 +547,9 @@ def generate_convention(request, convention_uuid):
     )
     request.user.check_perm("convention.view_convention", convention)
 
+    if request.POST.get("without_filigram"):
+        convention.statut = ConventionStatut.A_SIGNER.label
+
     data = convention_generator.generate_convention_doc(convention)
 
     response = HttpResponse(

--- a/templates/conventions/finalisation/cerfa.html
+++ b/templates/conventions/finalisation/cerfa.html
@@ -25,6 +25,7 @@
 
         <form method="post" action="{% url 'conventions:generate' convention_uuid=convention.uuid %}" data-turbo="false" class="fr-mb-7w">
             {% csrf_token %}
+            <input hidden name="without_filigram" value="1">
             <button class="fr-btn fr-btn--primary fr-icon-download-line fr-btn--icon-left">
                 Télécharger le CERFA de la convention
             </button>


### PR DESCRIPTION
To be able to overwrite the CERFA, we allow to download it without filigram during the finalisation step