### PR TITLE
Fix pdf generation due to wrong logements type

### DIFF
--- a/conventions/services/convention_generator.py
+++ b/conventions/services/convention_generator.py
@@ -128,7 +128,7 @@ def generate_convention_doc(convention: Convention, save_data=False):
     # If the cast fail, we order by designation as a string
     try:
         with transaction.atomic():
-            logements = list(
+            logements = (
                 convention.lot.logements.all()
                 .annotate(
                     int_designation=Cast(
@@ -144,10 +144,10 @@ def generate_convention_doc(convention: Convention, save_data=False):
                 )
                 .order_by("typologie", "int_designation")
             )
+            # Force queryset execution
+            list(logements)
     except DataError:
-        logements = list(
-            convention.lot.logements.all().order_by("typologie", "designation")
-        )
+        logements = convention.lot.logements.all().order_by("typologie", "designation")
 
     context = {
         **avenant_data,


### PR DESCRIPTION
Fix #1387
I was using a list instead of a queryset, which breaks pdf generation.
I was casting as a list to force queryset execution in the try clause, to fall in the except one if needed.

To fix the issue I kept the casting but not the assignation.