### PR TITLE
Remove commentaire denonciation

### DIFF
--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -49,7 +49,6 @@
                 {% endif %}
                 {% if convention.is_denonciation %}
                     {% include "conventions/recapitulatif/denonciation.html"  with target_url='conventions:denonciation' %}
-                    {% include "conventions/recapitulatif/commentaires.html" with target_url='conventions:avenant_commentaires' %}
                 {% elif convention.is_resiliation %}
                     {% if request.user.is_instructeur_departemental %}
                         {% include "conventions/recapitulatif/resiliation.html"  with target_url='conventions:resiliation' %}


### PR DESCRIPTION
Suite à un retour de Sabine, le bloc commentaire est retiré d'une dénonciation (déjà absent des résiliations)

Avant : 
![image](https://github.com/MTES-MCT/apilos/assets/26469767/ba921f84-dd0f-4283-9c03-40c9ae1a6a0c)

Après : 
<img width="1328" alt="Capture d’écran 2024-04-24 à 13 34 05" src="https://github.com/MTES-MCT/apilos/assets/26469767/2312ec96-d2ec-4fa9-af60-3eb744fc89a6">
