### PR TITLE
S241 List contributors to a convention

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import date
 
 from django.apps import apps
+from django.contrib.auth import get_user_model
 from django.db import models
 from django.db.models import Q
 from django.forms import model_to_dict
@@ -768,8 +769,8 @@ class Convention(models.Model):
     def get_contributors(self):
         result = {"instructeurs": [], "bailleurs": []}
         user_ids = self.conventionhistories.values_list("user_id", flat=True).distinct()
-        # get_model is used to avoid circular imports
-        user_model = apps.get_model("users", "User")
+        # get_user_model is used to avoid circular imports
+        user_model = get_user_model()
         for user_id in user_ids:
             try:
                 user = user_model.objects.get(id=user_id)

--- a/conventions/tests/models/test_contributors.py
+++ b/conventions/tests/models/test_contributors.py
@@ -1,0 +1,63 @@
+import pytest
+from django.test import RequestFactory
+
+from bailleurs.tests.factories import BailleurFactory
+from conventions.models.choices import ConventionStatut
+from conventions.tests.factories import ConventionFactory
+from conventions.views import save_convention
+from conventions.views.conventions import validate_convention
+from instructeurs.tests.factories import AdministrationFactory
+from programmes.tests.factories import ProgrammeFactory
+from users.tests.factories import GroupFactory, RoleFactory, UserFactory
+from users.type_models import TypeRole
+
+
+@pytest.mark.django_db
+def test_get_contributors():
+    # Create a new convention en projet
+    bailleur = BailleurFactory()
+    administration = AdministrationFactory()
+    programme = ProgrammeFactory(bailleur=bailleur, administration=administration)
+    convention = ConventionFactory(
+        statut=ConventionStatut.PROJET.label, lot__programme=programme
+    )
+
+    # Create a user bailleur and a user instructeur
+    user_bailleur = UserFactory()
+    RoleFactory(
+        user=user_bailleur,
+        bailleur=bailleur,
+        typologie=TypeRole.BAILLEUR,
+        group=GroupFactory(name="Bailleur", rw=["logement", "convention"]),
+    )
+    user_instructeur = UserFactory()
+    RoleFactory(
+        user=user_instructeur,
+        administration=administration,
+        typologie=TypeRole.INSTRUCTEUR,
+        group=GroupFactory(name="Instructeur", rwd=["logement", "convention"]),
+    )
+
+    # Submit the convention to instruction with a bailleur
+    request = RequestFactory().post("/", {"SubmitConvention": True})
+    request.session = "session"
+    request.user = user_bailleur
+    save_convention(request, convention.uuid)
+
+    # Bailleur should appear in contributors
+    assert convention.get_contributors() == {
+        "instructeurs": [],
+        "bailleurs": [(user_bailleur.first_name, user_bailleur.last_name)],
+    }
+
+    # Validate convention with an instructeur
+    request = RequestFactory().post("/", {"convention_numero": "1234"})
+    request.session = "session"
+    request.user = user_instructeur
+    validate_convention(request, convention.uuid)
+
+    # The instructor should appear in contributors
+    assert convention.get_contributors() == {
+        "instructeurs": [(user_instructeur.first_name, user_instructeur.last_name)],
+        "bailleurs": [(user_bailleur.first_name, user_bailleur.last_name)],
+    }

--- a/conventions/tests/models/test_contributors.py
+++ b/conventions/tests/models/test_contributors.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.test import RequestFactory
 
@@ -54,7 +56,8 @@ def test_get_contributors():
     request = RequestFactory().post("/", {"convention_numero": "1234"})
     request.session = "session"
     request.user = user_instructeur
-    validate_convention(request, convention.uuid)
+    with patch("conventions.tasks.task_generate_and_send.delay", Mock()):
+        validate_convention(request, convention.uuid)
 
     # The instructor should appear in contributors
     assert convention.get_contributors() == {

--- a/programmes/tests/factories.py
+++ b/programmes/tests/factories.py
@@ -25,6 +25,9 @@ class ProgrammeFactory(BaseFactory, UploadFactoryMixin):
     numero_operation = factory.LazyFunction(lambda: str(uuid.uuid4().int)[:13])
 
     bailleur = factory.SubFactory("bailleurs.tests.factories.BailleurFactory")
+    administration = factory.SubFactory(
+        "instructeurs.tests.factories.AdministrationFactory"
+    )
 
     ville = "Paris"
     code_postal = "75007"

--- a/programmes/tests/test_utils.py
+++ b/programmes/tests/test_utils.py
@@ -10,5 +10,10 @@ class TestDiffProgrammeDuplication(TestCase):
         duplicate = ProgrammeFactory(numero_operation=programme.numero_operation)
         self.assertEqual(
             diff_programme_duplication(programme.numero_operation),
-            {"bailleur_id": sorted([programme.bailleur_id, duplicate.bailleur_id])},
+            {
+                "administration_id": sorted(
+                    [programme.administration_id, duplicate.administration_id]
+                ),
+                "bailleur_id": sorted([programme.bailleur_id, duplicate.bailleur_id]),
+            },
         )

--- a/templates/conventions/contributors.html
+++ b/templates/conventions/contributors.html
@@ -1,4 +1,4 @@
-<p>
+<p class="fr-mb-4w">
     <span class="fr-icon-user-line" aria-hidden="true"></span> Contributeurs à la convention :
 
     {% if not contributors.instructeurs and not contributors.bailleurs %}

--- a/templates/conventions/contributors.html
+++ b/templates/conventions/contributors.html
@@ -1,0 +1,22 @@
+<p>
+    <span class="fr-icon-user-line" aria-hidden="true"></span> Contributeurs à la convention :
+
+    {% if not contributors.instructeurs and not contributors.bailleurs %}
+        aucun contributeur pour l'instant
+    {% endif %}
+    {% if contributors.instructeurs %}
+        pour l'instruction
+        {% for instructeur in contributors.instructeurs %}
+            <strong>{{instructeur.0}} {{instructeur.1}}</strong>
+            {% if not forloop.last %} et {% endif %}
+        {% endfor %}
+        {% if contributors.bailleurs %}, {% endif %}
+    {% endif %}
+    {% if contributors.bailleurs %}
+        pour le bailleur
+        {% for bailleur in contributors.bailleurs %}
+            <strong>{{bailleur.0}} {{bailleur.1}}</strong>
+            {% if not forloop.last %} et {% endif %}
+        {% endfor %}
+    {% endif %}
+</p>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -10,6 +10,7 @@
         {% include "conventions/common/form_header.html"%}
         {% include "common/nav_bar.html" with nav_bar_step="action" %}
         <div class="fr-container fr-py-5w">
+            {% include "conventions/contributors.html" with contributors=convention.get_contributors %}
             {% if not convention.is_avenant %}
                 <div class="fr-col-12 fr-mt-2w fr-mb-4w">
                     <p class="fr-alert__title">

--- a/templates/conventions/saved.html
+++ b/templates/conventions/saved.html
@@ -1,5 +1,7 @@
 {% extends "layout/base.html" %}
 
+{% load display_filters %}
+
 {% block page_title %}Sauvegarde - APiLos{% endblock%}
 
 {% block content %}


### PR DESCRIPTION
Airtable : https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recQm31ibPIwFJCiA?blocks=hide

J'ai utilisé les infos dans ConventionHistory. On enregistre les changements de status, pas juste un enregistrement de formulaire, donc il faut qu'un bailleur soumette à l'instructeur pour apparaître. A voir si on veut faire évoluer pour afficher plus.

Je n'ai pas affiché l'entité bailleur / l'administration : je ne sais pas si c'est une info récupérable sur les habilitations.


<img width="894" alt="Capture d’écran 2024-07-03 à 10 17 42" src="https://github.com/MTES-MCT/apilos/assets/26469767/899e7d8a-1b1f-4c1a-91fc-c34f974d8837">

