### PR TITLE
Eviter les erreurs de type User matching query does not exist

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -772,10 +772,12 @@ class Convention(models.Model):
         # get_user_model is used to avoid circular imports
         user_model = get_user_model()
         for user_id in user_ids:
+            if not user_id:
+                continue
             try:
                 user = user_model.objects.get(id=user_id)
             except user_model.DoesNotExist as e:
-                logger.error(e)
+                logger.warning(e)
                 continue
 
             if user.is_staff or user.is_superuser:

--- a/templates/conventions/contributors.html
+++ b/templates/conventions/contributors.html
@@ -1,8 +1,8 @@
 <div class="fr-pl-2w">
-    <a class="fr-link fr-text--sm" aria-describedby="tooltip-2989" id="link-2990" href="#">
+    <a class="fr-link fr-text--sm" aria-describedby="tooltip-contributors" id="link-contibutors" href="#">
         {{contributors.number}} contributeur{% if contributors.number > 1 %}s{% endif %}
     </a>
-    <span class="fr-tooltip fr-placement" id="tooltip-2989" role="tooltip" aria-hidden="true">
+    <span class="fr-tooltip fr-placement" id="tooltip-contributors" role="tooltip" aria-hidden="true">
         {% if contributors.number == 0 %}
             APiLos n'a pas connaissance de contributeurs à cette convention
         {% endif %}


### PR DESCRIPTION
Résoudre l'erreur Sentry : [User matching query does not exist.](https://sentry.incubateur.net/organizations/betagouv/issues/110504/events/fc6526c978c94f988a580bcc1bb22668/?project=29)

Pas d'urgence, c'est transparent pour l'utilisateur