### PR TITLE
Improve front page table layout

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -663,7 +663,8 @@ a[href].apilos-block-faqlink:after {
   background-image: none;
 }
 
-.fr-table--sm.table--header-lg .fr-table__content th {
+.fr-table--sm.table--vertical-lg .fr-table__content th,
+.fr-table--sm.table--vertical-lg .fr-table__content td {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
 }

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -7,7 +7,7 @@
         <div class="fr-grid-row fr-grid-row--gutters fr-card fr-card--no-border">
             <div class="fr-col-md-12">
                 {% if filtered_conventions_count > 0 %}
-                    <div class="fr-table table--header-lg fr-table--sm table--hover-animation">
+                    <div class="fr-table table--vertical-lg fr-table--sm table--hover-animation">
                         {% if filtered_conventions_count != all_conventions_count %}
                             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-2w">
                                 <div class="fr-grid-row fr-col-12">


### PR DESCRIPTION
Permet de moins tasser verticalement le tableau de la page d'accueil.

On utilise la classe `fr-table--sm` pour que le tableau tienne sur la page horizontalement malgré les nombreuses colonnes, et la classe custom `table--vertical-lg` permet de diminuer l'aspect compact.

Avant :
![Capture d’écran 2024-09-23 à 10 15 53](https://github.com/user-attachments/assets/8945b91b-822d-44ac-be55-1409372c5de3)

Après : 
![Capture d’écran 2024-09-23 à 10 16 02](https://github.com/user-attachments/assets/9a1c2c60-5639-4402-b156-8857692ef8c4)

