### PR TITLE
Permettre aux bailleurs de téléverser les conventions/avenants/denonciations signées

### DIFF
--- a/templates/conventions/actions/upload_signed_document.html
+++ b/templates/conventions/actions/upload_signed_document.html
@@ -1,41 +1,30 @@
 {% load display_filters %}
 
 <div class="fr-col-12 fr-my-2w">
-    {% if request|is_instructeur %}
-        <div role="alert" class="fr-alert fr-alert--A_signer fr-icon-draft-line">
-            <p class="fr-alert__title">
-                {% if convention.is_denonciation %}
-                    Déposer l'acte de dénonciation publié
-                {% else %}
-                    Déposer {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}}
-                {% endif %}
-            </p>
-            <p class="fr-mb-2w">
-                {% if convention.is_denonciation %}
-                    Ici, vous pouvez déposer l'acte de dénonciation de votre convention publié.
-                {% else %}
-                    votre {{convention|display_kind}} porte le numéro <strong>{{ convention.numero|default_if_none:'-' }}</strong><br/>
-                    Dernière étape : déposez la version signée pour la validation finale.
-                {% endif %}
-            </p>
+    <div role="alert" class="fr-alert fr-alert--A_signer fr-icon-draft-line">
+        <p class="fr-alert__title">
+            {% if convention.is_denonciation %}
+                Déposer l'acte de dénonciation publié
+            {% else %}
+                Déposer {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}}
+            {% endif %}
+        </p>
+        <p class="fr-mb-2w">
+            {% if convention.is_denonciation %}
+                Ici, vous pouvez déposer l'acte de dénonciation de votre convention publié.
+            {% else %}
+                votre {{convention|display_kind}} porte le numéro <strong>{{ convention.numero|default_if_none:'-' }}</strong><br/>
+                Dernière étape : déposez la version signée pour la validation finale.
+            {% endif %}
+        </p>
 
-            <div class="block--row-strech">
-                {% include "conventions/common/form_upload_signed_document.html" %}
+        <div class="block--row-strech">
+            {% include "conventions/common/form_upload_signed_document.html" %}
 
-                <a class="fr-my-1w fr-link fr-ml-2w" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
-                    Consulter le récapitulatif
-                </a>
-            </div>
-
-        </div>
-    {% else %}
-        <div role="alert" class="fr-alert fr-alert--success">
-            <p >Ici, {{convention|display_kind_with_pronom}} pourra être déposé{{convention|display_gender_terminaison}} par l'administration en charge dès qu'{{convention|display_personnal_pronom}} sera signé{{convention|display_gender_terminaison}}.
-            </p>
-            <a class="fr-my-1w fr-link" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
+            <a class="fr-my-1w fr-link fr-ml-2w" href="{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}">
                 Consulter le récapitulatif
             </a>
         </div>
-    {% endif %}
+    </div>
 </div>
 <hr>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -102,90 +102,88 @@
                     </form>
                 </div>
             </div>
-            {% if request|is_instructeur %}
+            <hr>
+            <div class="fr-col-12">
+                <div class="fr-mb-2w block--row-strech">
+                    <div class="block--row-strech-1 fr-my-2w">
+                        <p class="fr-alert__title">
+                            {% if convention.is_denonciation %}
+                                Déposer l'acte de dénonciation
+                            {% else %}
+                                Déposer à nouveau {{convention|display_kind_with_pronom}}
+                            {% endif %}
+                        </p>
+                        <p class="fr-mb-0">
+                            {% if convention.is_denonciation %}
+                                Vous pouvez déposer l'acte de dénonciation ici. Il sera accessible sur la page de visualisation de la dénonciation.
+                            {% else %}
+                                Si nécessaire, vous pouvez déposer une nouvelle version de {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}} ici.
+                            {% endif %}
+
+                        </p>
+                    </div>
+                    <form method="post" action="{% url 'conventions:sent' convention_uuid=convention.uuid %}" enctype="multipart/form-data" id="{{upform.file.id_for_label}}_form">
+                        {% csrf_token %}
+                        <input
+                            class="fileinput--hidden"
+                            type="file"
+                            id="{{upform.file.id_for_label}}"
+                            name="{{upform.file.html_name}}"
+                            accept="application/pdf">
+                        <div class="block--row-strech">
+                            <div>
+                                <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button"{% if request|is_readonly %} disabled{% endif %}>
+                                    {% if convention.is_denonciation %}
+                                        Déposer la dénonciation
+                                    {% else %}
+                                        Déposer {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}}
+                                    {% endif %}
+                                </button>
+                                {% for error in upform.file.errors %}
+                                    <p id="text-input-error-desc-error" class="fr-error-text">
+                                        {{ error }}
+                                    </p>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        <script type="text/javascript" nonce="{{request.csp_nonce}}">
+                            document.getElementById('{{upform.file.id_for_label}}_upload_button').onclick = function() {
+                                document.getElementById('{{upform.file.id_for_label}}').click();
+                            };
+                            document.getElementById('{{upform.file.id_for_label}}').onchange = function() {
+                                var input = document.createElement('input');
+                                input.setAttribute('type', 'hidden');//hidden input
+                                input.setAttribute('name', 'Upload');//set the param name
+                                input.setAttribute('value', 'True');//set the value
+                                this.form.appendChild(input)
+                                document.getElementById("{{upform.file.id_for_label}}_form").submit();
+                            }
+                        </script>
+                    </form>
+                </div>
+            </div>
+            {% if convention|display_is_not_resiliated_or_denonciated %}
                 <hr>
                 <div class="fr-col-12">
-                    <div class="fr-mb-2w block--row-strech">
-                        <div class="block--row-strech-1 fr-my-2w">
-                            <p class="fr-alert__title">
-                                {% if convention.is_denonciation %}
-                                    Déposer l'acte de dénonciation
-                                {% else %}
-                                    Déposer à nouveau {{convention|display_kind_with_pronom}}
-                                {% endif %}
-                            </p>
-                            <p class="fr-mb-0">
-                                {% if convention.is_denonciation %}
-                                    Vous pouvez déposer l'acte de dénonciation ici. Il sera accessible sur la page de visualisation de la dénonciation.
-                                {% else %}
-                                    Si nécessaire, vous pouvez déposer une nouvelle version de {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}} ici.
-                                {% endif %}
-
-                            </p>
-                        </div>
-                        <form method="post" action="{% url 'conventions:sent' convention_uuid=convention.uuid %}" enctype="multipart/form-data" id="{{upform.file.id_for_label}}_form">
-                            {% csrf_token %}
-                            <input
-                                class="fileinput--hidden"
-                                type="file"
-                                id="{{upform.file.id_for_label}}"
-                                name="{{upform.file.html_name}}"
-                                accept="application/pdf">
-                            <div class="block--row-strech">
-                                <div>
-                                    <button id="{{upform.file.id_for_label}}_upload_button" class="fr-icon-upload-line fr-btn--icon-left fr-btn fr-btn--secondary fr-my-1w" type="button"{% if request|is_readonly %} disabled{% endif %}>
-                                        {% if convention.is_denonciation %}
-                                            Déposer la dénonciation
-                                        {% else %}
-                                            Déposer {{convention|display_kind_with_pronom}} signé{{convention|display_gender_terminaison}}
-                                        {% endif %}
-                                    </button>
-                                    {% for error in upform.file.errors %}
-                                        <p id="text-input-error-desc-error" class="fr-error-text">
-                                            {{ error }}
-                                        </p>
-                                    {% endfor %}
-                                </div>
-                            </div>
-
-                            <script type="text/javascript" nonce="{{request.csp_nonce}}">
-                                document.getElementById('{{upform.file.id_for_label}}_upload_button').onclick = function() {
-                                    document.getElementById('{{upform.file.id_for_label}}').click();
-                                };
-                                document.getElementById('{{upform.file.id_for_label}}').onchange = function() {
-                                    var input = document.createElement('input');
-                                    input.setAttribute('type', 'hidden');//hidden input
-                                    input.setAttribute('name', 'Upload');//set the param name
-                                    input.setAttribute('value', 'True');//set the value
-                                    this.form.appendChild(input)
-                                    document.getElementById("{{upform.file.id_for_label}}_form").submit();
-                                }
-                            </script>
-                        </form>
+                    <div class="fr-mb-5w fr-pt-2w">
+                        <p class="fr-alert__title">
+                            Date de signature
+                        </p>
+                        {% include "conventions/actions/update_date_signature.html" %}
                     </div>
                 </div>
-                {% if convention|display_is_not_resiliated_or_denonciated %}
-                    <hr>
-                    <div class="fr-col-12">
-                        <div class="fr-mb-5w fr-pt-2w">
-                            <p class="fr-alert__title">
-                                Date de signature
-                            </p>
-                            {% include "conventions/actions/update_date_signature.html" %}
-                        </div>
+            {% endif %}
+            {% if convention|display_is_resiliated %}
+                <hr>
+                <div class="fr-col-12">
+                    <div class="fr-mb-5w fr-pt-2w">
+                        <p class="fr-alert__title">
+                            Date de résiliation
+                        </p>
+                        {% include "conventions/actions/update_date_resiliation.html" %}
                     </div>
-                {% endif %}
-                {% if convention|display_is_resiliated %}
-                    <hr>
-                    <div class="fr-col-12">
-                        <div class="fr-mb-5w fr-pt-2w">
-                            <p class="fr-alert__title">
-                                Date de résiliation
-                            </p>
-                            {% include "conventions/actions/update_date_resiliation.html" %}
-                        </div>
-                    </div>
-                {% endif %}
+                </div>
             {% endif %}
             {% if convention|display_back_to_instruction:request %}
                 <hr>


### PR DESCRIPTION
Carte airtable : [S1179: Donner la main au bailleur pour déposer convention signée](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recb31h69tA3IRTSw?blocks=hide)

- Supprimer les restriction d'interface qui interdisent aux bailleurs de télécharger ou retélécharger le doc de convention signé
- De même, permettre aux bailleurs de modifier la date de signature