### PR TITLE
Résolution d'une erreur d etype lors de la création dans l'admin d'un programme

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -478,7 +478,9 @@ class Convention(models.Model):
     @cached_property
     def is_outre_mer(self) -> bool:
         # Saint-Pierre-et-Miquelon (975) n'est pas dans cette liste
-        return int(self.programme.code_insee_departement) in [971, 972, 973, 974, 976]
+        return self.programme.code_insee_departement and int(
+            self.programme.code_insee_departement
+        ) in [971, 972, 973, 974, 976]
 
     @cached_property
     def is_denonciation(self):


### PR DESCRIPTION
Relatif à l'erreur sentry : https://sentry.incubateur.net/organizations/betagouv/issues/119997/?project=29&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=2