### PR TITLE
Pin django storages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-defender
 django-hijack
 django-simple-history
 django-sql-explorer[xls]
-django-storages
+django-storages==1.14.3
 django-waffle
 Django==4.2.15
 djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,9 +127,9 @@ django-sql-explorer[xls]==4.3 \
     --hash=sha256:9c0735b08270ac60276ea2697a499cb9457acf00f0d0016a230c092ab3b4d310 \
     --hash=sha256:c853bc0a270b290646d4ca731769f1e223a151e5724aee69e3b3967f0cf7b96f
     # via -r requirements.in
-django-storages==1.14.4 \
-    --hash=sha256:69aca94d26e6714d14ad63f33d13619e697508ee33ede184e462ed766dc2a73f \
-    --hash=sha256:d61930acb4a25e3aebebc6addaf946a3b1df31c803a6bf1af2f31c9047febaa3
+django-storages==1.14.3 \
+    --hash=sha256:31f263389e95ce3a1b902fb5f739a7ed32895f7d8b80179fe7453ecc0dfe102e \
+    --hash=sha256:95a12836cd998d4c7a4512347322331c662d9114c4344f932f5e9c0fce000608
     # via -r requirements.in
 django-waffle==4.1.0 \
     --hash=sha256:5979a2f3dd674ef7086480525b39651fc2045427f6d8e6a614192656d3402c5b \


### PR DESCRIPTION
D'après le github de django-storages les soucis avec S3 ne sont pas corrigés, je préfère pin la version utilisée.