### PR TITLE
Suppression d'un duplicat de reequête SQL sur l'écran de recherche

### DIFF
--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -169,7 +169,9 @@ class ConventionSearchView(LoginRequiredMixin, View):
             "conventions": paginator.get_page(request.GET.get("page", 1)),
             "filtered_conventions_count": paginator.count,
             "url_name": resolve(request.path_info).url_name,
-            "total_conventions": request.user.conventions().count(),
+            "user_has_conventions": bool(
+                paginator.count or request.user.conventions().count()
+            ),
             "bailleur_query": self.bailleurs_queryset,
             "debug_search_scoring": settings.DEBUG_SEARCH_SCORING,
             "siap_assistance_url": settings.SIAP_ASSISTANCE_URL,

--- a/templates/conventions/index.html
+++ b/templates/conventions/index.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block content %}
-    {% if total_conventions > 0 %}
+    {% if user_has_conventions %}
         <div class="fr-container-fluid ds_banner">
             <div class="fr-container">{% include "./_partial/search_header.html" %}</div>
         </div>


### PR DESCRIPTION
Pour résoudre l'erreur Sentry : https://sentry.incubateur.net/organizations/betagouv/issues/116233/?environment=production&project=29&query=is%3Aunresolved&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=0