### PR TITLE
Permettre de modifier le type_operation dans l'admin

### DIFF
--- a/programmes/admin.py
+++ b/programmes/admin.py
@@ -67,6 +67,7 @@ class ProgrammeAdmin(ApilosModelAdmin):
         "nature_logement",
         "date_achevement",
         "surface_utile_totale",
+        "type_operation",
         "search_vector",
     )
     readonly_fields = (


### PR DESCRIPTION
J'ai u le cas pour 2 opération, j'aimerai modifier les type opération pour ajouter que c'est du neuf aux opérations 2017DD0740057 et 2016DD0740222