### PR TITLE
Affichage de l'entête des habilitations quand celle-ci existe

### DIFF
--- a/templates/layout/siap/habilitations.html
+++ b/templates/layout/siap/habilitations.html
@@ -1,7 +1,7 @@
 <button class="fr-nav__btn orange-background" aria-expanded="false" aria-controls="list-habilitation" aria-current="true">
     {% for habilitation in request.session.habilitations %}
         {% if habilitation.id == request.session.habilitation_id %}
-            {{ habilitation.groupe.libelleRole }}<br>
+            {% if habilitation.entete %}{{ habilitation.entete}}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}<br>
             {% if habilitation.sousTitre1 %}
                 {{ habilitation.sousTitre1 }}<br>
             {% endif %}
@@ -17,7 +17,7 @@
             {% for habilitation in request.session.habilitations %}
                 {% if habilitation.id != request.session.habilitation_id %}
                     <li>
-                        <a class="fr-nav__link fr-p-1w" href="{{ request|get_change_habilitation_url:habilitation.id }}"><strong>{{ habilitation.groupe.libelleRole }}</strong><br>
+                        <a class="fr-nav__link fr-p-1w" href="{{ request|get_change_habilitation_url:habilitation.id }}"><strong>{% if habilitation.entete %}{{ habilitation.entete}}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}</strong><br>
                             {% if habilitation.sousTitre1 %}
                                 {{ habilitation.sousTitre1 }}<br>
                             {% endif %}


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Airtable / Lien Mattermost : [S1245: Intégrer la nouvelle entrée 'entête' dans l'affichage des habilitations](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwhG4jAQK4JhrSZz/recMhHOibvfxhE0mp?blocks=hide)

Pour faire suite à l'email de Rémi qui nous prévenait d'une modification futur de la 

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besoin)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
