### PR TITLE
Hide mode expert on ecoloweb conventions for readonly users

### DIFF
--- a/conventions/templatetags/custom_filters.py
+++ b/conventions/templatetags/custom_filters.py
@@ -508,3 +508,10 @@ def length_is(value, arg):
         return len(value) == int(arg)
     except (ValueError, TypeError):
         return False
+
+
+@register.filter
+def can_use_expert_mode(request, convention):
+    is_readonly = "readonly" in request.session and request.session["readonly"]
+    is_signee = convention.statut == ConventionStatut.SIGNEE.label
+    return is_signee and is_instructeur(request) and not is_readonly

--- a/conventions/tests/custom_filters/test_main_custom_filters.py
+++ b/conventions/tests/custom_filters/test_main_custom_filters.py
@@ -956,3 +956,23 @@ class CustomFiltersTest(TestCase):
             ),
             ["First line", "Second line", "Third line"],
         )
+
+    def _setup_expert_mode(self):
+        self.convention.statut = ConventionStatut.SIGNEE.label
+        self.request.session["currently"] = GroupProfile.SIAP_SER_GEST
+        self.request.session["readonly"] = False
+
+    def test_can_use_expert_mode(self):
+        self._setup_expert_mode()
+        assert custom_filters.can_use_expert_mode(self.request, self.convention)
+
+        self.convention.statut = ConventionStatut.CORRECTION.label
+        assert not custom_filters.can_use_expert_mode(self.request, self.convention)
+
+        self._setup_expert_mode()
+        self.request.session["currently"] = GroupProfile.BAILLEUR
+        assert not custom_filters.can_use_expert_mode(self.request, self.convention)
+
+        self._setup_expert_mode()
+        self.request.session["readonly"] = True
+        assert not custom_filters.can_use_expert_mode(self.request, self.convention)

--- a/templates/conventions/common/form_header.html
+++ b/templates/conventions/common/form_header.html
@@ -107,18 +107,20 @@
             </div>
         {% endif %}
     </div>
-    {% if convention.ecolo_reference and not request|is_readonly %}
+    {% if convention.ecolo_reference %}
         <div class="fr-container fr-pt-2w">
             <div role="alert" class="fr-col-12 fr-mb-3w apilos-alert apilos-alert-ecoloweb fr-pr-2w">
-                <p class="fr-text--lg">Cette convention a été importée automatiquement depuis <span class="fr-text--bold">Ecoloweb</span>, vous pouvez compléter ou corriger des informations en mode expert</p>
-                {% if not request.session.is_expert %}
-                    <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}"
-                       class="fr-btn fr-btn--secondary fr-mt-1w">
-                        Modifier la convention
-                    </a>
-                {% endif %}
+                <p class="fr-text--lg">Cette convention a été importée automatiquement depuis <span class="fr-text--bold">Ecoloweb</span>
+                    {% if request|can_use_expert_mode:convention %}, vous pouvez compléter ou corriger des informations en mode expert</p>
+                        {% if not request.session.is_expert %}
+                            <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}"
+                               class="fr-btn fr-btn--secondary fr-mt-1w">
+                                Modifier la convention
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                </div>
+                <hr class="fr-col-12 fr-my-3w">
             </div>
-            <hr class="fr-col-12 fr-my-3w">
-        </div>
     {% endif %}
 {% endif %}

--- a/templates/conventions/common/form_header.html
+++ b/templates/conventions/common/form_header.html
@@ -107,7 +107,7 @@
             </div>
         {% endif %}
     </div>
-    {% if convention.ecolo_reference %}
+    {% if convention.ecolo_reference and not request|is_readonly %}
         <div class="fr-container fr-pt-2w">
             <div role="alert" class="fr-col-12 fr-mb-3w apilos-alert apilos-alert-ecoloweb fr-pr-2w">
                 <p class="fr-text--lg">Cette convention a été importée automatiquement depuis <span class="fr-text--bold">Ecoloweb</span>, vous pouvez compléter ou corriger des informations en mode expert</p>

--- a/templates/conventions/recapitulatif.html
+++ b/templates/conventions/recapitulatif.html
@@ -30,7 +30,7 @@
                         {% include "comments/opened_comments.html" %}
                     </turbo-frame>
                 {% endif %}
-                {% if convention.statut == CONVENTION_STATUT.SIGNEE and request|is_instructeur and not request|is_readonly %}
+                {% if request|can_use_expert_mode:convention %}
                     <div class="fr-grid-row fr-grid-row--right">
                         <a href="{% url 'conventions:expert_mode' convention_uuid=convention.uuid %}"
                            class="fr-btn fr-btn--secondary">


### PR DESCRIPTION
Pb remonté sur le support : le bandeau de passage en mode expert était visible en readonly. Pas de pb fonctionnel derrière les champs n'étaient pas modifiables. 

Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/y5wptg93b785bkcdh75x1xrbne

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Se mettre en habilitation "lecteur national" sur la convention suivante : http://local.beta.gouv.fr:8001/conventions/post_action/0a873895-3026-4b72-a505-2fd890849

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
