### PR TITLE
Fix rounding in tableau logements

### DIFF
--- a/conventions/services/upload_objects.py
+++ b/conventions/services/upload_objects.py
@@ -292,8 +292,14 @@ def _extract_row(row, column_from_index, cls, *, class_field_mapping):
     return my_row, empty_line, new_warnings
 
 
-def _float_to_decimal_rounded_two_digits_half_up(number: float) -> Decimal:
-    return Decimal(str(number)).quantize(Decimal("1.00"), rounding=ROUND_HALF_UP)
+def _float_to_decimal_rounded_half_up(number: float, decimal_places: int) -> Decimal:
+    if decimal_places > 0:
+        decimal_target = "1." + ("0" * decimal_places)
+    else:
+        decimal_target = "1"
+    return Decimal(str(number)).quantize(
+        Decimal(decimal_target), rounding=ROUND_HALF_UP
+    )
 
 
 def _get_value_from_decimal_field(cell, model_field, column_from_index, new_warnings):
@@ -314,7 +320,9 @@ def _get_value_from_decimal_field(cell, model_field, column_from_index, new_warn
                     )
                 )
         elif isinstance(cell.value, (float, int)):
-            value = _float_to_decimal_rounded_two_digits_half_up(cell.value)
+            value = _float_to_decimal_rounded_half_up(
+                cell.value, model_field.decimal_places
+            )
         else:
             new_warnings.append(
                 Exception(

--- a/conventions/tests/services/test_upload_objects.py
+++ b/conventions/tests/services/test_upload_objects.py
@@ -3,23 +3,28 @@ from decimal import Decimal
 import pytest
 
 from conventions.services.upload_objects import (
-    _float_to_decimal_rounded_two_digits_half_up,
+    _float_to_decimal_rounded_half_up,
 )
 
 
 @pytest.mark.parametrize(
-    "float_input,expected",
+    "float_input,decimal_places,expected",
     [
-        (7.505, "7.51"),
-        (7.504, "7.50"),
-        (7.506, "7.51"),
-        (7.50499999999, "7.50"),
-        # No regression for two digits
-        (14444.59, "14444.59"),
-        (145.18, "145.18"),
+        (7.505, 2, "7.51"),
+        (7.504, 2, "7.50"),
+        (7.506, 2, "7.51"),
+        (7.50499999999, 2, "7.50"),
+        (14444.59, 2, "14444.59"),
+        (145.18, 2, "145.18"),
+        (7.505, 3, "7.505"),
+        (7.5049, 3, "7.505"),
+        (7.506787, 5, "7.50679"),
+        (7.65, 0, "8"),
     ],
 )
-def test_float_to_decimal_rounded_two_digits_half_up(float_input, expected):
-    assert _float_to_decimal_rounded_two_digits_half_up(float_input) == Decimal(
+def test_float_to_decimal_rounded_two_digits_half_up(
+    float_input, decimal_places, expected
+):
+    assert _float_to_decimal_rounded_half_up(float_input, decimal_places) == Decimal(
         expected
     )


### PR DESCRIPTION
Régression : on ne prenait plus en compte que deux chiffres après la virgule alors que cette valeur est définie dans `decimal_places`