### PR TITLE
Sort logements by designation casted as an int if possible

### DIFF
--- a/conventions/services/convention_generator.py
+++ b/conventions/services/convention_generator.py
@@ -8,6 +8,10 @@ import convertapi
 import jinja2
 from django.conf import settings
 from django.core.files.storage import default_storage
+from django.db import transaction
+from django.db.models import F, Func, IntegerField, Value
+from django.db.models.functions import Cast
+from django.db.utils import DataError
 from django.forms.models import model_to_dict
 from django.template.defaultfilters import date as template_date
 from docx.shared import Inches
@@ -119,6 +123,32 @@ def generate_convention_doc(convention: Convention, save_data=False):
 
     adresse = _get_adresse(convention)
 
+    # Logements are ordered by typologie first, then by designation
+    # Designation is a string, we try to find a number in it and cast it as a number to sort
+    # If the cast fail, we order by designation as a string
+    try:
+        with transaction.atomic():
+            logements = list(
+                convention.lot.logements.all()
+                .annotate(
+                    int_designation=Cast(
+                        Func(
+                            F("designation"),
+                            Value(r"\D"),
+                            Value(""),
+                            Value("g"),
+                            function="regexp_replace",
+                        ),
+                        IntegerField(),
+                    )
+                )
+                .order_by("typologie", "int_designation")
+            )
+    except DataError:
+        logements = list(
+            convention.lot.logements.all().order_by("typologie", "designation")
+        )
+
     context = {
         **avenant_data,
         "convention": convention,
@@ -127,9 +157,7 @@ def generate_convention_doc(convention: Convention, save_data=False):
         "lot": convention.lot,
         "administration": convention.programme.administration,
         "logement_edds": logement_edds,
-        "logements": convention.lot.logements.order_by(
-            "typologie", "designation"
-        ).all(),
+        "logements": logements,
         "locaux_collectifs": convention.lot.locaux_collectifs.all(),
         "annexes": annexes,
         "stationnements": convention.lot.type_stationnements.all(),

--- a/conventions/tests/services/test_convention_generator.py
+++ b/conventions/tests/services/test_convention_generator.py
@@ -216,6 +216,11 @@ class ConventionServiceGeneratorTest(TestCase):
             typologie=TypologieLogement.T1BIS,
             designation="Logement 4",
         )
+        Logement.objects.create(
+            lot=convention.lot,
+            typologie=TypologieLogement.T1BIS,
+            designation="Logement 34",
+        )
         convention.programme.nature_logement = NatureLogement.RESISDENCESOCIALE
 
         with patch(
@@ -230,6 +235,54 @@ class ConventionServiceGeneratorTest(TestCase):
             assert set(context.keys()) == convention_context_keys()
             assert [logement.designation for logement in context["logements"]] == [
                 "Logement 3",
+                "Logement 4",
+                "Logement 34",
+                "Logement 1",
+                "Logement 2",
+            ]
+
+    def test_generate_convention_doc_logements_without_numbers(self):
+        convention = Convention.objects.get(numero="0001")
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T2, designation="Logement 2"
+        )
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T2, designation="Logement 1"
+        )
+        Logement.objects.create(
+            lot=convention.lot, typologie=TypologieLogement.T1, designation="Logement 3"
+        )
+        Logement.objects.create(
+            lot=convention.lot,
+            typologie=TypologieLogement.T1BIS,
+            designation="Logement 4",
+        )
+        Logement.objects.create(
+            lot=convention.lot,
+            typologie=TypologieLogement.T1BIS,
+            designation="Logement 34",
+        )
+        Logement.objects.create(
+            lot=convention.lot,
+            typologie=TypologieLogement.T1BIS,
+            designation="Logement",
+        )
+        convention.programme.nature_logement = NatureLogement.RESISDENCESOCIALE
+
+        with patch(
+            "conventions.services.convention_generator.DocxTemplate.render"
+        ) as mocked_render:
+            generate_convention_doc(convention)
+
+            args, _ = mocked_render.call_args
+            context = args[0]
+
+            mocked_render.assert_called_once()
+            assert set(context.keys()) == convention_context_keys()
+            assert [logement.designation for logement in context["logements"]] == [
+                "Logement 3",
+                "Logement",
+                "Logement 34",
                 "Logement 4",
                 "Logement 1",
                 "Logement 2",


### PR DESCRIPTION
Ticket escaladé, lien mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/oswtck8m5t88jp5weakebjx91a

C'est tricky : la colonne de désignation est une string, mais les utilisateurs y mettent souvent des entiers. J'ai tenté un bout de code qui cherche un entier, et tri par cet entier, sinon tri par ordre alpha.

A voir si le bénéfice utilisateur justifie l'ajout de complexité.