### PR TITLE
Fix email settings always disable

### DIFF
--- a/templates/settings/user_profile.html
+++ b/templates/settings/user_profile.html
@@ -26,7 +26,7 @@
                             <form method="post" action="">
                                 {% csrf_token %}
 
-                                {% include "settings/form/email_preferences.html" with user=request.user form_input=form.preferences_email %}
+                                {% include "settings/form/email_preferences.html" with user=request.user form_input=form.preferences_email editable=True %}
 
                                 <button class="fr-btn fr-icon-save-line fr-btn--icon-left fr-mt-3w" type="submit">
                                     Enregistrer


### PR DESCRIPTION
https://mattermost.incubateur.net/fabnum-mte/pl/5r61t4bcht863midjks4uycqiw

Retour support : les préférences email sont en lecture seule depuis l'ajout du readonly