### PR TITLE
Disable readonly for staff users

### DIFF
--- a/siap/custom_middleware.py
+++ b/siap/custom_middleware.py
@@ -163,7 +163,8 @@ def _find_or_create_entity(
 
     # Manage readonly access
     request.session["readonly"] = (
-        from_habilitation["groupe"]["codeRole"]
+        not (request.user.is_staff or request.user.is_superuser)
+        and from_habilitation["groupe"]["codeRole"]
         in GroupProfileRole.readonly_group_profile_roles()
     )
 


### PR DESCRIPTION
Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/ztjoz1cqaiyi984py7wimar4go

![Capture d’écran 2025-02-20 à 16 27 15](https://github.com/user-attachments/assets/2c298112-b13c-420b-9d63-9884443f7f69)


J'ai besoin d'accéder à l'interface de gestion des délégataires, accessibles au staff dans les settings sur l'interface d'APiLos. Le mode readonly m'empêche de remplir les champs du formulaire en production... je vois mal comment régler ça juste pour ce module, alors je propose ce workaround peut-être un peu bourrin, mais efficace.

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
