### PR TITLE
Fix habilitations display since dsfr 1.13

### DIFF
--- a/static/css/ui_siap.css
+++ b/static/css/ui_siap.css
@@ -47,14 +47,19 @@
   margin-bottom: 0;
 }
 
-.habilitation-bloc .fr-menu__list ul {
+.habilitation-bloc .fr-menu__list {
   padding: 0;
 }
 
-.habilitation-bloc .fr-menu__list ul li {
+.habilitation-bloc .fr-menu__list li {
   text-align: left;
 }
 
-.habilitation-bloc .fr-menu__list ul li:hover a {
+.habilitation-bloc .fr-menu__list li:hover a {
   text-decoration: none;
+}
+
+.habilitation-bloc .fr-nav__link {
+  flex-direction: column;
+  align-items: flex-start;
 }

--- a/templates/layout/siap/habilitations.html
+++ b/templates/layout/siap/habilitations.html
@@ -1,9 +1,9 @@
 <button class="fr-nav__btn orange-background" aria-expanded="false" aria-controls="list-habilitation" aria-current="true">
     {% for habilitation in request.session.habilitations %}
         {% if habilitation.id == request.session.habilitation_id %}
-            {% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}<br>
+            {% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}
             {% if habilitation.sousTitre1 %}
-                {{ habilitation.sousTitre1 }}<br>
+                {{ habilitation.sousTitre1 }}
             {% endif %}
             {% if habilitation.sousTitre2 %}
                 {{ habilitation.sousTitre2 }}
@@ -12,14 +12,13 @@
     {% endfor %}
 </button>
 <div class="fr-collapse fr-menu habilitation-bloc" id="list-habilitation">
-    <div class="fr-menu__list">
-        <ul>
+    <ul class="fr-menu__list">
             {% for habilitation in request.session.habilitations %}
                 {% if habilitation.id != request.session.habilitation_id %}
                     <li>
-                        <a class="fr-nav__link fr-p-1w" href="{{ request|get_change_habilitation_url:habilitation.id }}"><strong>{% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}</strong><br>
+                        <a class="fr-nav__link fr-p-1w" href="{{ request|get_change_habilitation_url:habilitation.id }}"><strong>{% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}</strong>
                             {% if habilitation.sousTitre1 %}
-                                {{ habilitation.sousTitre1 }}<br>
+                                {{ habilitation.sousTitre1 }}
                             {% endif %}
                             {% if habilitation.sousTitre2 %}
                                 {{ habilitation.sousTitre2 }}
@@ -28,9 +27,8 @@
                     </li>
                 {% endif %}
             {% endfor %}
-        </ul>
         <a href="{{ request|get_manage_habilitation_url }}" class="fr-btn fr-px-2w fr-py-3v fr-text--md">
             <div aria-hidden="true">Gérer mes habilitations</div>
         </a>
-    </div>
+    </ul>
 </div>


### PR DESCRIPTION
Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/3bw5jxzu3tnpdgz5hrrjcahkie

Depuis l'upgrade au dsfr 1.13, le code front du menu habilitation est pété. Il s'agit d'une partie où on détourne le dsfr de manière assez conséquente.

Sans modif :
![Capture d’écran 2025-03-05 à 15 19 52](https://github.com/user-attachments/assets/11b90fd9-8745-49d9-9f3b-707823535ca2)


Avec modif :
![Capture d’écran 2025-03-05 à 15 18 53](https://github.com/user-attachments/assets/87d11625-b41b-47ee-9d5e-000de04b2f23)


**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local



- Faire tourner python manage.py collectstatic pour rebuild le css

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
