### PR TITLE
Fix regression after import_mapping became a string

### DIFF
--- a/conventions/services/upload_objects.py
+++ b/conventions/services/upload_objects.py
@@ -204,7 +204,9 @@ def _extract_row(row, column_from_index, cls, *, class_field_mapping):
         # Check the empty lines to don't fill it
         empty_line = False
         value = None
-        model_field = import_mapping[column_from_index[cell.column]]
+        model_field = cls._meta.get_field(
+            import_mapping[column_from_index[cell.column]]
+        )
 
         if isinstance(model_field, str):
             key = model_field


### PR DESCRIPTION
Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/9foti1cumjfwdmwibeyyci9wpr

Depuis que j'ai passé le import_mapping en string (pour permettre son écrasement dans des modèles proxy pour gérer les quatre tableaux logements), tous les imports xls se comportent bizarrement. C'est parce qu'on ne parvenait pas à récupérer le champ à partir de son nom. (alors qu'avant il était référencé directement dans l'import mapping)

Cette modif permet, à partir du nom d'un champ récupéré dans l'import mapping, d'obtenir le champ en question pour, par exemple, interroger son type.

https://docs.djangoproject.com/en/5.1/ref/models/meta/#retrieving-a-single-field-instance-of-a-model-by-name

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
