### PR TITLE
Fix upload de deux tableaux dans l'avenant logement

### DIFF
--- a/conventions/services/logements.py
+++ b/conventions/services/logements.py
@@ -23,6 +23,21 @@ class ConventionLogementsService(ConventionService):
     upform: UploadForm = UploadForm()
 
     def initialize_formsets(self):
+        if self.request.POST:
+            # Dans le cas d'un POST (à l'upload d'un fichier), on initialise les tableaux avec les params du POST
+            self.formset = LogementFormSet(self.request.POST, prefix="avec_loyer")
+            self.formset_sans_loyer = LogementSansLoyerFormSet(
+                self.request.POST, prefix="sans_loyer"
+            )
+            self.formset_corrigee = LogementCorrigeeFormSet(
+                self.request.POST, prefix="corrigee_avec_loyer"
+            )
+            self.formset_corrigee_sans_loyer = LogementCorrigeeSansLoyerFormSet(
+                self.request.POST, prefix="corrigee_sans_loyer"
+            )
+            return
+
+        # Dans le cas d'un GET, on initialise les tableaux à partir de la BDD
         initial = []
         initial_sans_loyer = []
         initial_corrigee = []
@@ -85,7 +100,6 @@ class ConventionLogementsService(ConventionService):
                             **surface_utile_params,
                         }
                     )
-
         self.formset = LogementFormSet(initial=initial, prefix="avec_loyer")
         self.formset_sans_loyer = LogementSansLoyerFormSet(
             initial=initial_sans_loyer, prefix="sans_loyer"


### PR DESCRIPTION
Problème présent depuis la MAJ des avenants logements pour avoir 4 tableaux : l'upload simultané de plusieurs tableaux sans sauvegarde intermédiaire plantait.

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- Dans un avenant logement de logement ordinaire, upload un premier tableau, puis un second sans sauvegarder entre temps : les deux tableaux doivent être présents sur la page.

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
