### PR TITLE
Suppression de la description des avenants

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import logging
 import uuid
 from datetime import date
@@ -280,25 +279,6 @@ class Convention(models.Model):
             return EcoloReference.objects.filter(
                 apilos_model="conventions.Convention", apilos_id=self.id
             ).first()
-
-        return None
-
-    @property
-    def description_avenant(self):
-        if self.commentaires is None:
-            return
-        try:
-            json_data = json.loads(self.commentaires)
-            if (
-                "text" in json_data
-                and isinstance(json_data["text"], dict)
-                and "description_avenant" in json_data["text"]
-            ):
-                return json_data["text"]["description_avenant"]
-        except (json.decoder.JSONDecodeError, TypeError):
-            logger.error(
-                f"Error while parsing commentaires for convention {self.id}, invalid JSON content"
-            )
 
         return None
 

--- a/conventions/tests/models/test_convention.py
+++ b/conventions/tests/models/test_convention.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-from datetime import date
 from unittest import mock
 
 import pytest
@@ -200,28 +199,6 @@ class ConventionModelsTest(TestCase):
     def test_convention_bailleur(self):
         convention = Convention.objects.order_by("uuid").first()
         self.assertEqual(convention.bailleur, convention.programme.bailleur)
-
-    def test_description_avenant(self):
-        assert (
-            ConventionFactory.build(
-                commentaires='{"files": {}, "text": {"description_avenant": "modifs surfaces"} }'
-            ).description_avenant
-            == "modifs surfaces"
-        )
-        assert (
-            ConventionFactory.build(commentaires="modifs surfaces").description_avenant
-            is None
-        )
-        assert (
-            ConventionFactory.build(
-                commentaires='{"files": {}, "text": {"description_avenant": } }'
-            ).description_avenant
-            is None
-        )
-        assert (
-            ConventionFactory.build(commentaires=date.today()).description_avenant
-            is None
-        )
 
 
 class ConventionPrefixTest(TestCase):

--- a/ecoloweb/services/resources/sql/importers/convention.sql
+++ b/ecoloweb/services/resources/sql/importers/convention.sql
@@ -1,9 +1,6 @@
 select
     ch.id as id,
     chp.id as parent_id,
-    -- Les avenants sont initialisés avec un type 'commentaires' dont la valeur est un résumé des altérations
-    -- déclarées depuis Ecoloweb
-    '{"files": {}, "text": {"description_avenant": "'||replace(a.description, '"', E'\\"')||'"} }' as commentaires,
     ch.conventionapl_id||':'||ch.numero as programme_id,
     -- Les lots d'un programme sont tous les logements partageant le même financement
     ch.id as lot_id,

--- a/templates/conventions/avenant_list.html
+++ b/templates/conventions/avenant_list.html
@@ -11,9 +11,7 @@
             <div class="fr-col-11">
                 <div class="fr-grid-row">
                     <p class="fr-m-0">
-                        Avenant {{convention.numero|default_if_none:'x' }} {% if convention.televersement_convention_signee_le %}du <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-' }} </strong></span>{% endif %}:&nbsp;{% if convention.description_avenant %}
-                            {{ convention.description_avenant|linebreaksbr }}
-                        {% endif %}
+                        Avenant {{convention.numero|default_if_none:'x' }} {% if convention.televersement_convention_signee_le %}du <span class="fr-ml-1v"><strong>{{convention.televersement_convention_signee_le|date:"d F Y"|default_if_none:'-' }} </strong></span>{% endif %}
                     </p>
                 </div>
 


### PR DESCRIPTION
Cette description provient de écoloweb et n'est pas editable. Comme elle provoque des erreurs, je propose de la supprimer