### PR TITLE
Readonly: disable for superusers

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -60,7 +60,7 @@ def is_instructeur(request: HttpRequest) -> bool:
 @register.filter
 def is_readonly(request: HttpRequest) -> bool:
     # Manage is_staff exception
-    if "readonly" in request.session:
+    if "readonly" in request.session and not request.user.is_superuser:
         return request.session["readonly"]
     return False
 


### PR DESCRIPTION
Pour pouvoir debug en production (par exemple là un problème de téléchargement de projet de convention), ça me semble indispensable d'avoir un bypass