### PR TITLE
Prefetch content_type pour éviter les erreurs de type Query N+1

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -341,7 +341,7 @@ class User(AbstractUser):
                 lambda permission: permission.content_type.name
                 + "."
                 + permission.codename,
-                role.group.permissions.all(),
+                role.group.permissions.prefetch_related("content_type").all(),
             )
         return perm in permissions
 


### PR DESCRIPTION
Pour résoudre l'erreur : https://sentry.incubateur.net/organizations/betagouv/issues/109010/?environment=production&project=29&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=3