### PR TITLE
Fix co bailleur privé mail en SIRET dans le SIAP

### DIFF
--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -98,6 +98,8 @@ def get_or_create_bailleur(bailleur_from_siap: dict):
     ]:
         if "email" in bailleur_from_siap and bailleur_from_siap["email"]:
             bailleur_siren = bailleur_from_siap["email"]
+        elif bailleur_from_siap.get("siret"):
+            bailleur_siren = bailleur_from_siap["siret"]
         else:
             raise NotHandledBailleurPriveSIAPException(
                 "The « Bailleurs privés » type of bailleur is not handled yet"

--- a/templates/500.html
+++ b/templates/500.html
@@ -6,7 +6,7 @@
                 <div class="fr-col-lg-11 fr-col-offset-lg-1 fr-mb-2w">
 
                     {% if exception_type == 'NotHandledBailleurPriveSIAPException' %}
-                        <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Cet fonctionnalité n'est pas encore prise en charge par la plateforme SIAP-APiLos</h2>
+                        <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Cette fonctionnalité n'est pas encore prise en charge par la plateforme SIAP-APiLos</h2>
                         <p class="fr-mb-3w">
                             Le conventionnement des opérations portées par des bailleurs privés (personnes physiques sans SIREN) n'est pas pris en charge actuellement par la plateforme SIAP-APiLos.<br>
                             Nos équipes techniques travaillent actuellement à la mise en place de cette fonctionnalité.


### PR DESCRIPTION
Voilà les infos reçues du SIAP dans le cadre du bailleur privé SANZ : 

`{'nom': 'Monsieur SANZ Henri', 'siren': None, 'commune': {'id': 3923, 'code': '11262', 'libelle': 'Narbonne', 'regionId': None}, 'adresseLigne': '8 Impasse le Tintoret', 'codePostal': '11100', 'adresseLigne3': None, 'adresseLigne4': '8 Impasse le Tintoret', 'adresseLigne6': '11100 Narbonne', 'siret': 'mcch2@wanadoo.fr', 'codeFamilleMO': NatureBailleur.PRIVES}`

On voit qu'il y a pas de champ email comme attendu par APiLos, le mail est en siret. J'ai ajouté ce cas, mais peut-être qu'on préfère changer ça côté SIAP.