### PR TITLE
introduce readonly notion on profil from SIAP habilitation

### DIFF
--- a/conventions/permissions.py
+++ b/conventions/permissions.py
@@ -6,7 +6,12 @@ from conventions.models.convention import Convention
 def has_campaign_permission(permission):
     def has_permission(function):
         def wrapper(view, request, **kwargs):
-            request.user.check_perm(permission, view.convention)
+            role_id = (
+                request.session["role"]["id"]
+                if "id" in request.session["role"]
+                else None
+            )
+            request.user.check_perm(permission, obj=view.convention, role_id=role_id)
             return function(view, request, **kwargs)
 
         return wrapper
@@ -18,7 +23,12 @@ def has_campaign_permission_view_function(permission):
     def has_permission(function):
         def wrapper(request, convention_uuid, **kwargs):
             convention = Convention.objects.get(uuid=convention_uuid)
-            request.user.check_perm(permission, convention)
+            role_id = (
+                request.session["role"]["id"]
+                if "id" in request.session["role"]
+                else None
+            )
+            request.user.check_perm(permission, obj=convention, role_id=role_id)
             return function(request, convention_uuid, **kwargs)
 
         return wrapper

--- a/conventions/permissions.py
+++ b/conventions/permissions.py
@@ -6,12 +6,7 @@ from conventions.models.convention import Convention
 def has_campaign_permission(permission):
     def has_permission(function):
         def wrapper(view, request, **kwargs):
-            role_id = (
-                request.session["role"]["id"]
-                if "id" in request.session["role"]
-                else None
-            )
-            request.user.check_perm(permission, obj=view.convention, role_id=role_id)
+            _check_campaign_permission(request, view.convention, permission)
             return function(view, request, **kwargs)
 
         return wrapper
@@ -23,14 +18,18 @@ def has_campaign_permission_view_function(permission):
     def has_permission(function):
         def wrapper(request, convention_uuid, **kwargs):
             convention = Convention.objects.get(uuid=convention_uuid)
-            role_id = (
-                request.session["role"]["id"]
-                if "id" in request.session["role"]
-                else None
-            )
-            request.user.check_perm(permission, obj=convention, role_id=role_id)
+            _check_campaign_permission(request, convention, permission)
             return function(request, convention_uuid, **kwargs)
 
         return wrapper
 
     return has_permission
+
+
+def _check_campaign_permission(request, convention, permission):
+    role_id = (
+        request.session["role"]["id"]
+        if "role" in request.session and "id" in request.session["role"]
+        else None
+    )
+    request.user.check_perm(permission, obj=convention, role_id=role_id)

--- a/conventions/permissions.py
+++ b/conventions/permissions.py
@@ -3,10 +3,32 @@
 from conventions.models.convention import Convention
 
 
-def has_campaign_permission(permission):
+def currentrole_permission_required(permission):
+    def has_permission(function):
+        def wrapper(request, *args, **kwargs):
+            _check_currentrole_permission(request, None, permission)
+            return function(request, *args, **kwargs)
+
+        return wrapper
+
+    return has_permission
+
+
+def currentrole_permission_required_view_function(permission):
+    def has_permission(function):
+        def wrapper(view, request, *args, **kwargs):
+            _check_currentrole_permission(request, None, permission)
+            return function(view, request, *args, **kwargs)
+
+        return wrapper
+
+    return has_permission
+
+
+def currentrole_campaign_permission_required(permission):
     def has_permission(function):
         def wrapper(view, request, **kwargs):
-            _check_campaign_permission(request, view.convention, permission)
+            _check_currentrole_permission(request, view.convention, permission)
             return function(view, request, **kwargs)
 
         return wrapper
@@ -14,11 +36,11 @@ def has_campaign_permission(permission):
     return has_permission
 
 
-def has_campaign_permission_view_function(permission):
+def currentrole_campaign_permission_required_view_function(permission):
     def has_permission(function):
         def wrapper(request, convention_uuid, **kwargs):
             convention = Convention.objects.get(uuid=convention_uuid)
-            _check_campaign_permission(request, convention, permission)
+            _check_currentrole_permission(request, convention, permission)
             return function(request, convention_uuid, **kwargs)
 
         return wrapper
@@ -26,7 +48,7 @@ def has_campaign_permission_view_function(permission):
     return has_permission
 
 
-def _check_campaign_permission(request, convention, permission):
+def _check_currentrole_permission(request, convention, permission):
     role_id = (
         request.session["role"]["id"]
         if "role" in request.session and "id" in request.session["role"]

--- a/conventions/services/conventions.py
+++ b/conventions/services/conventions.py
@@ -10,7 +10,6 @@ from conventions.forms.convention_form_dates import (
 from conventions.forms.convention_form_resiliation import ConventionResiliationForm
 from conventions.models import Convention, ConventionStatut
 from conventions.services import utils
-from conventions.services.file import ConventionFileService
 from conventions.services.search import AvenantListSearchService
 from core.request import AuthenticatedHttpRequest
 
@@ -42,29 +41,6 @@ class ConventionService(ABC):
     @abstractmethod
     def save(self):
         pass
-
-
-def convention_sent(request, convention_uuid):
-    convention = Convention.objects.get(uuid=convention_uuid)
-    result_status = None
-    if request.method == "POST":
-        upform = UploadForm(request.POST, request.FILES)
-        if upform.is_valid():
-            ConventionFileService.upload_convention_file(
-                convention, request.FILES["file"]
-            )
-            result_status = utils.ReturnStatus.SUCCESS
-    else:
-        upform = UploadForm()
-
-    return {
-        "success": result_status,
-        "convention": convention,
-        "upform": upform,  # Obsolète: cette approche sera dépréciée dans le futur, au profit de extra_forms.
-        "extra_forms": {
-            "upform": upform,
-        },
-    }
 
 
 def convention_post_action(request, convention_uuid):

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -12,6 +12,7 @@ from conventions.forms.convention_number import ConventionNumberForm
 from conventions.forms.notification import NotificationForm
 from conventions.forms.programme_number import ProgrammeNumberForm
 from conventions.forms.type1and2 import ConventionType1and2Form
+from conventions.forms.upload import UploadForm
 from conventions.models.choices import ConventionStatut
 from conventions.models.convention import Convention
 from conventions.models.convention_history import ConventionHistory
@@ -571,3 +572,37 @@ def convention_resiliation_validate(request, convention_uuid):
         "success": result_status,
         "convention": convention,
     }
+
+
+class ConventionSentService(ConventionService):
+    # convention: Convention
+    # request: HttpRequest
+    # upform: UploadForm = UploadForm()
+    # return_status: utils.ReturnStatus = utils.ReturnStatus.ERROR
+
+    def get(self):
+        upform = UploadForm()
+        return {
+            "convention": self.convention,
+            "upform": upform,
+            "extra_forms": {
+                "upform": upform,
+            },
+        }
+
+    def save(self):
+        upform = UploadForm(self.request.POST, self.request.FILES)
+        if upform.is_valid():
+            ConventionFileService.upload_convention_file(
+                self.convention, self.request.FILES["file"]
+            )
+            self.result_status = utils.ReturnStatus.SUCCESS
+
+        return {
+            "success": self.result_status,
+            "convention": self.convention,
+            "upform": upform,
+            "extra_forms": {
+                "upform": upform,
+            },
+        }

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -574,6 +574,7 @@ def convention_resiliation_validate(request, convention_uuid):
     }
 
 
+# FIXME to be tested
 class ConventionSentService(ConventionService):
     # convention: Convention
     # request: HttpRequest

--- a/conventions/services/utils.py
+++ b/conventions/services/utils.py
@@ -125,7 +125,7 @@ def base_convention_response_error(request, convention):
 
 
 def editable_convention(request: HttpRequest, convention: Convention):
-    if request.session["readonly"]:
+    if "readonly" in request.session and request.session["readonly"]:
         return False
     if is_instructeur(request):
         if "is_expert" in request.session and request.session["is_expert"] is True:

--- a/conventions/services/utils.py
+++ b/conventions/services/utils.py
@@ -125,6 +125,8 @@ def base_convention_response_error(request, convention):
 
 
 def editable_convention(request: HttpRequest, convention: Convention):
+    if request.session["readonly"]:
+        return False
     if is_instructeur(request):
         if "is_expert" in request.session and request.session["is_expert"] is True:
             return True

--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -58,6 +58,14 @@ def is_instructeur(request: HttpRequest) -> bool:
 
 
 @register.filter
+def is_readonly(request: HttpRequest) -> bool:
+    # Manage is_staff exception
+    if "readonly" in request.session:
+        return request.session["readonly"]
+    return False
+
+
+@register.filter
 def current_administration(request: HttpRequest) -> None | int:
     if is_instructeur(request) and request.session.get("administration"):
         administration = Administration.objects.get(

--- a/conventions/tests/services/test_conventions_service.py
+++ b/conventions/tests/services/test_conventions_service.py
@@ -4,11 +4,7 @@ from django.http import HttpRequest, QueryDict
 from django.test import RequestFactory, TestCase
 
 from conventions.models import Convention
-from conventions.services.conventions import (
-    ConventionService,
-    convention_post_action,
-    convention_sent,
-)
+from conventions.services.conventions import ConventionService, convention_post_action
 from users.models import User
 
 
@@ -45,10 +41,6 @@ class ConventionConventionsServiceTests(TestCase):
         service = ConventionServiceImpl(self.convention, self.request)
         self.assertEqual(self.convention, service.convention)
         self.assertEqual(self.request, service.request)
-
-    def test_convention_sent_basic(self):
-        result = convention_sent(self.request, self.convention.uuid)
-        self.assertEqual(result["convention"], self.convention)
 
     def test_convention_post_action_basic(self):
         self.request.POST = QueryDict()

--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -275,7 +275,7 @@ urlpatterns = [
     ),
     path(
         "sent/<convention_uuid>",
-        views.sent,
+        views.ConventionSentView.as_view(),
         name="sent",
     ),
     path(

--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
     ),
     path(
         "post_action/<convention_uuid>",
-        views.post_action,
+        views.ActionsPostValidation.as_view(),
         name="post_action",
     ),
     path(

--- a/conventions/urls.py
+++ b/conventions/urls.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.decorators import permission_required
 from django.urls import path
 from django.views.generic import RedirectView, TemplateView
 
@@ -51,16 +50,12 @@ urlpatterns = [
     ),
     path(
         "from_operation/add_convention/<numero_operation>",
-        permission_required("convention.add_convention")(
-            views.AddConventionView.as_view()
-        ),
+        views.AddConventionView.as_view(),
         name="from_operation_add_convention",
     ),
     path(
         "from_operation/add_avenants/<uuid:convention_uuid>",
-        permission_required("convention.add_convention")(
-            views.AddAvenantsView.as_view()
-        ),
+        views.AddAvenantsView.as_view(),
         name="from_operation_add_avenants",
     ),
     # Pages pour la finalisation d'une convention par un instructeur
@@ -87,9 +82,7 @@ urlpatterns = [
     ),
     path(
         "new_convention_anru",
-        permission_required("convention.add_convention")(
-            views.NewConventionAnruView.as_view()
-        ),
+        views.NewConventionAnruView.as_view(),
         name="new_convention_anru",
     ),
     path(
@@ -317,9 +310,7 @@ urlpatterns = [
     ),
     path(
         "search_for_avenant",
-        permission_required("convention.add_convention")(
-            views.SearchForAvenantResultView.as_view()
-        ),
+        views.SearchForAvenantResultView.as_view(),
         name="search_for_avenant",
     ),
     path(

--- a/conventions/views/avenants.py
+++ b/conventions/views/avenants.py
@@ -81,6 +81,7 @@ def new_avenants_for_avenant(
     )
 
 
+# FIXME : update to View class
 @login_required
 def form_avenants_for_avenant(request, convention_uuid):
     result = complete_avenants_for_avenant(request, convention_uuid)

--- a/conventions/views/avenants.py
+++ b/conventions/views/avenants.py
@@ -1,27 +1,30 @@
 from uuid import UUID
 
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.views import View
-from django.http import HttpRequest, HttpResponse
+from django.views.decorators.http import require_http_methods
 
 from conventions.forms import AvenantSearchForm
+from conventions.permissions import (
+    currentrole_permission_required,
+    currentrole_permission_required_view_function,
+)
 from conventions.services.avenants import (
-    create_avenant,
-    upload_avenants_for_avenant,
     complete_avenants_for_avenant,
+    create_avenant,
     remove_avenant_type_from_avenant,
+    upload_avenants_for_avenant,
 )
 from conventions.services.selection import ConventionSelectionService
 from conventions.services.utils import ReturnStatus
-from django.views.decorators.http import require_http_methods
 
 
 @login_required
-@permission_required("convention.add_convention")
+@currentrole_permission_required("convention.add_convention")
 def new_avenant(request: HttpRequest, convention_uuid: UUID) -> HttpResponse:
     result = create_avenant(request, convention_uuid)
     if result["success"] == ReturnStatus.SUCCESS:
@@ -57,7 +60,7 @@ def new_avenant(request: HttpRequest, convention_uuid: UUID) -> HttpResponse:
 
 
 @login_required
-@permission_required("convention.add_convention")
+@currentrole_permission_required("convention.add_convention")
 def new_avenants_for_avenant(
     request: HttpRequest, convention_uuid: UUID
 ) -> HttpResponse:
@@ -98,7 +101,7 @@ def form_avenants_for_avenant(request, convention_uuid):
 
 
 @login_required
-@permission_required("convention.add_convention")
+@currentrole_permission_required("convention.add_convention")
 @require_http_methods(["POST"])
 def remove_from_avenant(
     request: HttpRequest, convention_uuid: UUID
@@ -114,6 +117,7 @@ def remove_from_avenant(
 
 
 class SearchForAvenantResultView(LoginRequiredMixin, View):
+    @currentrole_permission_required_view_function("convention.view_convention")
     def get(self, request):
         is_submitted = request.GET.get("departement", None) is not None
         search_form = (
@@ -149,6 +153,7 @@ class SearchForAvenantResultView(LoginRequiredMixin, View):
             {"conventions": None, "search_form": search_form},
         )
 
+    @currentrole_permission_required_view_function("convention.add_convention")
     def post(self, request):
         service = ConventionSelectionService(request)
         service.post_for_avenant()

--- a/conventions/views/convention_form.py
+++ b/conventions/views/convention_form.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.views import View
 
 from conventions.models import Convention
-from conventions.permissions import has_campaign_permission
+from conventions.permissions import currentrole_campaign_permission_required
 from conventions.services.conventions import ConventionService
 from conventions.services.utils import (
     ReturnStatus,
@@ -369,7 +369,7 @@ class ConventionView(ABC, BaseConventionView):
             active_classname=type(self).__name__,
         )
 
-    @has_campaign_permission("convention.view_convention")
+    @currentrole_campaign_permission_required("convention.view_convention")
     def get(self, request, **kwargs):
         service = self.service_class(convention=self.convention, request=request)
         service.get()
@@ -394,7 +394,7 @@ class ConventionView(ABC, BaseConventionView):
     def post_action(self):
         self.service.save()
 
-    @has_campaign_permission("convention.change_convention")
+    @currentrole_campaign_permission_required("convention.change_convention")
     def post(self, request, convention_uuid):
         self.request = request
         self.service = self.service_class(convention=self.convention, request=request)

--- a/conventions/views/convention_form_from_operation.py
+++ b/conventions/views/convention_form_from_operation.py
@@ -15,6 +15,7 @@ from django.views.generic.base import (
 from waffle.mixins import WaffleFlagMixin
 
 from conventions.models import ConventionStatut
+from conventions.permissions import currentrole_permission_required_view_function
 from conventions.services import utils
 from conventions.services.from_operation import (
     AddAvenantsService,
@@ -68,9 +69,11 @@ class AddConventionView(
     template_name = "conventions/from_operation/add_convention.html"
     step_number = 2
 
+    @currentrole_permission_required_view_function("convention.add_convention")
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         return self._handle(request, *args, **kwargs)
 
+    @currentrole_permission_required_view_function("convention.add_convention")
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         return self._handle(request, *args, **kwargs)
 
@@ -109,9 +112,11 @@ class AddAvenantsView(FromOperationBaseView, TemplateResponseMixin, ContextMixin
     template_name = "conventions/from_operation/add_avenants.html"
     step_number = 3
 
+    @currentrole_permission_required_view_function("convention.add_convention")
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         return self._handle(request, *args, **kwargs)
 
+    @currentrole_permission_required_view_function("convention.add_convention")
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         return self._handle(request, *args, **kwargs)
 

--- a/conventions/views/convention_form_selection.py
+++ b/conventions/views/convention_form_selection.py
@@ -4,12 +4,13 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views import View
 
+from conventions.permissions import currentrole_permission_required_view_function
 from conventions.services.selection import ConventionSelectionService
 from conventions.services.utils import ReturnStatus
 
 
 class NewConventionAnruView(LoginRequiredMixin, View):
-    # @permission_required("convention.add_convention")
+    @currentrole_permission_required_view_function("convention.add_convention")
     def get(self, request):
         service = ConventionSelectionService(request)
         service.get_create_convention()
@@ -23,7 +24,7 @@ class NewConventionAnruView(LoginRequiredMixin, View):
             },
         )
 
-    # @permission_required("convention.add_convention")
+    @currentrole_permission_required_view_function("convention.add_convention")
     def post(self, request):
         service = ConventionSelectionService(request)
         service.post_create_convention()

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -495,27 +495,44 @@ def sent(request, convention_uuid, *args):
     )
 
 
-@login_required
-@require_http_methods(["GET", "POST"])
-@has_campaign_permission_view_function("convention.change_convention")
-def post_action(request, convention_uuid):
-    # Step 12/12
-    result = convention_post_action(request, convention_uuid)
-    if result["success"] == ReturnStatus.SUCCESS:
-        if result["form_posted"] == "resiliation":
+class ActionsPostValidation(BaseConventionView):
+    @has_campaign_permission("convention.view_convention")
+    def get(self, request, convention_uuid):
+        result = convention_post_action(request, convention_uuid)
+        if result["success"] == ReturnStatus.SUCCESS:
+            if result["form_posted"] == "resiliation":
+                return HttpResponseRedirect(
+                    reverse("conventions:recapitulatif", args=[convention_uuid])
+                )
             return HttpResponseRedirect(
-                reverse("conventions:recapitulatif", args=[convention_uuid])
+                reverse("conventions:post_action", args=[convention_uuid])
             )
-        return HttpResponseRedirect(
-            reverse("conventions:post_action", args=[convention_uuid])
+        return render(
+            request,
+            "conventions/post_action.html",
+            {
+                **result,
+            },
         )
-    return render(
-        request,
-        "conventions/post_action.html",
-        {
-            **result,
-        },
-    )
+
+    @has_campaign_permission("convention.change_convention")
+    def post(self, request, convention_uuid):
+        result = convention_post_action(request, convention_uuid)
+        if result["success"] == ReturnStatus.SUCCESS:
+            if result["form_posted"] == "resiliation":
+                return HttpResponseRedirect(
+                    reverse("conventions:recapitulatif", args=[convention_uuid])
+                )
+            return HttpResponseRedirect(
+                reverse("conventions:post_action", args=[convention_uuid])
+            )
+        return render(
+            request,
+            "conventions/post_action.html",
+            {
+                **result,
+            },
+        )
 
 
 @login_required

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -477,8 +477,9 @@ def preview(request, convention_uuid):
     )
 
 
+# FIXME : update it as a ConventionView
 @login_required
-@has_campaign_permission_view_function("convention.change_convention")
+@has_campaign_permission_view_function("convention.view_convention")
 def sent(request, convention_uuid, *args):
     result = convention_sent(request, convention_uuid)
     if result["success"] == ReturnStatus.SUCCESS:

--- a/core/settings.py
+++ b/core/settings.py
@@ -578,7 +578,6 @@ DEBUG_SEARCH_SCORING = get_env_variable(
 # Waffle
 SWITCH_VISIBILITY_AVENANT_BAILLEUR = "switch_visibility_avenant_bailleur"
 FLAG_ADD_CONVENTION = "ajout_convention"
-FLAG_OVERRIDE_CERFA = "override_cerfa"
 
 WAFFLE_ENABLE_ADMIN_PAGES = False
 MIDDLEWARE += ["waffle.middleware.WaffleMiddleware"]

--- a/programmes/api/tests/test_apis.py
+++ b/programmes/api/tests/test_apis.py
@@ -73,8 +73,8 @@ def create_all_for_siap():
         cerbere=True,
     )
 
-    GroupFactory(name="Instructeur", rwd=["logement", "convention"])
-    GroupFactory(name="Bailleur", rw=["logement", "convention"])
+    GroupFactory(name="instructeur", rwd=["logement", "convention"])
+    GroupFactory(name="bailleur", rw=["logement", "convention"])
 
     administration = AdministrationFactory(
         nom="CA d'Arles-Crau-Camargue-Montagnette",

--- a/siap/custom_middleware.py
+++ b/siap/custom_middleware.py
@@ -12,7 +12,7 @@ from siap.exceptions import (
 )
 from siap.siap_client.client import SIAPClient
 from siap.siap_client.utils import get_or_create_administration, get_or_create_bailleur
-from users.models import GroupProfile, Role
+from users.models import GroupProfile, GroupRoleProfile, Role
 from users.type_models import TypeRole
 
 
@@ -126,7 +126,7 @@ def _get_perimetre_geographique(from_habilitation: dict) -> tuple[None, str]:
     return (perimetre_departement, perimetre_region)
 
 
-def _manage_role(from_habilitation, session_only=False, **kwargs):
+def _manage_role(from_habilitation: dict, session_only: bool = False, **kwargs) -> dict:
     (perimetre_departement, perimetre_region) = _get_perimetre_geographique(
         from_habilitation
     )
@@ -255,3 +255,8 @@ def _find_or_create_entity(
             user=request.user,
             group=Group.objects.get(name__iexact="instructeur"),
         )
+
+    # Manage readonly access
+    request.session["readonly"] = from_habilitation["groupe"]["codeRole"] in [
+        GroupRoleProfile.ADM_CENTRALE_LECTEUR
+    ]

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -950,10 +950,10 @@ table .apilos-badge {
   top: 0;
 }
 .apilos-sticky-2 {
-  top: 176px;
+  top: 141px;
 }
 .fr-container-fluid:has(.apilos-notice--warning) .apilos-sticky-2 {
-  top: 248px;
+  top: 213px;
 }
 .recapitulatif .recapitulatif-link {
   display: none;

--- a/static/js/comment-factory.js
+++ b/static/js/comment-factory.js
@@ -422,15 +422,21 @@ class CommentFactory {
       if (this.empty_toggle_on) {
         let inputs = this.empty_toggle_on.getElementsByTagName("input");
         for (var i = 0; i < inputs.length; i++) {
-          inputs[i].disabled = false;
+          if (inputs[i].dataset["readonly"] != "true") {
+            inputs[i].disabled = false;
+          }
         }
         let selects = this.empty_toggle_on.getElementsByTagName("select");
         for (var i = 0; i < selects.length; i++) {
-          selects[i].disabled = false;
+          if (inputs[i].dataset["readonly"] != "true") {
+            selects[i].disabled = false;
+          }
         }
         let textareas = this.empty_toggle_on.getElementsByTagName("textarea");
         for (var i = 0; i < textareas.length; i++) {
-          textareas[i].disabled = false;
+          if (inputs[i].dataset["readonly"] != "true") {
+            textareas[i].disabled = false;
+          }
         }
         if (this.empty_toggle_on.tagName == "TR") {
           if (document.getElementById("download_upload_block") !== null) {

--- a/static/js/comment-factory.js
+++ b/static/js/comment-factory.js
@@ -428,13 +428,13 @@ class CommentFactory {
         }
         let selects = this.empty_toggle_on.getElementsByTagName("select");
         for (var i = 0; i < selects.length; i++) {
-          if (inputs[i].dataset["readonly"] != "true") {
+          if (selects[i].dataset["readonly"] != "true") {
             selects[i].disabled = false;
           }
         }
         let textareas = this.empty_toggle_on.getElementsByTagName("textarea");
         for (var i = 0; i < textareas.length; i++) {
-          if (inputs[i].dataset["readonly"] != "true") {
+          if (textareas[i].dataset["readonly"] != "true") {
             textareas[i].disabled = false;
           }
         }

--- a/templates/common/button/next_and_save.html
+++ b/templates/common/button/next_and_save.html
@@ -1,3 +1,5 @@
-<button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right" {% if targetted_form %}form="{{ targetted_form }}"{% endif %}>
-    Enregistrer et Suivant
-</button>
+{% if not request|is_readonly %}
+    <button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right" {% if targetted_form %}form="{{ targetted_form }}"{% endif %}>
+        Enregistrer et Suivant
+    </button>
+{% endif %}

--- a/templates/common/button/noteditable_button.html
+++ b/templates/common/button/noteditable_button.html
@@ -1,11 +1,13 @@
 <input type="hidden" name="redirect_to_recap" value='True'>
 <input type="hidden" name="editable_after_upload" value="{{ editable_after_upload }}">
 <div>
-    <div id="save_after_comments" hidden>
-        <button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right">
-            Enregistrer et retour au Récapitulatif
-        </button>
-    </div>
+    {% if not request|is_readonly %}
+        <div id="save_after_comments" hidden>
+            <button class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right">
+                Enregistrer et retour au Récapitulatif
+            </button>
+        </div>
+    {% endif %}
     <div id="back_to_recap" hidden>
         <a class="fr-btn fr-icon-arrow-right-s-line fr-btn--icon-right"
            href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
@@ -20,11 +22,12 @@
         has_comments ||= !(comments[i].hidden)
     }
     if (has_comments) {
-        document.getElementById('save_after_comments').hidden = false
-        document.getElementById('back_to_recap').hidden = true
+        if (document.getElementById('save_after_comments'))  document.getElementById('save_after_comments').hidden = false;
+        document.getElementById('back_to_recap').hidden = true;
+
     }
     else {
-        document.getElementById('save_after_comments').hidden = true
+        if (document.getElementById('save_after_comments'))  document.getElementById('save_after_comments').hidden = true;
         document.getElementById('back_to_recap').hidden = false
     }
 </script>

--- a/templates/common/form/disable_form_input.html
+++ b/templates/common/form/disable_form_input.html
@@ -1,6 +1,8 @@
 {% load custom_filters %}
 
-{% if comments and parent_object_field %}
+{% if request|is_readonly %}
+    disabled
+{% elif comments and parent_object_field %}
     {% if not editable and comments|hasnt_active_comments:parent_object_field %}disabled{% endif %}
 {% elif comments and object_field %}
     {% if not editable and comments|hasnt_active_comments:object_field %}disabled{% endif %}

--- a/templates/common/form/disable_form_input.html
+++ b/templates/common/form/disable_form_input.html
@@ -1,7 +1,7 @@
 {% load custom_filters %}
 
 {% if request|is_readonly %}
-    disabled
+    disabled data-readonly="true"
 {% elif comments and parent_object_field %}
     {% if not editable and comments|hasnt_active_comments:parent_object_field %}disabled{% endif %}
 {% elif comments and object_field %}

--- a/templates/common/form/download_upload_form.html
+++ b/templates/common/form/download_upload_form.html
@@ -1,48 +1,50 @@
 {% load static %}
 
-<p>Télécharger le modèle, éditer puis déposer vos {{ what }}.<br>
-    <span class="fr-icon-warning-line fr-mr-1w" aria-hidden="true"></span>Attention, la liste des {{ what }} déposée écrase la liste courante.
-</p>
-{% if file_type == "logements_edd" %}
-    <p class="fr-mt-1w"><em>Depuis le 1er juin 2022, un nouveau format de fichier est entré en vigueur. La colonne "type des logements" a été remplacée par "numéro de lot". Vous pouvez mettre à jour votre fichier en téléchargeant le nouveau modèle puis en le téléversant à nouveau.</em></p>
-{% endif %}
+{% if not request|is_readonly %}
+    <p>Télécharger le modèle, éditer puis déposer vos {{ what }}.<br>
+        <span class="fr-icon-warning-line fr-mr-1w" aria-hidden="true"></span>Attention, la liste des {{ what }} déposée écrase la liste courante.
+    </p>
+    {% if file_type == "logements_edd" %}
+        <p class="fr-mt-1w"><em>Depuis le 1er juin 2022, un nouveau format de fichier est entré en vigueur. La colonne "type des logements" a été remplacée par "numéro de lot". Vous pouvez mettre à jour votre fichier en téléchargeant le nouveau modèle puis en le téléversant à nouveau.</em></p>
+    {% endif %}
 
-<input
-    class="fileinput--hidden"
-    type="file"
-    id="{{upform.file.id_for_label}}"
-    name="{{upform.file.html_name}}"
-    accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
-<div class="block--row-strech">
-    <a class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left" href="{% url 'conventions:load_xlsx_model' file_type=file_type %}">
-        Télécharger le modèle des {{ what }}
-    </a>
+    <input
+        class="fileinput--hidden"
+        type="file"
+        id="{{upform.file.id_for_label}}"
+        name="{{upform.file.html_name}}"
+        accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
+    <div class="block--row-strech">
+        <a class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left" href="{% url 'conventions:load_xlsx_model' file_type=file_type %}">
+            Télécharger le modèle des {{ what }}
+        </a>
 
-    <div class="fr-mx-2w">Puis</div>
+        <div class="fr-mx-2w">Puis</div>
 
-    <div>
-        <button id="{{upform.file.id_for_label}}_upload_button" class="fr-btn fr-icon-upload-line fr-btn--icon-left" type="button">
-            Déposer le fichier de vos {{ what }}
-        </button>
-        {% for error in upform.file.errors %}
-            <p id="text-input-error-desc-error" class="fr-error-text">
-                {{ error }}
-            </p>
-        {% endfor %}
+        <div>
+            <button id="{{upform.file.id_for_label}}_upload_button" class="fr-btn fr-icon-upload-line fr-btn--icon-left" type="button">
+                Déposer le fichier de vos {{ what }}
+            </button>
+            {% for error in upform.file.errors %}
+                <p id="text-input-error-desc-error" class="fr-error-text">
+                    {{ error }}
+                </p>
+            {% endfor %}
+        </div>
+
     </div>
 
-</div>
-
-<script type="text/javascript" nonce="{{request.csp_nonce}}">
-    document.getElementById('{{upform.file.id_for_label}}_upload_button').onclick = function() {
-        document.getElementById('{{upform.file.id_for_label}}').click();
-    };
-    document.getElementById('{{upform.file.id_for_label}}').onchange = function() {
-        var input = document.createElement('input');
-        input.setAttribute('type', 'hidden');//hidden input
-        input.setAttribute('name', 'Upload');//set the param name
-        input.setAttribute('value', 'True');//set the value
-        this.form.appendChild(input)
-        this.form.submit()
-    }
-</script>
+    <script type="text/javascript" nonce="{{request.csp_nonce}}">
+        document.getElementById('{{upform.file.id_for_label}}_upload_button').onclick = function() {
+            document.getElementById('{{upform.file.id_for_label}}').click();
+        };
+        document.getElementById('{{upform.file.id_for_label}}').onchange = function() {
+            var input = document.createElement('input');
+            input.setAttribute('type', 'hidden');//hidden input
+            input.setAttribute('name', 'Upload');//set the param name
+            input.setAttribute('value', 'True');//set the value
+            this.form.appendChild(input)
+            this.form.submit()
+        }
+    </script>
+{% endif %}

--- a/templates/common/form/input_textarea.html
+++ b/templates/common/form/input_textarea.html
@@ -60,7 +60,7 @@
             id="{{form_input.id_for_label}}"
             name="{{form_input.html_name}}"
             rows="{% if rows %}{{rows}}{% else %}3{% endif %}"
-            {% if not editable %}disabled{% endif %}>{{ form_input.value|default_if_none:'' }}</textarea>
+            {% include "common/form/disable_form_input.html" %}>{{ form_input.value|default_if_none:'' }}</textarea>
         {% include "common/utils/comments_field.html" %}
     </div>
     {% for error in form_input.errors %}

--- a/templates/common/form/input_upload.html
+++ b/templates/common/form/input_upload.html
@@ -39,7 +39,7 @@
             <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
         {% endif %}
 
-        {% if not editable and comments|hasnt_active_comments:object_field %}
+        {% if not editable and comments|hasnt_active_comments:object_field or request|is_readonly %}
             <div class="fr-mt-6w">
                 {% include "common/display_files.html" with file_list=file_list %}
             </div>

--- a/templates/conventions/_bailleur_administration.html
+++ b/templates/conventions/_bailleur_administration.html
@@ -21,7 +21,7 @@
                     </div>
                     <details {% if form.errors %}open=""{% endif %} class="fr-mt-3w fr-col-12 fr-col-md-5">
                         <summary>
-                            <div class="fr-btn fr-mt-auto fr-ml-auto fr-mb-1w">Changer l'administration</div>
+                            <div class="fr-btn fr-btn--secondary fr-mt-auto fr-ml-auto fr-mb-1w">Changer l'administration</div>
                         </summary>
                         {% with convention_uuid_str=convention.uuid|stringformat:"s" %}
                             {% url 'users:search_administration' as search_administration_url %}
@@ -31,7 +31,9 @@
                         <button
                             name="change_administration"
                             value="True"
-                            class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-warning-line" type="submit"
+                            class="fr-btn fr-btn--icon-left fr-icon-warning-line"
+                            type="submit"
+                            {% include "common/form/disable_form_input.html" %}
                         >
                             Valider le changement d'administration
                         </button>

--- a/templates/conventions/_bailleur_entreprise.html
+++ b/templates/conventions/_bailleur_entreprise.html
@@ -35,12 +35,12 @@
                         </div>
                         <details {% if form.errors %}open{% endif %} class="fr-mt-3w">
                             <summary>
-                                <div class="fr-btn">Changer le bailleur de cette convention et de son opération</div>
+                                <div class="fr-btn fr-btn--secondary">Changer le bailleur de cette convention et de son opération</div>
                             </summary>
                             <div>
                                 {% url 'users:search_bailleur' as search_bailleur_url %}
                                 {% include "common/form/input_search_select.html" with form_input=form.bailleur url=search_bailleur_url %}
-                                <button class="fr-btn" name="change_bailleur" value="True">
+                                <button class="fr-btn" name="change_bailleur" value="True" {% include "common/form/disable_form_input.html" %}>
                                     Changer le bailleur
                                 </button>
                             </div>

--- a/templates/conventions/actions/back_to_instruction.html
+++ b/templates/conventions/actions/back_to_instruction.html
@@ -1,8 +1,7 @@
 {% load custom_filters %}
 {% load display_filters %}
 
-{% if convention|display_back_to_instruction:request %}
-
+{% if convention|display_back_to_instruction:request and not request|is_readonly %}
     <div class="fr-col-12">
         <div class="block--row-strech">
             <div class="block--row-strech-1 fr-mr-6w">

--- a/templates/conventions/actions/back_to_instruction.html
+++ b/templates/conventions/actions/back_to_instruction.html
@@ -21,7 +21,7 @@
             </div>
             <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
                 {% csrf_token %}
-                <button name="BackToInstruction" value=True class="fr-btn  apilos-btn--secondary--red fr-my-1w">
+                <button name="BackToInstruction" value=True class="fr-btn  apilos-btn--secondary--red fr-my-1w" {% include "common/form/disable_form_input.html" %}>
                     Retour à l'instruction
                 </button>
             </form>

--- a/templates/conventions/actions/update_date_resiliation.html
+++ b/templates/conventions/actions/update_date_resiliation.html
@@ -11,7 +11,7 @@
             </p>
             {% include "common/form/input_date.html" with form_input=resiliation_date_form.date_resiliation editable=True %}
         </div>
-        <button class="fr-btn fr-btn--secondary">
+        <button class="fr-btn fr-btn--secondary" {% include "common/form/disable_form_input.html" %}>
             Mettre à jour la date
         </button>
     </div>

--- a/templates/conventions/actions/update_date_signature.html
+++ b/templates/conventions/actions/update_date_signature.html
@@ -11,7 +11,7 @@
             </p>
             {% include "common/form/input_date.html" with form_input=signature_date_form.televersement_convention_signee_le editable=True %}
         </div>
-        <button class="fr-btn fr-btn--secondary">
+        <button class="fr-btn fr-btn--secondary" {% include "common/form/disable_form_input.html" %}>
             Mettre à jour la date
         </button>
     </div>

--- a/templates/conventions/avenant/denonciation_start.html
+++ b/templates/conventions/avenant/denonciation_start.html
@@ -12,7 +12,7 @@
             {% csrf_token %}
             <input id="denonciation_start" type="hidden" name="denonciation_start" value="true">
             <input type="hidden" value="denonciation" name="avenant_type">
-            <button class="fr-btn apilos-btn--secondary--red fr-btn--icon-left fr-icon-delete-line fr-my-2w">Dénoncer la convention</button>
+            <button class="fr-btn apilos-btn--secondary--red fr-btn--icon-left fr-icon-delete-line fr-my-2w" {% include "common/form/disable_form_input.html" %}>Dénoncer la convention</button>
         </form>
     {% else %}
         <button class="fr-btn fr-btn--icon-left fr-icon-delete-line fr-my-2w" disabled>Dénoncer la convention</button>

--- a/templates/conventions/avenant/resiliation_start.html
+++ b/templates/conventions/avenant/resiliation_start.html
@@ -12,7 +12,7 @@
             {% csrf_token %}
             <input id="resiliation_start" type="hidden" name="resiliation_start" value="true">
             <input type="hidden" value="resiliation" name="avenant_type">
-            <button class="fr-btn apilos-btn--secondary--red fr-btn--icon-left fr-icon-delete-line fr-my-2w">Résilier la convention</button>
+            <button class="fr-btn apilos-btn--secondary--red fr-btn--icon-left fr-icon-delete-line fr-my-2w" {% include "common/form/disable_form_input.html" %}>Résilier la convention</button>
         </form>
     {% else %}
         <button class="fr-btn fr-btn--icon-left fr-icon-delete-line fr-my-2w" disabled>Résilier la convention</button>

--- a/templates/conventions/cadastre.html
+++ b/templates/conventions/cadastre.html
@@ -94,12 +94,14 @@
                                             <div class="fr-radio-group">
                                                 <input type="radio" value= "achevement" id="achevement" name="achevement" class="achevement_choice_button"
                                                        {% if convention.programme.date_achevement %} checked {% endif %}
+                                                       {% include "common/form/disable_form_input.html" %}
                                                 >
                                                 <label for="achevement">Mon bâtiment est achevé</label>
                                             </div>
                                             <div class="fr-radio-group">
                                                 <input type="radio" value= "achevement_previsible" id="achevement_previsible" name="achevement"class="achevement_choice_button"
                                                        {% if convention.programme.date_achevement_previsible and convention.programme.date_achevement is None %} checked {% endif %}
+                                                       {% include "common/form/disable_form_input.html" %}
                                                 >
                                                 <label for="achevement_previsible">Mon bâtiment est en construction</label>
                                             </div>

--- a/templates/conventions/common/form_upload_signed_document.html
+++ b/templates/conventions/common/form_upload_signed_document.html
@@ -12,7 +12,8 @@
 
     <div class="block--row-strech">
         <div>
-            <button id="{{upform.file.id_for_label}}_upload_button" class="fr-btn fr-icon-upload-line fr-btn--icon-left" type="button">
+            <button id="{{upform.file.id_for_label}}_upload_button" class="fr-btn fr-icon-upload-line fr-btn--icon-left" type="button"
+                    {% if request|is_readonly %}disabled{% endif %}>
                 {% if convention.is_denonciation %}
                     Déposer l'acte de dénonciation publié
                 {% else %}

--- a/templates/conventions/foyer_attribution.html
+++ b/templates/conventions/foyer_attribution.html
@@ -40,7 +40,8 @@
                                             id="{{form.attribution_type.html_name}}-agees"
                                             value="agees"
                                             name="{{form.attribution_type.html_name}}"
-                                            {% if form.attribution_type.value == 'agees' %}checked{% endif %}>
+                                            {% if form.attribution_type.value == 'agees' %}checked{% endif %}
+                                            {% include "common/form/disable_form_input.html" %}>
                                         <label class="fr-label fr-h5" for="{{form.attribution_type.html_name}}-agees">Aux personnes âgées seules ou en ménage
                                         </label>
                                     </div>
@@ -58,7 +59,8 @@
                                             id="{{form.attribution_type.html_name}}-handicapees"
                                             value="handicapees"
                                             name="{{form.attribution_type.html_name}}"
-                                            {% if form.attribution_type.value == 'handicapees' %}checked{% endif %}>
+                                            {% if form.attribution_type.value == 'handicapees' %}checked{% endif %}
+                                            {% include "common/form/disable_form_input.html" %}>
                                         <label class="fr-label fr-h5" for="{{form.attribution_type.html_name}}-handicapees">Aux personnes handicapées seules ou en ménage
                                         </label>
                                     </div>
@@ -75,7 +77,8 @@
                                             id="{{form.attribution_type.html_name}}-inclusif"
                                             value="inclusif"
                                             name="{{form.attribution_type.html_name}}"
-                                            {% if form.attribution_type.value == 'inclusif' %}checked{% endif %}>
+                                            {% if form.attribution_type.value == 'inclusif' %}checked{% endif %}
+                                            {% include "common/form/disable_form_input.html" %}>
                                         <label class="fr-label fr-h5" for="{{form.attribution_type.html_name}}-inclusif">Habitat inclusif
                                             <span class="fr-hint-text">Aux personnes en situation de perte d’autonomie liée à l’âge ou au handicap seules ou en ménage</span>
                                         </label>

--- a/templates/conventions/journal.html
+++ b/templates/conventions/journal.html
@@ -10,43 +10,45 @@
         {% include "common/nav_bar.html" with nav_bar_step="journal" %}
 
         <div class="fr-container fr-my-6w">
-            <div class="fr-card fr-card--no-arrow">
-                <div class="fr-card__body fr-my-2w">
-                    <h2 class="fr-text--lg">Ajouter un évènement au journal</h2>
-                    {% if action == 'create' %}
-                        <form method="POST">
-                            {% csrf_token %}
-                            <div class="fr-col-12 fr-mb-2w">
-                                {% include "common/form/input_select.html" with form_input=form.type_evenement editable=True %}
-                            </div>
-
-                            <div class="fr-col-12 fr-mb-4w">
-                                {% include "common/form/input_textarea.html" with form_input=form.description editable=True %}
-                            </div>
-
-                            <div class="fr-grid-row fr-grid-row--right">
-                                <div class="fr-mr-4w fr-mt-1w">
-                                    <a class="fr-link" href={% url 'conventions:journal' convention_uuid=convention.uuid %}>Annuler</a>
-                                </div>
-                                <button class="fr-btn" name="action" value="submit" type="submit">
-                                    <span class="fr-icon-save-line fr-mr-1w" aria-hidden="true"></span>Enregistrer
-                                </button>
-                            </div>
-                        </form>
-                    {% else %}
-                        <div class="fr-col-12 block--row-strech">
-                            <div class="block--row-strech-1 fr-mr-6w">
-                                <p>Un nouvel évènement est survenu dans la vie de la convention, vous pouvez le signaler ici.</p>
-                            </div>
+            {% if not request|is_readonly %}
+                <div class="fr-card fr-card--no-arrow">
+                    <div class="fr-card__body fr-my-2w">
+                        <h2 class="fr-text--lg">Ajouter un évènement au journal</h2>
+                        {% if action == 'create' %}
                             <form method="POST">
                                 {% csrf_token %}
-                                <button class="fr-btn fr-btn--secondary fr-icon-add-circle-line fr-btn--icon-left fr-my-1w fr-mr-2w" name="action" value="create" type="submit">Ajouter un évènement
-                                </button>
+                                <div class="fr-col-12 fr-mb-2w">
+                                    {% include "common/form/input_select.html" with form_input=form.type_evenement editable=True %}
+                                </div>
+
+                                <div class="fr-col-12 fr-mb-4w">
+                                    {% include "common/form/input_textarea.html" with form_input=form.description editable=True %}
+                                </div>
+
+                                <div class="fr-grid-row fr-grid-row--right">
+                                    <div class="fr-mr-4w fr-mt-1w">
+                                        <a class="fr-link" href={% url 'conventions:journal' convention_uuid=convention.uuid %}>Annuler</a>
+                                    </div>
+                                    <button class="fr-btn" name="action" value="submit" type="submit">
+                                        <span class="fr-icon-save-line fr-mr-1w" aria-hidden="true"></span>Enregistrer
+                                    </button>
+                                </div>
                             </form>
-                        </div>
-                    {% endif %}
+                        {% else %}
+                            <div class="fr-col-12 block--row-strech">
+                                <div class="block--row-strech-1 fr-mr-6w">
+                                    <p>Un nouvel évènement est survenu dans la vie de la convention, vous pouvez le signaler ici.</p>
+                                </div>
+                                <form method="POST">
+                                    {% csrf_token %}
+                                    <button class="fr-btn fr-btn--secondary fr-icon-add-circle-line fr-btn--icon-left fr-my-1w fr-mr-2w" name="action" value="create" type="submit">Ajouter un évènement
+                                    </button>
+                                </form>
+                            </div>
+                        {% endif %}
+                    </div>
                 </div>
-            </div>
+            {% endif %}
             <div class="fr-mt-4w">
                 {% for evenement in events %}
                     {% if action == 'edit' and selected == evenement %}

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -53,9 +53,16 @@
                         <p>Votre projet a évolué. Vous avez identifié des informations erronées ou caduques ?</p>
                         <div class="block--row-strech">
                             {% if convention.is_avenant and convention.parent|display_create_avenant or not convention.is_avenant and convention|display_create_avenant  %}
-                                <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
-                                    <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un {% if convention.is_avenant %}autre {% endif %}avenant
-                                </a>
+                                {% if request|is_readonly %}
+                                    <button class="fr-btn fr-my-1w fr-mr-2w" type="button" disabled>
+                                        <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un {% if convention.is_avenant %}autre {% endif %}avenant
+                                    </button>
+                                {% else %}
+
+                                    <a class="fr-btn fr-my-1w fr-mr-2w" href="{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}">
+                                        <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>Créer un {% if convention.is_avenant %}autre {% endif %}avenant
+                                    </a>
+                                {% endif %}
                             {% else %}
                                 <button class="fr-btn fr-my-1w fr-mr-2w" disabled>
                                     <span class="fr-icon-add-circle-line fr-mr-1w" aria-hidden="true"></span>
@@ -126,7 +133,7 @@
                                 accept="application/pdf">
                             <div class="block--row-strech">
                                 <div>
-                                    <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button">
+                                    <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button" {% include "common/form/disable_form_input.html" %}>
                                         {% if convention.is_denonciation %}
                                             Déposer la dénonciation
                                         {% else %}

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -129,44 +129,46 @@
                     {% include "conventions/recapitulatif/variantes.html" with target_url='conventions:variantes' %}
                     {% include "conventions/recapitulatif/commentaires.html" with target_url='conventions:commentaires' %}
                 {% endif %}
-                <turbo-frame id="convention_actions" data-turbo="true">
-                    {% include "conventions/actions/submit_convention.html" %}
-                    {% include "conventions/actions/instructeur_notification.html" %}
-                    {% if not convention|display_is_validated %}
-                        <div class="fr-grid-row fr-grid-row--gutters fr-mt-3w">
-                            {% include "conventions/actions/bailleur_notification.html" %}
-                            {% if not convention.is_resiliation %}
-                                <div class="fr-col-6 fr-py-5w fr-px-3w apilos-or-border">
-                            {% endif %}
-                            {% if convention.is_resiliation and request.user.is_instructeur_departemental %}
-                                <div class="fr-col-6 fr-py-5w fr-px-3w apilos-or-border">
-                            {% endif %}
-                            {% if convention.is_denonciation %}
-                                {% include "conventions/actions/validate_denonciation.html" %}
-                            {% elif convention.is_resiliation %}
-                                {% if request.user.is_instructeur_departemental %}
-                                    {% include "conventions/actions/validate_resiliation.html" %}
+                {% if not request|is_readonly %}
+                    <turbo-frame id="convention_actions" data-turbo="true">
+                        {% include "conventions/actions/submit_convention.html" %}
+                        {% include "conventions/actions/instructeur_notification.html" %}
+                        {% if not convention|display_is_validated %}
+                            <div class="fr-grid-row fr-grid-row--gutters fr-mt-3w">
+                                {% include "conventions/actions/bailleur_notification.html" %}
+                                {% if not convention.is_resiliation %}
+                                    <div class="fr-col-6 fr-py-5w fr-px-3w apilos-or-border">
                                 {% endif %}
-                            {% else %}
-                                {% include "conventions/actions/instructeur_validation.html" %}
-                            {% endif %}
-                            {% if not convention.is_resiliation %}
-                                </div>
-                            {% endif %}
-                            {% if convention.is_resiliation and request.user.is_instructeur_departemental %}
-                                </div>
-                            {% endif %}
-                        </div>
-                    {% endif %}
-                    {% include "conventions/actions/type1and2_options.html" %}
-                    {% if not convention.is_denonciation and not convention.is_resiliation %}
-                        {% include "conventions/actions/generate_convention.html" %}
-                    {% endif %}
-                    {% include "conventions/actions/cancel_convention.html" %}
-                    {% include "conventions/actions/delete.html" %}
-                    {% include "conventions/actions/display_spf_info.html" %}
-                    {% include "conventions/actions/display_resiliation_info.html" %}
-                </turbo-frame>
+                                {% if convention.is_resiliation and request.user.is_instructeur_departemental %}
+                                    <div class="fr-col-6 fr-py-5w fr-px-3w apilos-or-border">
+                                {% endif %}
+                                {% if convention.is_denonciation %}
+                                    {% include "conventions/actions/validate_denonciation.html" %}
+                                {% elif convention.is_resiliation %}
+                                    {% if request.user.is_instructeur_departemental %}
+                                        {% include "conventions/actions/validate_resiliation.html" %}
+                                    {% endif %}
+                                {% else %}
+                                    {% include "conventions/actions/instructeur_validation.html" %}
+                                {% endif %}
+                                {% if not convention.is_resiliation %}
+                                    </div>
+                                {% endif %}
+                                {% if convention.is_resiliation and request.user.is_instructeur_departemental %}
+                                    </div>
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                        {% include "conventions/actions/type1and2_options.html" %}
+                        {% if not convention.is_denonciation and not convention.is_resiliation %}
+                            {% include "conventions/actions/generate_convention.html" %}
+                        {% endif %}
+                        {% include "conventions/actions/cancel_convention.html" %}
+                        {% include "conventions/actions/delete.html" %}
+                        {% include "conventions/actions/display_spf_info.html" %}
+                        {% include "conventions/actions/display_resiliation_info.html" %}
+                    </turbo-frame>
+                {% endif %}
                 <div class="fr-col-12 fr-py-5w">{% include "common/button/return_convention_index.html" %}</div>
             </div>
         </div>

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -30,7 +30,7 @@
                         {% include "comments/opened_comments.html" %}
                     </turbo-frame>
                 {% endif %}
-                {% if convention.statut == CONVENTION_STATUT.SIGNEE and request|is_instructeur %}
+                {% if convention.statut == CONVENTION_STATUT.SIGNEE and request|is_instructeur and not request|is_readonly %}
                     <div class="fr-grid-row fr-grid-row--right">
                         <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}"
                            class="fr-btn fr-btn--secondary">

--- a/templates/settings/form/email_preferences.html
+++ b/templates/settings/form/email_preferences.html
@@ -14,7 +14,8 @@
                         id="tous"
                         value="TOUS"
                         {% if form_input.value == "TOUS" %}checked{% endif %}
-                        name="{{ form_input.html_name }}">
+                        name="{{ form_input.html_name }}"
+                        {% include "common/form/disable_form_input.html" %}>
                     <label class="fr-label" for="tous">
                         {% if user.is_bailleur %}
                             Toutes les conventions
@@ -34,7 +35,8 @@
                         id="partiel"
                         value="PARTIEL"
                         {% if form_input.value == "PARTIEL" %}checked{% endif %}
-                        name="{{ form_input.html_name }}">
+                        name="{{ form_input.html_name }}"
+                        {% include "common/form/disable_form_input.html" %}>
                     <label class="fr-label" for="partiel">
                         {% if user.is_bailleur %}
                             Les conventions que vous avez soumises à l'instruction
@@ -54,7 +56,8 @@
                         id="aucun"
                         value="AUCUN"
                         {% if form_input.value == "AUCUN" %}checked{% endif %}
-                        name="{{ form_input.html_name }}">
+                        name="{{ form_input.html_name }}"
+                        {% include "common/form/disable_form_input.html" %}>
                     <label class="fr-label" for="aucun">
                         {% if user.is_bailleur %}
                             Aucun email

--- a/users/fixtures/auth.json
+++ b/users/fixtures/auth.json
@@ -870,5 +870,47 @@
         ["view_administration", "instructeurs", "administration"]
       ]
     }
+  },
+  {
+    "model": "auth.group",
+    "fields": {
+      "name": "readonly_bailleur",
+      "permissions": [
+        ["view_bailleur", "bailleurs", "bailleur"],
+        ["add_comment", "comments", "comment"],
+        ["change_comment", "comments", "comment"],
+        ["view_comment", "comments", "comment"],
+        ["view_convention", "conventions", "convention"],
+        ["view_administration", "instructeurs", "administration"]
+      ]
+    }
+  },
+  {
+    "model": "auth.group",
+    "fields": {
+      "name": "readonly_instructeur",
+      "permissions": [
+        ["view_bailleur", "bailleurs", "bailleur"],
+        ["add_comment", "comments", "comment"],
+        ["change_comment", "comments", "comment"],
+        ["view_comment", "comments", "comment"],
+        ["view_convention", "conventions", "convention"],
+        ["view_administration", "instructeurs", "administration"]
+      ]
+    }
+  },
+  {
+    "model": "auth.group",
+    "fields": {
+      "name": "readonly_administrateur",
+      "permissions": [
+        ["view_bailleur", "bailleurs", "bailleur"],
+        ["add_comment", "comments", "comment"],
+        ["change_comment", "comments", "comment"],
+        ["view_comment", "comments", "comment"],
+        ["view_convention", "conventions", "convention"],
+        ["view_administration", "instructeurs", "administration"]
+      ]
+    }
   }
 ]

--- a/users/models.py
+++ b/users/models.py
@@ -323,6 +323,9 @@ class User(AbstractUser):
         )
 
     def has_perm(self, perm, obj=None, role_id: int | None = None):
+        if self.is_staff or self.is_superuser:
+            return self.is_active
+
         # check object permission
         if obj is not None and not self.has_object_permission(obj):
             return False

--- a/users/models.py
+++ b/users/models.py
@@ -332,6 +332,7 @@ class User(AbstractUser):
 
         # check permission itself
         permissions = []
+        # Get current role here
         roles = self.roles.all()
         if role_id:
             roles = roles.filter(id=role_id)

--- a/users/models.py
+++ b/users/models.py
@@ -55,6 +55,10 @@ class GroupProfile(models.TextChoices):
         ]
 
 
+class GroupRoleProfile(models.TextChoices):
+    ADM_CENTRALE_LECTEUR = "ADM_CENTRALE_LECTEUR", "Lecteur national"
+
+
 class User(AbstractUser):
     siap_habilitation = {}
     telephone = models.CharField(

--- a/users/models.py
+++ b/users/models.py
@@ -323,9 +323,6 @@ class User(AbstractUser):
         )
 
     def has_perm(self, perm, obj=None, role_id: int | None = None):
-        if self.is_staff or self.is_superuser:
-            return self.is_active
-
         # check object permission
         if obj is not None and not self.has_object_permission(obj):
             return False

--- a/users/models.py
+++ b/users/models.py
@@ -37,26 +37,186 @@ class GroupProfile(models.TextChoices):
     @classmethod
     def instructeur_profiles(cls):
         return [
-            GroupProfile.STAFF,
-            GroupProfile.INSTRUCTEUR,
-            GroupProfile.SIAP_SER_GEST,
-            GroupProfile.SIAP_ADM_CENTRALE,
-            GroupProfile.SIAP_DIR_REG,
-            GroupProfile.SIAP_SER_DEP,
+            cls.STAFF,
+            cls.INSTRUCTEUR,
+            cls.SIAP_SER_GEST,
+            cls.SIAP_ADM_CENTRALE,
+            cls.SIAP_DIR_REG,
+            cls.SIAP_SER_DEP,
         ]
 
     @classmethod
     def bailleur_profiles(cls):
         return [
-            GroupProfile.STAFF,
-            GroupProfile.BAILLEUR,
-            GroupProfile.SIAP_MO_PERS_MORALE,
-            GroupProfile.SIAP_MO_PERS_PHYS,
+            cls.STAFF,
+            cls.BAILLEUR,
+            cls.SIAP_MO_PERS_MORALE,
+            cls.SIAP_MO_PERS_PHYS,
         ]
 
 
-class GroupRoleProfile(models.TextChoices):
-    ADM_CENTRALE_LECTEUR = "ADM_CENTRALE_LECTEUR", "Lecteur national"
+class GroupProfileRole(models.TextChoices):
+    ADM_CENTRALE_ADMIN = (
+        "ADM_CENTRALE_ADMIN",
+        "appartient au groupe ADM_CENTRALE, périmètre NAT",
+    )
+    ADM_CENTRALE_LECTEUR = (
+        "ADM_CENTRALE_LECTEUR",
+        "appartient au groupe ADM_CENTRALE, périmètre NAT",
+    )
+    DIR_REG_ADMIN = "DIR_REG_ADMIN", "appartient au groupe DIR_REG, périmètre REG"
+    DIR_REG_INSTRUCTEUR = (
+        "DIR_REG_INSTRUCTEUR",
+        "appartient au groupe DIR_REG, périmètre REG",
+    )
+    DIR_REG_LECTEUR = "DIR_REG_LECTEUR", "appartient au groupe DIR_REG, périmètre REG"
+    SERV_DEP_ADMIN = "SERV_DEP_ADMIN", "appartient au groupe SER_DEP, périmètre DEP"
+    SERV_DEP_INSTRUCTEUR = (
+        "SERV_DEP_INSTRUCTEUR",
+        "appartient au groupe SER_DEP, périmètre DEP",
+    )
+    SERV_DEP_LECTEUR = "SERV_DEP_LECTEUR", "appartient au groupe SER_DEP, périmètre DEP"
+    SERV_INSTR_ADMIN = (
+        "SERV_INSTR_ADMIN",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_INSTRUCTEUR = (
+        "SERV_INSTR_INSTRUCTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_VALIDEUR = (
+        "SERV_INSTR_VALIDEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_INSTRUCTEUR_CHORUS = (
+        "SERV_INSTR_INSTRUCTEUR_CHORUS",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_LECTEUR = (
+        "SERV_INSTR_LECTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG2_ADMIN = (
+        "SERV_INSTR_DELGEG2_ADMIN",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG2_INSTRUCTEUR = (
+        "SERV_INSTR_DELGEG2_INSTRUCTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG2_VALIDEUR = (
+        "SERV_INSTR_DELGEG2_VALIDEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG2_LECTEUR = (
+        "SERV_INSTR_DELGEG2_LECTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG3_ADMIN = (
+        "SERV_INSTR_DELGEG3_ADMIN",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG3_INSTRUCTEUR = (
+        "SERV_INSTR_DELGEG3_INSTRUCTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG3_VALIDEUR = (
+        "SERV_INSTR_DELGEG3_VALIDEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG3_LECTEUR = (
+        "SERV_INSTR_DELGEG3_LECTEUR",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    ASS_HLM_NAT_LECTEUR = (
+        "ASS_HLM_NAT_LECTEUR",
+        "appartient au groupe ASS_HLM, périmètre NAT",
+    )
+    ASS_HLM_REG_LECTEUR = (
+        "ASS_HLM_REG_LECTEUR",
+        "appartient au groupe ASS_HLM, périmètre REG",
+    )
+    MO_MORAL_NAT_ADMIN = (
+        "MO_MORAL_NAT_ADMIN",
+        "appartient au groupe MO_PERS_MORALE, périmètre NAT",
+    )
+    MO_MORAL_NAT_LECTEUR = (
+        "MO_MORAL_NAT_LECTEUR",
+        "appartient au groupe MO_PERS_MORALE, périmètre NAT",
+    )
+    MO_MORAL_REG_ADMIN = (
+        "MO_MORAL_REG_ADMIN",
+        "appartient au groupe MO_PERS_MORALE, périmètre REG",
+    )
+    MO_MORAL_REG_INSTRUCTEUR = (
+        "MO_MORAL_REG_INSTRUCTEUR",
+        "appartient au groupe MO_PERS_MORALE, périmètre REG",
+    )
+    MO_MORAL_REG_VALIDEUR = (
+        "MO_MORAL_REG_VALIDEUR",
+        "appartient au groupe MO_PERS_MORALE, périmètre REG",
+    )
+    MO_MORAL_REG_LECTEUR = (
+        "MO_MORAL_REG_LECTEUR",
+        "appartient au groupe MO_PERS_MORALE, périmètre REG",
+    )
+    MO_PHYS = "MO_PHYS", "appartient au groupe MO_PERS_PHYS, périmètre COM"
+    DIR_REG_VALIDEUR = "DIR_REG_VALIDEUR", "appartient au groupe DIR_REG, périmètre REG"
+    DIR_REG_INSTRUCTEUR_CHORUS = (
+        "DIR_REG_INSTRUCTEUR_CHORUS",
+        "appartient au groupe DIR_REG, périmètre REG",
+    )
+    SERV_DEP_VALIDEUR = (
+        "SERV_DEP_VALIDEUR",
+        "appartient au groupe SER_DEP, périmètre DEP",
+    )
+    SERV_DEP_INSTRUCTEUR_CHORUS = (
+        "SERV_DEP_INSTRUCTEUR_CHORUS",
+        "appartient au groupe SER_DEP, périmètre DEP",
+    )
+    SERV_INSTR_SIGNATAIRE = (
+        "SERV_INSTR_SIGNATAIRE",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    SERV_INSTR_DELGEG3_SIGNATAIRE = (
+        "SERV_INSTR_DELGEG3_SIGNATAIRE",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+    MO_MORAL_REG_SIGNATAIRE = (
+        "MO_MORAL_REG_SIGNATAIRE",
+        "appartient au groupe MO_PERS_MORALE, périmètre REG",
+    )
+    DIR_REG_SIGNATAIRE = (
+        "DIR_REG_SIGNATAIRE",
+        "appartient au groupe DIR_REG, périmètre REG",
+    )
+    SERV_DEP_SIGNATAIRE = (
+        "SERV_DEP_SIGNATAIRE",
+        "appartient au groupe SER_DEP, périmètre DEP",
+    )
+    SERV_INSTR_DELGEG2_SIGNATAIRE = (
+        "SERV_INSTR_DELGEG2_SIGNATAIRE",
+        "appartient au groupe SER_GEST, périmètre LOC",
+    )
+
+    @classmethod
+    def readonly_group_profile_roles(cls):
+        return [
+            cls.ADM_CENTRALE_LECTEUR,
+            cls.DIR_REG_LECTEUR,
+            cls.SERV_DEP_LECTEUR,
+            cls.SERV_INSTR_LECTEUR,
+            cls.SERV_INSTR_DELGEG2_LECTEUR,
+            cls.SERV_INSTR_DELGEG3_LECTEUR,
+            cls.SERV_INSTR_LECTEUR,
+            cls.SERV_INSTR_LECTEUR,
+            cls.ASS_HLM_NAT_LECTEUR,
+            cls.ASS_HLM_REG_LECTEUR,
+            cls.MO_MORAL_NAT_LECTEUR,
+            cls.MO_MORAL_REG_LECTEUR,
+            cls.DIR_REG_INSTRUCTEUR_CHORUS,
+            cls.SERV_DEP_INSTRUCTEUR_CHORUS,
+        ]
 
 
 class User(AbstractUser):
@@ -162,7 +322,7 @@ class User(AbstractUser):
             + "permission 'change_convention'"
         )
 
-    def has_perm(self, perm, obj=None):
+    def has_perm(self, perm, obj=None, role_id: int | None = None):
         if self.is_staff or self.is_superuser:
             return self.is_active
 
@@ -172,7 +332,10 @@ class User(AbstractUser):
 
         # check permission itself
         permissions = []
-        for role in self.roles.all():
+        roles = self.roles.all()
+        if role_id:
+            roles = roles.filter(id=role_id)
+        for role in roles:
             permissions += map(
                 lambda permission: permission.content_type.name
                 + "."
@@ -181,8 +344,8 @@ class User(AbstractUser):
             )
         return perm in permissions
 
-    def check_perm(self, perm, obj=None):
-        if not self.has_perm(perm, obj):
+    def check_perm(self, perm, obj=None, role_id: int | None = None):
+        if not self.has_perm(perm, obj=obj, role_id=role_id):
             raise PermissionDenied
 
     def is_bailleur(self, bailleur_id=None):


### PR DESCRIPTION
To do :

- [x] manage a different role than instructeur / administrateur / bailleur to manage readonly permission
- [x] Manage form button : `Next without save`
- [x] Manage activation on adding a comment
- [x] Manage call too action : do not display for readonly profil : Ongoing

Some view function to transform as a class (add some tests if possible)
- [x] convention.sent

Some behavior to adapt
- [x] don't allow to create an avenant
- [x] check that permssion_required works for the current permission of the user