### PR TITLE
Création d'un Mock remplacant l'authentification CERBERE en development

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -71,3 +71,6 @@ TEST_DOT_ENV_FILE=.env.test.local
 
 # LibreOffice for MacOS
 LIBREOFFICE_EXEC=/Applications/LibreOffice.app/Contents/MacOS/soffice
+
+# Mock Cerbere user id - in case of CERBERE authentication failure
+MOCK_CERBERE_USER_ID=

--- a/DEVELOPPEUR.md
+++ b/DEVELOPPEUR.md
@@ -273,15 +273,13 @@ DUMP_FILE=</path/to/dump/file>
 pg_restore -d "${DB_URL}" --clean --no-acl --no-owner --no-privileges "${DUMP_FILE}"
 ```
 
-## Utilisateurs
+## MOCK
 
-DEPRECATED ?
+En cas de non disponibilité de CERBERE en recette, il est possible de bouchonner l'authentification via CERBERE en définisant en variable d'environnement l'id de l'utilisateur à authentifier (à récupérer en base de données directement):
 
-L'import des fixtures crée plusieurs utilisateurs utiles lors du développement
+```sh
+# Mock Cerbere user id - in case of CERBERE authentication failure
+MOCK_CERBERE_USER_ID=
+```
 
-|             | identifiant      | mot de passe | email                       |
-|-------------|------------------|--------------|-----------------------------|
-| bailleur    | demo.bailleur    | demo.12345   | demo.bailleur@oudard.org    |
-| instructeur | demo.instructeur | instru12345  | demo.instructeur@oudard.org |
-
-TODO : décrire ici le mode autonome et le mode SIAP
+Si cette variable est définie, alors l'utilisateur est directement considéré comme authentifié et est utilisé pour récupérer les habilitations fournies par le SIAP.

--- a/core/backends.py
+++ b/core/backends.py
@@ -7,7 +7,8 @@ from django.contrib.auth.backends import ModelBackend
 from django.db.models import Q
 from django_cas_ng.backends import CASBackend
 
-from users.models import GroupProfile
+from core import settings
+from users.models import GroupProfile, User
 
 
 class CerbereCASBackend(CASBackend):
@@ -20,6 +21,14 @@ class CerbereCASBackend(CASBackend):
 
 
 UserModel = get_user_model()
+
+
+class MockCerbereBackend:
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        return User.objects.get(id=settings.MOCK_CERBERE_USER_ID)
+
+    def get_user(self, user_id):
+        return User.objects.get(pk=settings.MOCK_CERBERE_USER_ID)
 
 
 class EmailBackend(ModelBackend):

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,17 +1,18 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model, login
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth import login
+UserModel = get_user_model()
+
 
 class AutoLoginMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        User = get_user_model()
         try:
-            user = User.objects.get(pk=725)
-            login(request, user, backend='core.backends.MockCerbereBackend')
-        except User.DoesNotExist:
+            user = UserModel.objects.get(pk=settings.MOCK_CERBERE_USER_ID)
+            login(request, user, backend="core.backends.MockCerbereBackend")
+        except UserModel.DoesNotExist:
             pass
 
         response = self.get_response(request)

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,18 @@
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth import login
+
+class AutoLoginMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        User = get_user_model()
+        try:
+            user = User.objects.get(pk=725)
+            login(request, user, backend='core.backends.MockCerbereBackend')
+        except User.DoesNotExist:
+            pass
+
+        response = self.get_response(request)
+        return response

--- a/core/settings.py
+++ b/core/settings.py
@@ -487,7 +487,7 @@ NO_SIAP_MENU = get_env_variable("NO_SIAP_MENU", cast=bool)
 
 MOCK_CERBERE_USER_ID = get_env_variable("MOCK_CERBERE_USER_ID")
 
-if MOCK_CERBERE_USER_ID and ENVIRONMENT == 'development':
+if MOCK_CERBERE_USER_ID and ENVIRONMENT == "development":
     AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
         "core.backends.MockCerbereBackend",
     ]

--- a/core/settings.py
+++ b/core/settings.py
@@ -485,6 +485,16 @@ CERBERE_AUTH = get_env_variable("CERBERE_AUTH")
 USE_MOCKED_SIAP_CLIENT = get_env_variable("USE_MOCKED_SIAP_CLIENT", cast=bool)
 NO_SIAP_MENU = get_env_variable("NO_SIAP_MENU", cast=bool)
 
+MOCK_CERBERE_USER_ID = get_env_variable("MOCK_CERBERE_USER_ID")
+
+if MOCK_CERBERE_USER_ID and ENVIRONMENT == 'development':
+    AUTHENTICATION_BACKENDS = AUTHENTICATION_BACKENDS + [
+        "core.backends.MockCerbereBackend",
+    ]
+    MIDDLEWARE = MIDDLEWARE + [
+        "core.middleware.AutoLoginMiddleware",
+    ]
+
 if CERBERE_AUTH:
     MIDDLEWARE = MIDDLEWARE + [
         "django_cas_ng.middleware.CASMiddleware",


### PR DESCRIPTION
# Description succincte du problème résolu

Pour palier aux problèmes d'authentification avec CERBERE, il est possible de configurer directement en variable d'envirnnement `MOCK_CERBERE_USER_ID` id de l'utilisateur dans le base de données APILOS local, alors l'utilisateur est directement authentifié sans appel à CERBERE

Cette fonctionnalité n'est accessible qu'en environnement de développement


<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [ ] Bug fix
- [x] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- dans le base de données locale `psql -U apilos -h localhost -p 5433`
- trouver son utilisateur CERBERE : `select * from users_user where email = 'john@beta.gouv.fr';` et copier son id
- dans. `.env` configurer la variable d'environnement `MOCK_CERBERE_USER_ID=<ID>`
- relancer l'application et accéder à l'application

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
