### PR TITLE
[fix] Changement du signataire en instruction

### DIFF
--- a/templates/conventions/recapitulatif/bailleur.html
+++ b/templates/conventions/recapitulatif/bailleur.html
@@ -36,15 +36,14 @@
                     {% if convention.identification_bailleur %}
                         {% include "common/display_field_if_exists.html" with label="Identification personalisée du bailleur" value=convention.identification_bailleur_detail object_field="convention__identification_bailleur_detail__"|add:convention_uuid %}
                     {% else %}
-                        {% if bailleur.signataire_nom %}
-                            {% include "common/display_field_if_exists.html" with value=bailleur.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}
-                            <em>{% include "common/display_field_if_exists.html" with value=bailleur.signataire_fonction object_field="bailleur__signataire_fonction__"|add:bailleur_uuid %}</em>
-                            {% include "common/display_field_if_exists.html" with label="Date de délibération" value=bailleur.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:bailleur_uuid %}
-
-                        {% else %}
+                        {% if convention.signataire_nom %}
                             {% include "common/display_field_if_exists.html" with value=convention.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}
                             <em>{% include "common/display_field_if_exists.html" with value=convention.signataire_fonction object_field="bailleur__signataire_fonction__"|add:bailleur_uuid %}</em>
                             {% include "common/display_field_if_exists.html" with label="Date de délibération" value=convention.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:bailleur_uuid %}
+                        {% elif bailleur.signataire_nom %}
+                            {% include "common/display_field_if_exists.html" with value=bailleur.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}
+                            <em>{% include "common/display_field_if_exists.html" with value=bailleur.signataire_fonction object_field="bailleur__signataire_fonction__"|add:bailleur_uuid %}</em>
+                            {% include "common/display_field_if_exists.html" with label="Date de délibération" value=bailleur.signataire_date_deliberation object_field="bailleur__signataire_date_deliberation__"|add:bailleur_uuid %}
                         {% endif %}
                     {% endif %}
                     {% if bailleur.signature_nom %}


### PR DESCRIPTION
# Description succincte du problème résolu

[Carte Airtable](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/rec8Q5tbnuu2sJAZM?blocks=hide)

Quand on modifie le signatire (nom & fonction) sur une convention validée (mode expert ou retour en instruction), la nouvelle valeur n'est pas affichée sur le recap.

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

- Modifier le signataire sur une convention validée (mode expert ou retour en instruction)
- vérifier que les infos sont correctes au niveau des informations détaillées
- vérifier que les nouvelles infos sont prises en compte dans le document final généré


