### PR TITLE
Move format contributors logic to model

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -787,3 +787,26 @@ class Convention(models.Model):
                 # Idée : rajouter le nom de l'administration (récupérable dans les habilitations ?)
                 result["instructeurs"].append((user.first_name, user.last_name))
         return result
+
+    def format_contributors(self):
+        contributors = self.get_contributors()
+        result = ""
+        if not contributors["instructeurs"] and not contributors["bailleurs"]:
+            return "aucun contributeur connu pour l'instant"
+
+        if len(contributors["instructeurs"]) > 0:
+            result += "pour l'instruction "
+            for i, instructeur in enumerate(contributors["instructeurs"]):
+                result += f"{instructeur[0]} {instructeur[1]}"
+                if i != len(contributors["instructeurs"]) - 1:
+                    result += ", "
+
+        if len(contributors["bailleurs"]) > 0:
+            if len(contributors["instructeurs"]) > 0:
+                result += " et "
+            result += "pour le bailleur "
+            for i, bailleur in enumerate(contributors["bailleurs"]):
+                result += f"{bailleur[0]} {bailleur[1]}"
+                if i != len(contributors["bailleurs"]) - 1:
+                    result += ", "
+        return result

--- a/conventions/tests/models/test_contributors.py
+++ b/conventions/tests/models/test_contributors.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 
 from bailleurs.tests.factories import BailleurFactory
 from conventions.models.choices import ConventionStatut
+from conventions.models.convention import Convention
 from conventions.tests.factories import ConventionFactory
 from conventions.views import save_convention
 from conventions.views.conventions import validate_convention
@@ -64,3 +65,25 @@ def test_get_contributors():
         "instructeurs": [(user_instructeur.first_name, user_instructeur.last_name)],
         "bailleurs": [(user_bailleur.first_name, user_bailleur.last_name)],
     }
+
+
+@pytest.mark.django_db
+@patch.object(Convention, "get_contributors")
+def test_format_contributors_empty(mock_get_contributors):
+    mock_get_contributors.return_value = {"instructeurs": [], "bailleurs": []}
+    convention = ConventionFactory()
+    assert convention.format_contributors() == "aucun contributeur connu pour l'instant"
+
+
+@pytest.mark.django_db
+@patch.object(Convention, "get_contributors")
+def test_format_contributors(mock_get_contributors):
+    mock_get_contributors.return_value = {
+        "instructeurs": [("John", "Doe"), ("Alice", "Tokyo"), ("Jean", "Madrid")],
+        "bailleurs": [("Sarah", "Berlin")],
+    }
+    convention = ConventionFactory()
+    assert (
+        convention.format_contributors()
+        == "pour l'instruction John Doe, Alice Tokyo, Jean Madrid et pour le bailleur Sarah Berlin"
+    )

--- a/templates/conventions/contributors.html
+++ b/templates/conventions/contributors.html
@@ -1,22 +1,5 @@
 <p class="fr-mb-4w">
     <span class="fr-icon-user-line" aria-hidden="true"></span> Contributeurs à la convention :
 
-    {% if not contributors.instructeurs and not contributors.bailleurs %}
-        aucun contributeur pour l'instant
-    {% endif %}
-    {% if contributors.instructeurs %}
-        pour l'instruction
-        {% for instructeur in contributors.instructeurs %}
-            <strong>{{instructeur.0}} {{instructeur.1}}</strong>
-            {% if not forloop.last %} et {% endif %}
-        {% endfor %}
-        {% if contributors.bailleurs %}, {% endif %}
-    {% endif %}
-    {% if contributors.bailleurs %}
-        pour le bailleur
-        {% for bailleur in contributors.bailleurs %}
-            <strong>{{bailleur.0}} {{bailleur.1}}</strong>
-            {% if not forloop.last %} et {% endif %}
-        {% endfor %}
-    {% endif %}
+    {{convention.format_contributors}}
 </p>


### PR DESCRIPTION
Je déplace la logique du formatage des contributeurs du template vers le modèle pour pouvoir la tester. Légères corrections sur le formatage.