### PR TITLE
[fix] Ajout d'une convention depuis une opération

### DIFF
--- a/conventions/tests/views/test_from_operation_views.py
+++ b/conventions/tests/views/test_from_operation_views.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.conf import settings
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 from django.urls import reverse
+from pytest_django.asserts import assertRedirects
 from unittest_parametrize import ParametrizedTestCase, param, parametrize
 from waffle.testutils import override_flag
 
@@ -119,13 +120,14 @@ class AddConventionViewTest(TestCase):
         session["habilitation_id"] = 5
         session.save()
 
-    def test_basic(self):
+    def test_redirect_if_numero_operaion_is_unknown(self):
         self._login()
 
         response = self.client.get(
             reverse("conventions:from_operation_add_convention", args=["123"])
         )
-        assert response.status_code == 200
+        assert response.status_code == 302
+        assertRedirects(response, reverse("conventions:from_operation_select"))
 
     # TODO: add tests
 

--- a/conventions/views/convention_form_from_operation.py
+++ b/conventions/views/convention_form_from_operation.py
@@ -80,10 +80,19 @@ class AddConventionView(
     def _handle(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         numero_operation = kwargs.get("numero_operation")
 
-        #  TODO: handle null operation and user rights
         operation = SelectOperationService(
             request=request, numero_operation=numero_operation
         ).get_operation()
+
+        if not operation:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"L'opération {numero_operation} n'a pas été trouvée dans Apilos.",
+            )
+            return HttpResponseRedirect(
+                reverse("conventions:from_operation_select"),
+            )
 
         service = AddConventionService(request=request, operation=operation)
         if request.method == "POST":

--- a/templates/conventions/from_operation/select_operation_list.html
+++ b/templates/conventions/from_operation/select_operation_list.html
@@ -121,9 +121,8 @@
     <script type="text/javascript" nonce="{{request.csp_nonce}}">
         rows = document.querySelectorAll('tr.clickable')
         rows.forEach(row => {
-            numero = row.children[0].textContent
-            row.addEventListener("click", () => {
-                window.location = "from_operation/add_convention/" + encodeURIComponent(numero)
+            row.addEventListener("click", (e) => {
+                window.location = "from_operation/add_convention/" + encodeURIComponent(e.currentTarget.children[0].textContent)
             })
         });
     </script>


### PR DESCRIPTION
# Description succincte du problème résolu

Bug sur l'ajout de convention depuis une opération.
Dans la première étape, on recherche une opération et on affiche la liste. Le lien vers l'opération sélectionnée est erroné, le code JS prend le numéro de la mauvaise row.

J'ai également ajouté un renforcement sur l'étape 2, pour gérer le cas où on atterit sur cette page avec un numéro d'opération inconnu.

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [x] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

Aller sur `/conventions/from_operation`, faire un recherche, sélectionner un item
=> on devrait atterir sur `/conventions/from_operation/add_convention/<numero_operation_selected>`

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
