### PR TITLE
Adapt export for SRU

### DIFF
--- a/programmes/api/operation_serializers.py
+++ b/programmes/api/operation_serializers.py
@@ -187,6 +187,7 @@ class OperationInfoSIAPSerializer(serializers.ModelSerializer):
             "ville",
             "adresse",
             "numero_operation",
+            "nature_logement",
             "zone_123",
             "zone_abc",
             "type_operation",
@@ -216,6 +217,24 @@ class ConventionInfoSIAPSerializer(serializers.ModelSerializer):
     lot = LotSerializer(read_only=True)
     operation = OperationInfoSIAPSerializer(source="programme", read_only=True)
     prets = PretSerializer(many=True)
+    numero_avenant = serializers.SerializerMethodField()
+    numero_convention = serializers.SerializerMethodField()
+    convention_date_signature = serializers.SerializerMethodField()
+
+    def get_numero_convention(self, obj):
+        if obj.parent:
+            return obj.parent.numero
+        return obj.numero
+
+    def get_numero_avenant(self, obj):
+        if obj.parent:
+            return obj.numero
+        return None
+
+    def get_convention_date_signature(self, obj):
+        if obj.parent:
+            return obj.parent.televersement_convention_signee_le
+        return obj.televersement_convention_signee_le
 
     # ajout de la date de signature de la convention mère
     # vérifier si le numéro de la convention est le numéro de la convention mère
@@ -228,7 +247,10 @@ class ConventionInfoSIAPSerializer(serializers.ModelSerializer):
             "lot",
             "prets",
             "operation",
-            "numero",
+            "numero_convention",
+            "numero_avenant",
+            "gestionnaire",
+            "convention_date_signature",
             "statut",
         )
         ref_name = "ConventionInfoSIAP"

--- a/programmes/api/operation_serializers.py
+++ b/programmes/api/operation_serializers.py
@@ -251,6 +251,8 @@ class ConventionInfoSIAPSerializer(serializers.ModelSerializer):
             "numero_avenant",
             "gestionnaire",
             "convention_date_signature",
+            "date_denonciation",
+            "date_resiliation",
             "statut",
         )
         ref_name = "ConventionInfoSIAP"


### PR DESCRIPTION
Export, add options: 
- limit : number of conventions to export
- with-ended : include denonciated and resiliated conventions

Convention export, add columns:
- "numero_convention": Numero de la convention initial
- "numero_avenant": Numero du dernier avenant, null si la convention n'a pas d'avenant
- "gestionnaire": Nom de l'organisme gestionnaire dans le cas des foyers et résidences
- "convention_date_signature": date de signature de la convention initial
- "date_denonciation": date de denonciation de la convention si dénoncée
- "date_resiliation": date de resiliation de la convention si resiliée
- "nature_logement": nature des logements -> LOGEMENTSORDINAIRES, AUTRE, HEBERGEMENT, RESISDENCESOCIALE, PENSIONSDEFAMILLE, RESIDENCEDACCUEIL, RESIDENCEUNIVERSITAIRE
