### PR TITLE
add a validate_convention permission and apply it

### DIFF
--- a/conventions/views/convention_finalisation.py
+++ b/conventions/views/convention_finalisation.py
@@ -57,11 +57,11 @@ class FinalisationBase(BaseConventionView, TemplateView):
             context["form"] = service.form
         return context
 
-    @currentrole_campaign_permission_required("convention.change_convention")
+    @currentrole_campaign_permission_required("convention.validate_convention")
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-    @currentrole_campaign_permission_required("convention.change_convention")
+    @currentrole_campaign_permission_required("convention.validate_convention")
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
@@ -71,7 +71,7 @@ class FinalisationNumero(FinalisationBase):
     step_number = 1
     service_class = FinalisationNumeroService
 
-    @currentrole_campaign_permission_required("convention.change_convention")
+    @currentrole_campaign_permission_required("convention.validate_convention")
     def post(self, request, **kwargs):
         convention_uuid = str(kwargs.get("convention_uuid"))
         service = self.service_class(convention_uuid=convention_uuid, request=request)

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -298,7 +298,9 @@ def feedback_convention(request, convention_uuid):
 
 @require_POST
 @login_required
-@currentrole_campaign_permission_required_view_function("convention.change_convention")
+@currentrole_campaign_permission_required_view_function(
+    "convention.validate_convention"
+)
 def validate_convention(request, convention_uuid):
     convention = (
         Convention.objects.prefetch_related("programme__bailleur")

--- a/templates/conventions/actions/back_to_instruction.html
+++ b/templates/conventions/actions/back_to_instruction.html
@@ -21,7 +21,10 @@
             </div>
             <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
                 {% csrf_token %}
-                <button name="BackToInstruction" value=True class="fr-btn  apilos-btn--secondary--red fr-my-1w" {% include "common/form/disable_form_input.html" %}>
+                <button name="BackToInstruction"
+                        value=True
+                        class="fr-btn  apilos-btn--secondary--red fr-my-1w"
+                >
                     Retour à l'instruction
                 </button>
             </form>

--- a/users/fixtures/auth.json
+++ b/users/fixtures/auth.json
@@ -290,6 +290,14 @@
   {
     "model": "auth.permission",
     "fields": {
+      "name": "Can validate convention",
+      "content_type": ["conventions", "convention"],
+      "codename": "validate_convention"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "fields": {
       "name": "Can delete convention",
       "content_type": ["conventions", "convention"],
       "codename": "delete_convention"
@@ -846,6 +854,7 @@
         ["add_convention", "conventions", "convention"],
         ["change_convention", "conventions", "convention"],
         ["view_convention", "conventions", "convention"],
+        ["validate_convention", "conventions", "convention"],
         ["delete_convention", "conventions", "convention"],
         ["change_administration", "instructeurs", "administration"],
         ["view_administration", "instructeurs", "administration"]
@@ -865,6 +874,7 @@
         ["add_convention", "conventions", "convention"],
         ["change_convention", "conventions", "convention"],
         ["view_convention", "conventions", "convention"],
+        ["validate_convention", "conventions", "convention"],
         ["delete_convention", "conventions", "convention"],
         ["change_administration", "instructeurs", "administration"],
         ["view_administration", "instructeurs", "administration"]


### PR DESCRIPTION
- Ajout de la permission validate_convention
- Association de cette permission aux profiles instructeur et administrateur qui ont des droits en écriture
- Application de cette permission aux action d'affichage et de validation des étapes de finalisation d'une convention