### PR TITLE
Allow bailleur to submit avenant without operation number

### DIFF
--- a/templates/conventions/actions/submit_convention.html
+++ b/templates/conventions/actions/submit_convention.html
@@ -13,7 +13,7 @@
             <p>Si vous avez encore des modifications à apporter au projet de {{convention|display_kind_with_preposition}}, vous pouvez y revenir plus tard.
             </p>
             {% with numero_operation=convention.programme.numero_operation %}
-                {% if not numero_operation %}
+                {% if not numero_operation and not convention.is_avenant %}
                     <div class="fr-grid-row fr-my-2w">
                         <div class="fr-icon-warning-line fr-mr-2w"></div>
                         <div class="fr-col-11">
@@ -26,8 +26,8 @@
                 {% endif %}
                 <form method="post" action="{% url 'conventions:save' convention_uuid=convention.uuid %}" data-turbo="false">
                     {% csrf_token %}
-                    <button name="SubmitConvention" value=True class="fr-btn fr-my-3w" {% if not numero_operation %}disabled{% endif %}>
-                        {% if not numero_operation %}Veuillez définir le numéro d'opération avant de soumettre{% else %}Soumettre{% endif %} au service instructeur
+                    <button name="SubmitConvention" value=True class="fr-btn fr-my-3w" {% if not numero_operation and not convention.is_avenant %}disabled{% endif %}>
+                        {% if not numero_operation and not convention.is_avenant %}Veuillez définir le numéro d'opération avant de soumettre{% else %}Soumettre{% endif %} au service instructeur
                     </button>
                 </form>
             {% endwith %}


### PR DESCRIPTION
Permet de soumettre un avenant sans renseigner le numéro d'opération, utile sur de vieilles conv ecoloweb.

Carte Airtable / Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/ntcch7rfy7r8dnjhwjysdoagur

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :

Créer un avenant sur la conv : http://local.beta.gouv.fr:8001/conventions/post_action/039463ca-85db-438f-ab89-05e144bc6f37
Hijack un utilisateur de l'USSAP et créer un avenant, l'envoyer en instruction
