### PR TITLE
Use SIAP_ASSISTANCE_URL in error messsages

### DIFF
--- a/conventions/views/convention_form_from_operation.py
+++ b/conventions/views/convention_form_from_operation.py
@@ -58,7 +58,6 @@ class SelectOperationView(FromOperationBaseView, TemplateView):
 
         return super().get_context_data(**kwargs) | {
             "operations": operations,
-            "siap_assistance_url": settings.SIAP_ASSISTANCE_URL,
             "exact_match": exact_match,
         }
 

--- a/conventions/views/conventions.py
+++ b/conventions/views/conventions.py
@@ -179,7 +179,6 @@ class ConventionSearchView(LoginRequiredMixin, View):
             ),
             "bailleur_query": self.bailleurs_queryset,
             "debug_search_scoring": settings.DEBUG_SEARCH_SCORING,
-            "siap_assistance_url": settings.SIAP_ASSISTANCE_URL,
         } | {
             k: self._get_non_empty_query_param(k, default="")
             for k in (

--- a/core/context_processor.py
+++ b/core/context_processor.py
@@ -17,6 +17,7 @@ def get_environment(request):
         nature_bailleur.name: nature_bailleur.label
         for nature_bailleur in NatureBailleur
     }
+    data["SIAP_ASSISTANCE_URL"] = settings.SIAP_ASSISTANCE_URL
 
     if settings.CERBERE_AUTH:
         client = SIAPClient.get_instance()

--- a/core/settings.py
+++ b/core/settings.py
@@ -600,7 +600,7 @@ MIDDLEWARE += ["waffle.middleware.WaffleMiddleware"]
 # Assistance
 SIAP_ASSISTANCE_URL = get_env_variable(
     "SIAP_ASSISTANCE_URL",
-    default="https://siap-logement.atlassian.net/servicedesk/customer/portal/3/group/8/create/14",
+    default="https://siap-logement.atlassian.net/servicedesk/customer/portal/3",
 )
 
 # LibreOffice

--- a/programmes/services.py
+++ b/programmes/services.py
@@ -2,7 +2,6 @@ import functools
 from datetime import date
 from typing import Any
 
-from django.conf import settings
 from django.db.models import Q
 from django.http import HttpRequest
 from django.urls import resolve
@@ -76,7 +75,6 @@ class OperationService:
             "conventions": paginator.get_page(self.request.GET.get("page", 1)),
             "filtered_conventions_count": paginator.count,
             "all_conventions_count": paginator.count,
-            "siap_assistance_url": settings.SIAP_ASSISTANCE_URL,
             "search_operation_nom": "",
             "search_numero": "",
             "search_lieu": "",

--- a/templates/403.html
+++ b/templates/403.html
@@ -13,7 +13,7 @@
                         N'hésitez pas nous prévenir si vous pensez que ce comportement n'est pas normal
                     </p>
                     <p class="fr-mb-3w">
-                        L'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a>
+                        L'équipe <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">APiLos</a>
                     </p>
                 </div>
             </div>

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,7 @@
                         La page demandée ou l'objet demandé n'ont pas été trouvés. Il peut aussi s'agir d'un problème de droits sur la ressource demandée.
                     </p>
                     <p class="fr-mb-3w">
-                        Si le problème persiste merci de contacter l'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a>
+                        Si le problème persiste merci de contacter l'équipe <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">APiLos</a>
                     </p>
                 </div>
             </div>

--- a/templates/500.html
+++ b/templates/500.html
@@ -13,7 +13,7 @@
                             Nos équipes techniques travaillent actuellement à la mise en place de cette fonctionnalité.
                         </p>
                         <p class="fr-mb-3w">
-                            Nous vous prions de nous excuser pour la gène occasionnée. Si votre besoin est urgent, merci de contacter notre assistance à l'adresse suivante : <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">contact@apilos.beta.gouv.fr</a>.
+                            Nous vous prions de nous excuser pour la gène occasionnée. Si votre besoin est urgent, merci de <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">contacter notre assistance</a>
                         </p>
                     {% elif exception_type == 'NoConventionForOperationSIAPException' %}
                         <h2 class="fr-mt-3w fr-mt-md-5w fr-mb-5w">Cette opération ne donne pas lieu à un conventionnement.</h2>
@@ -26,7 +26,7 @@
                             Une erreur est survenue. Nous vous prions de nous excuser.
                         </p>
                         <p class="fr-mb-3w">
-                            Si le problème persiste merci de contacter l'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a>
+                            Si le problème persiste merci de contacter l'équipe <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">APiLos</a>
                         </p>
                     {% endif %}
                     {% if CERBERE_AUTH %}

--- a/templates/conventions/convention_list.html
+++ b/templates/conventions/convention_list.html
@@ -180,13 +180,11 @@
                                 </a>
                             </li>
                         {% endif %}
-                        {% if siap_assistance_url %}
-                            <li>
-                                <a class="fr-btn fr-btn--tertiary fr-icon-mail-line apilos-no-dsfr-target" href="{{ siap_assistance_url }}" target="_blank"  rel="noopener">
-                                    Contactez l'assistance
-                                </a>
-                            </li>
-                        {% endif %}
+                        <li>
+                            <a class="fr-btn fr-btn--tertiary fr-icon-mail-line apilos-no-dsfr-target" href="{{ SIAP_ASSISTANCE_URL }}" target="_blank"  rel="noopener">
+                                Contactez l'assistance
+                            </a>
+                        </li>
                     </ul>
                     <img class="fr-mr-3w" src="/static/icons/not_found.png" alt="not_found">
                 {% else %}
@@ -213,13 +211,11 @@
                                             </a>
                                         </div>
                                     {% endflag %}
-                                    {% if siap_assistance_url %}
-                                        <div class="">
-                                            <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary" href="{{ siap_assistance_url }}" target="_blank"  rel="noopener">
-                                                Contactez l'assistance
-                                            </a>
-                                        </div>
-                                    {% endif %}
+                                    <div class="">
+                                        <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary" href="{{ SIAP_ASSISTANCE_URL }}" target="_blank"  rel="noopener">
+                                            Contactez l'assistance
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/templates/conventions/from_operation/select_operation_list.html
+++ b/templates/conventions/from_operation/select_operation_list.html
@@ -62,13 +62,11 @@
                     </div>
                     <div class="fr-mt-5w fr-ml-1w">
                         <div class="fr-grid-row fr-grid-row--gutters" >
-                            {% if siap_assistance_url %}
-                                <div class="">
-                                    <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ siap_assistance_url }}" target="_blank" rel="noopener">
-                                        Contactez l'assistance
-                                    </a>
-                                </div>
-                            {% endif %}
+                            <div class="">
+                                <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ SIAP_ASSISTANCE_URL }}" target="_blank" rel="noopener">
+                                    Contactez l'assistance
+                                </a>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -90,13 +88,11 @@
                 </div>
                 <div class="fr-mt-5w fr-ml-1w">
                     <div class="fr-grid-row fr-grid-row--gutters" >
-                        {% if siap_assistance_url %}
-                            <div class="">
-                                <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ siap_assistance_url }}" target="_blank" rel="noopener">
-                                    Contactez l'assistance
-                                </a>
-                            </div>
-                        {% endif %}
+                        <div class="">
+                            <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ SIAP_ASSISTANCE_URL }}" target="_blank" rel="noopener">
+                                Contactez l'assistance
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -106,11 +102,9 @@
         </div>
     {% else %}
         <p class="fr-mt-10w fr-mb-2w">Vous n'avez pas le numéro de l'opération ?</p>
-        {% if siap_assistance_url %}
-            <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ siap_assistance_url }}" target="_blank" rel="noopener">
-                Contactez l'assistance
-            </a>
-        {% endif %}
+        <a class="fr-btn fr-icon-mail-line fr-btn--icon-left fr-btn--tertiary apilos-no-dsfr-target" href="{{ SIAP_ASSISTANCE_URL }}" target="_blank" rel="noopener">
+            Contactez l'assistance
+        </a>
     {% endif %}
 
 

--- a/templates/conventions/home/instructeur_no_convention.html
+++ b/templates/conventions/home/instructeur_no_convention.html
@@ -21,7 +21,7 @@
                 <div class="fr-col-9 fr-col-md-9">
                     <div class="fr-mb-3w">
                         <h3>Je prends contact avec l'équipe APiLos</h3>
-                        <p>Toute l'équipe APiLos est à votre disposition, n'hésitez pas à nous envoyer un email à l'adresse <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">contact@apilos.beta.gouv.fr</a></p>
+                        <p>Toute l'équipe APiLos est à votre disposition, n'hésitez pas à <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">contacter notre assitance</a></p>
                     </div>
                     <div class="fr-mb-3w">
                         <h3>Je consulte l'aide en ligne</h3>

--- a/templates/conventions/submitted.html
+++ b/templates/conventions/submitted.html
@@ -26,7 +26,7 @@
                     <p class="fr-mb-3w">Vous pouvez cependant consulter à tout moment les données saisies ainsi que le statut d'instruction sur la plateforme APiLos</p>
                     <p class="fr-mb-3w">Nous restons à votre disposition pour toute information et question.</p>
                     <p class="fr-mb-3w">En vous remerciant, nous vous souhaitons une bonne journée</p>
-                    <p class="fr-mb-3w">L'équipe <a href="mailto:contact@apilos.beta.gouv.fr" target="_blank">APiLos</a></p>
+                    <p class="fr-mb-3w">L'équipe <a href="{{ SIAP_ASSISTANCE_URL }}" target="_blank">APiLos</a></p>
                 </div>
             </div>
 


### PR DESCRIPTION
Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/ehzosk7t37ndjqjw7esgkten5o

Nous avons un déjà setting avec le lien de l'assistance. J'ai modifié sa valeur par défaut après discussion avec Ibtihel, et je l'ai utilisé à la place du mail dans différents messages d'erreurs.

J'ai choisi de l'ajouter au contexte global plutôt que de le passer à chaque vue.

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [x] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
