### PR TITLE
Ne pas surdefinir les codes regions et departements quand il sont déjà défini

### DIFF
--- a/programmes/signals.py
+++ b/programmes/signals.py
@@ -24,6 +24,13 @@ def compute_date_achevement_compile(sender, instance, *args, **kwargs):
     instance.date_achevement_compile = (
         instance.date_achevement or instance.date_achevement_previsible
     )
+
+
+@receiver(pre_save, sender=Programme)
+def set_insee_code(sender, instance, *args, **kwargs):
+    if instance.code_insee_departement and instance.code_insee_region:
+        return
+
     if instance.code_postal and len(instance.code_postal) == 5:
         if instance.code_postal.isnumeric() and int(instance.code_postal) >= 97000:
             code_departement = instance.code_postal[0:3]


### PR DESCRIPTION
# Description succincte du problème résolu

cf. mattermost : 
https://mattermost.incubateur.net/fabnum-mte/pl/tmpo5bpaeb83dn7goozjj7r8fy

Pas besoin de surdefinir les codes insee quand ils ont été transmis par le SIAP

J'en ai profité pour séparer les logiques dans 2 actions `pre_save`

<!-- Cocher la/les case.s appropriée.s -->
**Type de changement** :

- [x] Bug fix
- [ ] Nouvelle fonctionnalité
- [ ] Mise à jour de données / DAG
- [ ] Les changements nécessitent une mise à jour de documentation
- [ ] Refactoring de code (explication à retrouver dans la description)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
