### PR TITLE
display 'Acte de propriété' and 'Certif. adressage' files in 'Récapitulatif'

### DIFF
--- a/templates/conventions/recapitulatif/references_cadastrales.html
+++ b/templates/conventions/recapitulatif/references_cadastrales.html
@@ -68,7 +68,9 @@
                             <a class="fr-mb-1w fr-link" href="{% url 'conventions:cadastre' convention_uuid=convention.uuid %}#id_reference_cadastrale_div" >Ajouter une référence cadastrale</a>
                         </div>
                     {% endif %}
-                    {% include "common/display_text_and_files_if_exists.html" with file_list=programme.effet_relatif|get_files_from_textfiles %}
+                    {% include "common/display_text_and_files_if_exists.html" with label="Effet relatif" file_list=programme.effet_relatif|get_files_from_textfiles %}
+                    {% include "common/display_text_and_files_if_exists.html" with label="Acte de propriété / Acte notarial" file_list=programme.acte_de_propriete|get_files_from_textfiles %}
+                    {% include "common/display_text_and_files_if_exists.html" with label="Certificat d'adressage / Autres" file_list=programme.certificat_adressage|get_files_from_textfiles %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Actually, it is already available in another section : 

![CleanShot 2024-05-24 at 11 59 57](https://github.com/MTES-MCT/apilos/assets/454431/21d87332-4378-4caf-bd33-32e55014cdce)

Which one should we keep ????

https://mattermost.incubateur.net/fabnum-mte/pl/8kuytwo4cjf3pruwqyy7hg1kah