### PR TITLE
Fix tableaux après l'upgrade DSFR

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -728,9 +728,12 @@ a[href].apilos-block-faqlink:after {
 .fr-link--sm:before {
   margin: 0.1rem !important;
 }
-.fr-table--hover-animation tbody tr:hover {
+.table--hover-animation tbody tr:hover {
   transform: scale(1.02);
   background-size: 98% 1px;
+}
+.table--hover-animation tbody tr:hover td{
+  background-color: #f6f6f6;
 }
 
 .apilos-link {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -163,7 +163,7 @@ details > summary::-webkit-details-marker {
   color: #e10600;
 }
 
-.table--limited-height {
+.fr-table.table--limited-height .fr-table__content{
   max-height: 400px;
   overflow-y: auto;
 }
@@ -662,17 +662,15 @@ a[href].apilos-block-faqlink:after {
 .apilos-order-menu .apilos-order-menu--open a {
   background-image: none;
 }
-table.fullwidth {
-  width: 100%;
+
+.fr-table--sm.table--header-lg .fr-table__content th {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
 }
 
-.table--layout-fixed {
-  width: 100%;
-}
-
-.table--layout-fixed table {
-  display: table;
-  /* table-layout: fixed; */
+.fr-table .fr-table__wrapper .fr-table__content table th,
+.fr-table .fr-table__wrapper .fr-table__content table td {
+  white-space: normal;
 }
 
 .clickable {
@@ -730,8 +728,7 @@ table.fullwidth {
 .fr-link--sm:before {
   margin: 0.1rem !important;
 }
-.fr-table--bordered tbody tr:hover {
-  background-color: white;
+.fr-table--hover-animation tbody tr:hover {
   transform: scale(1.02);
   background-size: 98% 1px;
 }

--- a/templates/comments/opened_comments.html
+++ b/templates/comments/opened_comments.html
@@ -14,7 +14,7 @@
                 </a>
             </div>
 
-            <div class="fr-table  fr-table--bordered table--layout-fixed table--limited-height fr-table--no-caption">
+            <div class="fr-table table--limited-height fr-table--no-caption">
                 <div class="fr-table__wrapper">
                     <div class="fr-table__container">
                         <div class="fr-table__content">

--- a/templates/conventions/cadastre.html
+++ b/templates/conventions/cadastre.html
@@ -170,7 +170,7 @@
                         {% endfor %}
 
                         {{ formset.management_form }}
-                        <div class="fr-table fr-table--bordered table--layout-fixed">
+                        <div class="fr-table">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/common/form_annexes.html
+++ b/templates/conventions/common/form_annexes.html
@@ -31,7 +31,7 @@
         {% endfor %}
 
         {{ formset.management_form }}
-        <div class="fr-table fr-table--bordered table--layout-fixed">
+        <div class="fr-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
                     <div class="fr-table__content">

--- a/templates/conventions/common/form_collectif.html
+++ b/templates/conventions/common/form_collectif.html
@@ -28,7 +28,7 @@
         {% endfor %}
 
         {{ formset.management_form }}
-        <div class="fr-table fr-table--bordered table--layout-fixed">
+        <div class="fr-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
                     <div class="fr-table__content">

--- a/templates/conventions/common/form_foyer_residence_logements.html
+++ b/templates/conventions/common/form_foyer_residence_logements.html
@@ -26,7 +26,7 @@
         {% endfor %}
 
         {{ formset.management_form }}
-        <div class="fr-table fr-table--bordered table--layout-fixed">
+        <div class="fr-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
                     <div class="fr-table__content">

--- a/templates/conventions/common/form_logements.html
+++ b/templates/conventions/common/form_logements.html
@@ -31,7 +31,7 @@
         {% endif %}
 
         {{ formset.management_form }}
-        <div class="fr-table fr-table--bordered table--layout-fixed">
+        <div class="fr-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
                     <div class="fr-table__content">

--- a/templates/conventions/common/form_stationnements.html
+++ b/templates/conventions/common/form_stationnements.html
@@ -25,7 +25,7 @@
         {% endfor %}
 
         {{ formset.management_form }}
-        <div class="fr-table fr-table--bordered table--layout-fixed">
+        <div class="fr-table">
             <div class="fr-table__wrapper">
                 <div class="fr-table__container">
                     <div class="fr-table__content">

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -7,7 +7,7 @@
         <div class="fr-grid-row fr-grid-row--gutters fr-card fr-card--no-border">
             <div class="fr-col-md-12">
                 {% if filtered_conventions_count > 0 %}
-                    <div class="fr-table table--header-lg fr-table--sm">
+                    <div class="fr-table table--header-lg fr-table--sm table--hover-animation">
                         {% if filtered_conventions_count != all_conventions_count %}
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-2w">
                                 <div class="fr-grid-row fr-col-12">

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -7,23 +7,23 @@
         <div class="fr-grid-row fr-grid-row--gutters fr-card fr-card--no-border">
             <div class="fr-col-md-12">
                 {% if filtered_conventions_count > 0 %}
-                    <div class="fr-table fr-table--bordered table--layout-fixed">
+                    <div class="fr-table table--header-lg fr-table--sm">
+                        {% if filtered_conventions_count != all_conventions_count %}
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-2w">
+                                <div class="fr-grid-row fr-col-12">
+
+                                    <div class="fr-mr-2w notes">{{ filtered_conventions_count }} résultats</div>
+                                    <a href="/" class="fr-link">
+                                        <span class="fr-icon-close-circle-line fr-mr-1w"></span>
+                                        Réinitialiser la recherche
+                                    </a>
+                                </div>
+                            </div>
+                        {% endif %}
                         <div class="fr-table__wrapper">
                             <div class="fr-table__container">
                                 <div class="fr-table__content">
                                     <table aria-label="Conventions">
-                                        {% if filtered_conventions_count != all_conventions_count %}
-                                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-2w">
-                                                <div class="fr-grid-row fr-col-12">
-
-                                                    <div class="fr-mr-2w notes">{{ filtered_conventions_count }} résultats</div>
-                                                    <a href="/" class="fr-link">
-                                                        <span class="fr-icon-close-circle-line fr-mr-1w"></span>
-                                                        Réinitialiser la recherche
-                                                    </a>
-                                                </div>
-                                            </div>
-                                        {% endif %}
                                         <thead>
                                             <tr class="th_inline">
                                                 {% if debug_search_scoring %}

--- a/templates/conventions/edd.html
+++ b/templates/conventions/edd.html
@@ -69,7 +69,7 @@
                         {% endfor %}
 
                         {{ formset.management_form }}
-                        <div class="fr-table fr-table--bordered table--layout-fixed">
+                        <div class="fr-table">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/financement.html
+++ b/templates/conventions/financement.html
@@ -45,7 +45,7 @@
                         {% endfor %}
 
                         {{ formset.management_form }}
-                        <div class="fr-table fr-table--bordered table--layout-fixed">
+                        <div class="fr-table">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/from_operation/add_avenants.html
+++ b/templates/conventions/from_operation/add_avenants.html
@@ -20,7 +20,7 @@
         {% include "../common/stepper.html"%}
 
         {% if avenants %}
-            <div class="fr-table fr-table--bordered fr-table--layout-fixed apilos-text--black fr-mt-2w">
+            <div class="fr-table apilos-text--black fr-mt-2w">
                 <div class="fr-table__wrapper">
                     <div class="fr-table__container">
                         <div class="fr-table__content">

--- a/templates/conventions/from_operation/add_convention.html
+++ b/templates/conventions/from_operation/add_convention.html
@@ -43,7 +43,7 @@
                     </div>
                 </div>
                 {% if conventions.count > 0 %}
-                    <div class="fr-table fr-table--bordered fr-table--layout-fixed apilos-text--black">
+                    <div class="fr-table apilos-text--black">
                         <div class="fr-table__wrapper">
                             <div class="fr-table__container">
                                 <div class="fr-table__content">

--- a/templates/conventions/from_operation/select_operation_list.html
+++ b/templates/conventions/from_operation/select_operation_list.html
@@ -1,7 +1,7 @@
 
 {% if operations %}
 
-    <div class="fr-table fr-table--bordered table--layout-fixed">
+    <div class="fr-table">
         <div class="fr-table__wrapper">
             <div class="fr-table__container">
                 <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/annexes.html
+++ b/templates/conventions/recapitulatif/annexes.html
@@ -15,7 +15,7 @@
                         {% include "conventions/actions/goto.html" %}
                     </div>
                     {% if annexes %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/collectif.html
+++ b/templates/conventions/recapitulatif/collectif.html
@@ -15,7 +15,7 @@
                         {% include "conventions/actions/goto.html" %}
                     </div>
                     {% if locaux_collectifs %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/foyer_residence_logements.html
+++ b/templates/conventions/recapitulatif/foyer_residence_logements.html
@@ -18,7 +18,7 @@
                         {% include "common/display_field_if_exists.html" with label="Nombre de logements" value=lot.nb_logements object_field="lot__nb_logements__"|add:lot_uuid %}
                     </div>
                     {% if logements %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/logements.html
+++ b/templates/conventions/recapitulatif/logements.html
@@ -18,7 +18,7 @@
                         {% include "common/display_field_if_exists.html" with label="Nombre de logements à conventionner" value=lot.nb_logements object_field="lot__nb_logements__"|add:lot_uuid %}
                     </div>
                     {% if logements %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">
@@ -113,7 +113,7 @@
 
                             {% if convention.ecolo_reference and repartition_surfaces %}
                                 <p class="fr-my-2w notes"><em>Cependant, vous avez déclaré depuis Ecoloweb la répartition des logement suivante:</em></p>
-                                <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                                <div class="fr-table table--limited-height">
                                     <div class="fr-table__wrapper">
                                         <div class="fr-table__container">
                                             <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/logements.html
+++ b/templates/conventions/recapitulatif/logements.html
@@ -18,7 +18,7 @@
                         {% include "common/display_field_if_exists.html" with label="Nombre de logements à conventionner" value=lot.nb_logements object_field="lot__nb_logements__"|add:lot_uuid %}
                     </div>
                     {% if logements %}
-                        <div class="fr-table">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/pieces_jointes.html
+++ b/templates/conventions/recapitulatif/pieces_jointes.html
@@ -12,7 +12,7 @@
                         <p>{{ convention.pieces_jointes.count }} document(s) issu(s) d'Ecoloweb</p>
                     </div>
                 </div>
-                <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                <div class="fr-table table--limited-height">
                     <div class="fr-table__wrapper">
                         <div class="fr-table__container">
                             <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/references_cadastrales.html
+++ b/templates/conventions/recapitulatif/references_cadastrales.html
@@ -19,7 +19,7 @@
                     </div>
                     {% include "common/display_text_and_files_if_exists.html" with text=programme.reference_cadastrale|get_text_from_textfiles file_list=programme.reference_cadastrale|get_files_from_textfiles %}
                     {% if reference_cadastrales %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/conventions/recapitulatif/stationnements.html
+++ b/templates/conventions/recapitulatif/stationnements.html
@@ -14,7 +14,7 @@
                         {% include "conventions/actions/goto.html" %}
                     </div>
                     {% if stationnements %}
-                        <div class="fr-table fr-table--bordered table--layout-fixed table--limited-height">
+                        <div class="fr-table table--limited-height">
                             <div class="fr-table__wrapper">
                                 <div class="fr-table__container">
                                     <div class="fr-table__content">

--- a/templates/operations/conventions.html
+++ b/templates/operations/conventions.html
@@ -13,7 +13,7 @@
 
     <div class="fr-container">
         <div class="fr-grid-row fr-grid-row--gutters">
-            <div class="fr-my-5w fr-table fr-table--bordered table--layout-fixed">
+            <div class="fr-my-5w fr-table">
                 {% if programme is None %}
                     <div class="fr-col-md-12 fr-mb-5w fr-mt-3w">
                         <div role="alert" class="fr-alert fr-alert--warning">

--- a/templates/settings/administrations.html
+++ b/templates/settings/administrations.html
@@ -30,7 +30,7 @@
                         {% endif %}
                     </form>
 
-                    <div class="fr-table fr-table--bordered table--layout-fixed">
+                    <div class="fr-table">
                         <div class="fr-table__wrapper">
                             <div class="fr-table__container">
                                 <div class="fr-table__content">

--- a/templates/settings/bailleur_list_table.html
+++ b/templates/settings/bailleur_list_table.html
@@ -1,4 +1,4 @@
-<div class="fr-table fr-table--bordered table--layout-fixed">
+<div class="fr-table">
     <div class="fr-table__wrapper">
         <div class="fr-table__container">
             <div class="fr-table__content">

--- a/templates/settings/delegataires/form.html
+++ b/templates/settings/delegataires/form.html
@@ -33,7 +33,7 @@
             </p>
         {% endfor %}
         {% if communes %}
-            <div class="fr-table fr-table--md fr-table--no-caption table--layout-fixed fr-mt-5w" id="table-md-component">
+            <div class="fr-table fr-table--no-caption fr-mt-5w" id="table-md-component">
                 <div class="fr-table__wrapper">
                     <div class="fr-table__container">
                         <div class="fr-table__content">

--- a/templates/settings/user_list.html
+++ b/templates/settings/user_list.html
@@ -17,7 +17,7 @@
     {% endif %}
 </form>
 
-<div class="fr-table fr-table--bordered table--layout-fixed">
+<div class="fr-table">
     <div class="fr-table__wrapper">
         <div class="fr-table__container">
             <div class="fr-table__content">


### PR DESCRIPTION
Voici les différents changements apportés :
`table--limited-height` : classe custom donner un scroll vertical quand le tableau contient beaucoup de ligne -> je l'ai **adaptée au nouveau layout**, pas de changement fonctionnel

`table.fullwidth`: classe custom pour donner une largeur de 100% au tableau. C'est maintenant le comportement par défaut, j'ai supprimé.

`table--layout-fixed` : classe custom pour avoir une largeur de 100% et un display: table. Comportement par défaut du nouveau layout, j'ai supprimé.



