### PR TITLE
Résolution d'une erreur 500 qui pouvait arrivé quand on supprimait un programme

### DIFF
--- a/programmes/signals.py
+++ b/programmes/signals.py
@@ -61,6 +61,6 @@ def compute_date_achevement_compile(sender, instance, *args, **kwargs):
 
 @receiver(post_delete, sender=Lot)
 def remove_lot(sender, instance, *args, **kwargs):
-    programme = Programme.objects.get(id=instance.programme_id)
-    if programme.conventions.count() == 0:
+    programme = Programme.objects.filter(id=instance.programme_id).first()
+    if programme and programme.conventions.count() == 0:
         programme.delete()


### PR DESCRIPTION
Lors de la suppression d'un programme, on cascade la suppression de ses lots qui eux même supprime le programme

Cette PR ajout de la flexibilité et ignore si le programme du lot n'existe plus, ce qui évite une erreur 500 qu'on pouvait avoir dans l'admin