### PR TITLE
Utiliser autocomplete_fields pour les foreignKey plutôt que readonly

### DIFF
--- a/conventions/admin.py
+++ b/conventions/admin.py
@@ -134,15 +134,14 @@ class ConventionAdmin(ApilosModelAdmin):
     )
     readonly_fields = (
         "uuid",
-        "programme",
         "bailleur",
-        "lot",
         "administration",
         "parent",
         "numero_pour_recherche",
         "cree_par",
         "cree_le",
     )
+    autocomplete_fields = ("programme", "lot")
     list_filter = (
         IsAvenantFilter,
         ("statut", StatutFilter),

--- a/programmes/admin.py
+++ b/programmes/admin.py
@@ -65,15 +65,16 @@ class ProgrammeAdmin(ApilosModelAdmin):
         "zone_123",
         "zone_abc",
         "nature_logement",
+        "date_achevement",
+        "surface_utile_totale",
         "search_vector",
     )
     readonly_fields = (
         "uuid",
-        "administration",
-        "bailleur",
         "search_vector",
         "numero_operation_pour_recherche",
     )
+    autocomplete_fields = ("administration", "bailleur")
     list_filter = (
         IsCloneFilter,
         "nature_logement",
@@ -106,6 +107,16 @@ def view_programme(lot):
 class LotAdmin(ApilosModelAdmin):
     list_display = (view_programme, "financement", "uuid")
 
+    list_select_related = ("programme",)
+
+    search_fields = [
+        "programme__ville",
+        "programme__nom",
+        "programme__numero_operation",
+        "financement",
+        "uuid",
+    ]
+
     fields = (
         "uuid",
         "financement",
@@ -114,12 +125,9 @@ class LotAdmin(ApilosModelAdmin):
         "programme",
     )
 
-    readonly_fields = (
-        "uuid",
-        "programme",
-    )
+    readonly_fields = ("uuid",)
 
-    list_select_related = ("programme",)
+    autocomplete_fields = ("programme",)
 
 
 @admin.register(Annexe)


### PR DESCRIPTION
Permet de modifier les appartenances directement en admin, cela simplifie la résolution de conflit entre lot / programme et convention et évite de modifier cela directement en base de données

Avant : 

![CleanShot 2024-08-26 at 09 00 42@2x](https://github.com/user-attachments/assets/1befa6b4-5656-43af-ae32-21b5003b283d)

Après

![CleanShot 2024-08-26 at 09 02 19@2x](https://github.com/user-attachments/assets/6a748ae1-7506-4a85-86fe-75ddf6e20c6d)

++

Ajout des champs `date_achevement` et `surface_utile_totale` editable en adminitration pour les mêmes raisons : résolution de conflit