### PR TITLE
capter l'erreur OngoingAvenantError et rediriger plutôt qu'afficher une erreur

### DIFF
--- a/conventions/services/avenants.py
+++ b/conventions/services/avenants.py
@@ -26,14 +26,14 @@ class OngoingAvenantError(Exception):
 def create_avenant(request: HttpRequest, convention_uuid: UUID) -> dict[str, Any]:
     parent_convention = (
         Convention.objects.prefetch_related("programme")
-        # .prefetch_related("lot")
-        .prefetch_related("avenants").get(uuid=convention_uuid)
+        .prefetch_related("avenants")
+        .get(uuid=convention_uuid)
     )
     if parent_convention.is_avenant():
         parent_convention = (
             Convention.objects.prefetch_related("programme")
-            # .prefetch_related("lot")
-            .prefetch_related("avenants").get(id=parent_convention.parent_id)
+            .prefetch_related("avenants")
+            .get(id=parent_convention.parent_id)
         )
 
     if request.method == "POST":


### PR DESCRIPTION
# Description succincte du problème résolu

Sentry : [OngoingAvenantError](https://sentry.incubateur.net/organizations/betagouv/issues/128831/?project=29&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=2)

Eviter l'erreur sentry

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- créer un avenant
- cclicker sur le bouton "modifier" d'un bloque
- clicker sur le bouton "back" du navigateur

Avant ça affichait une erreur, maintenannt ça affiche le récap de l'avenant

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
