### PR TITLE
[fix] Completer les codes insee manquants

### DIFF
--- a/programmes/management/commands/check_code_insee_commune.py
+++ b/programmes/management/commands/check_code_insee_commune.py
@@ -11,7 +11,7 @@ from programmes.models import Programme
 
 
 class Command(BaseCommand):
-    help = "Complete the empty code_insee field of the Programme model"
+    help = "Vérifie et corrige les codes INSEE communes des programmes"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/programmes/management/commands/check_code_insee_dpt.py
+++ b/programmes/management/commands/check_code_insee_dpt.py
@@ -1,9 +1,47 @@
 from django.core.management.base import BaseCommand
+from django.db.models import F
+from django.db.models.functions import Left, Length
+
+from programmes.models import Programme
 
 
 class Command(BaseCommand):
     help = "Vérifie et corrige les codes INSEE departementaux"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dryrun",
+            action="store_true",
+            help="Run the command in dry run mode without making any changes",
+        )
+
     def handle(self, *args, **options):
-        pass
-        # TODO: implement this command
+        queryset = (
+            Programme.objects.exclude(code_insee_commune="")
+            .annotate(code_insee_departement_len=Length("code_insee_departement"))
+            .exclude(code_insee_departement_len=3)
+            .annotate(dpt_code_from_insee_commune=Left("code_insee_commune", 2))
+            .exclude(dpt_code_from_insee_commune=F("code_insee_departement"))
+        )
+
+        self.stdout.write(f"Nombre de programmes à corriger: {queryset.count()}")
+
+        for programme in queryset:
+            self.stdout.write(
+                f"Programme {programme.id}, "
+                f"commune: {programme.code_insee_commune}, "
+                f"dpt: {programme.code_insee_departement} => {programme.dpt_code_from_insee_commune}"
+            )
+            if options["dryrun"]:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Dry run: Programme {programme.id} non mis à jour"
+                    )
+                )
+                continue
+
+            programme.code_insee_departement = programme.dpt_code_from_insee_commune
+            programme.save()
+            self.stdout.write(
+                self.style.SUCCESS(f"Programme {programme.id} mis à jour")
+            )

--- a/programmes/management/commands/check_code_insee_dpt.py
+++ b/programmes/management/commands/check_code_insee_dpt.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Vérifie et corrige les codes INSEE departementaux"
+
+    def handle(self, *args, **options):
+        pass
+        # TODO: implement this command

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -171,4 +171,13 @@ extra_code_insee_entries = [
     {"insee_com": "74010", "postal_code": "74370", "nom_comm": "ANNECY"},
     {"insee_com": "19123", "postal_code": "19360", "nom_comm": "MALEMORT"},
     {"insee_com": "59004", "postal_code": "59310", "nom_comm": "AIX EN PEVELE"},
+    {"insee_com": "59526", "postal_code": "59230", "nom_comm": "SAINT AMAND"},
+    {"insee_com": "59586", "postal_code": "59242", "nom_comm": "TEMPLEUVE EN PEVELE"},
+    {"insee_com": "68070", "postal_code": "68350", "nom_comm": "BRUNSTATT DIDENHEIM"},
+    {"insee_com": "76108", "postal_code": "76230", "nom_comm": "BOIS GUILLAUME"},
+    {
+        "insee_com": "78158",
+        "postal_code": "78150",
+        "nom_comm": "LE CHESNAY ROCQUENCOURT",
+    },
 ]

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         self.stdout.write("Chargement du référentiel des codes INSEE...")
         insee_table_by_postal_code, insee_table_by_commune = self._load_code_insee_ref()
 
-        errors_unknown_code_postal = []
+        errors_invalid_code_postal = []
         errors_unknown_commune = []
         errors_multiple_choices = []
 
@@ -105,7 +105,7 @@ class Command(BaseCommand):
                         code_insee_commune=ref_commune_entries[0]["insee_com"],
                     )
                 else:
-                    errors_unknown_code_postal.append(
+                    errors_invalid_code_postal.append(
                         f"Programme {programme.id} (code_postal: {programme.code_postal}, commune: {commune or '???'})"
                     )
                 continue
@@ -134,7 +134,7 @@ class Command(BaseCommand):
                         f"Programme {programme.id} ({programme.code_postal}, {commune})"
                     )
 
-        errors_unknown_code_postal = sorted(list(set(errors_unknown_code_postal)))
+        errors_invalid_code_postal = sorted(list(set(errors_invalid_code_postal)))
         errors_multiple_choices = sorted(list(set(errors_multiple_choices)))
         errors_unknown_commune = sorted(list(set(errors_unknown_commune)))
 
@@ -142,10 +142,10 @@ class Command(BaseCommand):
         self.stdout.write("Résultats:")
         self._print_status()
 
-        if len(errors_unknown_code_postal):
+        if len(errors_invalid_code_postal):
             self.stdout.write(
                 self.style.ERROR(
-                    f"{len(errors_unknown_code_postal)} programmes au code postal inconnu."
+                    f"{len(errors_invalid_code_postal)} programmes avec un code postal erroné."
                 )
             )
 
@@ -165,16 +165,15 @@ class Command(BaseCommand):
 
         if output_dir := options["output_dir"]:
             os.makedirs(output_dir, exist_ok=True)
-            with open(f"{output_dir}/insee_table_by_postal_code.json", "w") as f:
-                f.write(json.dumps(insee_table_by_postal_code, indent=2))
-            with open(f"{output_dir}/insee_table_by_commune.json", "w") as f:
-                f.write(json.dumps(insee_table_by_commune, indent=2))
-            with open(f"{output_dir}/errors_unknown_code_postal.json", "w") as f:
-                f.write(json.dumps(errors_unknown_code_postal, indent=2))
-            with open(f"{output_dir}/errors_multiple_choices.json", "w") as f:
-                f.write(json.dumps(errors_multiple_choices, indent=2))
-            with open(f"{output_dir}/errors_unknown_commune.json", "w") as f:
-                f.write(json.dumps(errors_unknown_commune, indent=2))
+            for var_name in (
+                "insee_table_by_postal_code",
+                "insee_table_by_commune",
+                "errors_invalid_code_postal",
+                "errors_multiple_choices",
+                "errors_unknown_commune",
+            ):
+                with open(f"{output_dir}/{var_name}.json", "w") as f:
+                    f.write(json.dumps(locals()[var_name], indent=2))
             self.stdout.write(f"Données enregistrées dans {output_dir}.")
 
 

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -33,8 +33,9 @@ class Command(BaseCommand):
         for c in ["(", ")", "-", "'"]:
             n_str = n_str.replace(c, " ")
         n_str = re.sub(" +", " ", n_str)
+        n_str = n_str.upper().strip()
         n_str = n_str.replace("ST ", "SAINT ").replace("STE ", "SAINTE ")
-        return n_str.upper()
+        return n_str
 
     def _load_code_insee_ref(self) -> dict[list[dict[str, str]]]:
         """
@@ -180,4 +181,54 @@ extra_code_insee_entries = [
         "postal_code": "78150",
         "nom_comm": "LE CHESNAY ROCQUENCOURT",
     },
+    {"insee_com": "85008", "postal_code": "85430", "nom_comm": "AUBIGNY LES CLOUZEAUX"},
+    {
+        "insee_com": "25368",
+        "postal_code": "25640",
+        "nom_comm": "MARCHAUX CHAUDEFONTAINE",
+    },
+    {
+        "insee_com": "62764",
+        "postal_code": "62223",
+        "nom_comm": "SAINT NICOLAS LEZ ARRAS",
+    },
+    {"insee_com": "31232", "postal_code": "31330", "nom_comm": "GRENADE SUR GARONNE"},
+    {
+        "insee_com": "59588",
+        "postal_code": "59229",
+        "nom_comm": "TETEGHEM COUDEKERQUE VILLAGE",
+    },
+    {"insee_com": "33344", "postal_code": "33350", "nom_comm": "PUJOLS SUR DORDOGNE"},
+    {"insee_com": "59405", "postal_code": "59400", "nom_comm": "MOEUVRES"},
+    {"insee_com": "67372", "postal_code": "67350", "nom_comm": "VAL DE MODER"},
+    {"insee_com": "49200", "postal_code": "49770", "nom_comm": "LONGUENEE EN ANJOU"},
+    {"insee_com": "49200", "postal_code": "49220", "nom_comm": "LONGUENEE EN ANJOU"},
+    {"insee_com": "31277", "postal_code": "31530", "nom_comm": "LASSERRE PRADERE"},
+    {"insee_com": "49301", "postal_code": "49230", "nom_comm": "SEVREMOINE"},
+    {"insee_com": "50292", "postal_code": "50570", "nom_comm": "MARIGNY LE LOZON"},
+    {"insee_com": "01130", "postal_code": "01340", "nom_comm": "BRESSE VALLONS"},
+    {"insee_com": "49023", "postal_code": "49600", "nom_comm": "BEAUPREAU EN MAUGES"},
+    {"insee_com": "39491", "postal_code": "39170", "nom_comm": "COTEAUX DU LIZON"},
+    {"insee_com": "54079", "postal_code": "54700", "nom_comm": "BLENOD LES PAM"},
+    {"insee_com": "28422", "postal_code": "28150", "nom_comm": "LES VILLAGES VOVEENS"},
+    {"insee_com": "30112", "postal_code": "30730", "nom_comm": "FONS OUTRE GARDON"},
+    {"insee_com": "25035", "postal_code": "25870", "nom_comm": "LES AUXONS"},
+    {"insee_com": "24312", "postal_code": "24660", "nom_comm": "SANILHAC"},
+    {"insee_com": "79179", "postal_code": "79320", "nom_comm": "MONCOUTANT SUR SEVRE"},
+    {
+        "insee_com": "41059",
+        "postal_code": "41700",
+        "nom_comm": "LE CONTROIS EN SOLOGNE",
+    },
+    {"insee_com": "76618", "postal_code": "76370", "nom_comm": "PETIT CAUX"},
+    {"insee_com": "53136", "postal_code": "53200", "nom_comm": "LA ROCHE NEUVILLE"},
+    {"insee_com": "86281", "postal_code": "86380", "nom_comm": "SAINT MARTIN LA PALLU"},
+    {
+        "insee_com": "48094",
+        "postal_code": "48500",
+        "nom_comm": "MASSEGROS CAUSSES GORGES",
+    },
+    {"insee_com": "85084", "postal_code": "85140", "nom_comm": "ESSARTS EN BOCAGE"},
+    {"insee_com": "80621", "postal_code": "80320", "nom_comm": "HYPERCOURT"},
+    {"insee_com": "26038", "postal_code": "26600", "nom_comm": "BEAUMONT MONTEUX"},
 ]

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -231,4 +231,12 @@ extra_code_insee_entries = [
     {"insee_com": "85084", "postal_code": "85140", "nom_comm": "ESSARTS EN BOCAGE"},
     {"insee_com": "80621", "postal_code": "80320", "nom_comm": "HYPERCOURT"},
     {"insee_com": "26038", "postal_code": "26600", "nom_comm": "BEAUMONT MONTEUX"},
+    {
+        "insee_com": "28015",
+        "postal_code": "28700",
+        "nom_comm": "AUNEAU BLEURY SAINT SYMPHORIEN",
+    },
+    {"insee_com": "39043", "postal_code": "39190", "nom_comm": "BEAUFORT ORBAGNA"},
+    {"insee_com": "02018", "postal_code": "02320", "nom_comm": "ANIZY LE GRAND"},
+    {"insee_com": "49125", "postal_code": "49700", "nom_comm": "DOUE EN ANJOU"},
 ]

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -1,0 +1,129 @@
+import json
+import os
+import re
+from collections import defaultdict
+
+import requests
+from django.core.management.base import BaseCommand
+
+from core.utils import strip_accents
+from programmes.models import Programme
+
+
+class Command(BaseCommand):
+    help = "Complete the empty code_insee field of the Programme model"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output-dir",
+            type=str,
+            help="Output directory for the generated files",
+            default=None,
+        )
+
+    def _print_status(self):
+        total_count = Programme.objects.count()
+        to_handle_count = Programme.objects.filter(code_insee_commune="").count()
+        self.stdout.write(
+            f"{to_handle_count}/{total_count} programmes sans code insee commune."
+        )
+
+    def _normalize(self, s: str) -> str:
+        n_str = strip_accents(s)
+        for c in ["(", ")", "-", "'"]:
+            n_str = n_str.replace(c, " ")
+        n_str = re.sub(" +", " ", n_str)
+        n_str = n_str.replace("ST ", "SAINT ").replace("STE ", "SAINTE ")
+        return n_str.upper()
+
+    def _load_code_insee_ref(self) -> dict[list[dict[str, str]]]:
+        """
+        Chargement d'un tableau de correspondance code postal / (code INSEE, nom commune)
+        """
+
+        insee_table = defaultdict(list)
+
+        response = requests.get(
+            "https://public.opendatasoft.com/api/explore/v2.1/catalog/datasets/correspondance-code-insee-code-postal/exports/json?lang=fr&timezone=Europe%2FBerlin"
+        )
+        response.raise_for_status()
+
+        for entry in response.json():
+            for postal_code in entry["postal_code"].split("/"):
+                insee_table[postal_code].append(
+                    {
+                        "insee_com": entry["insee_com"],
+                        "nom_comm": self._normalize(entry["nom_comm"]),
+                    }
+                )
+
+        return insee_table
+
+    def handle(self, *args, **options):
+        self._print_status()
+
+        self.stdout.write("Chargement du référentiel des codes INSEE...")
+        insee_table = self._load_code_insee_ref()
+
+        errors_unknown_code_postal = []
+        errors_multiple_choices = []
+
+        self.stdout.write("Processing...")
+        for programme in Programme.objects.filter(code_insee_commune="").exclude(
+            code_postal="", ville=""
+        ):
+            p_code_postal = programme.code_postal or "???"
+            p_commune = self._normalize(programme.ville or "???")
+
+            entries = insee_table.get(p_code_postal, [])
+
+            if not len(entries):
+                errors_unknown_code_postal.append(p_code_postal)
+                continue
+
+            if len(entries) == 1:
+                programme.code_insee_commune = entries[0]["insee_com"]
+                programme.save()
+                continue
+
+            if len(entries) > 1:
+                for entry in entries:
+                    if entry["nom_comm"] == p_commune:
+                        programme.code_insee_commune = entry["insee_com"]
+                        programme.save()
+                        break
+                else:
+                    errors_multiple_choices.append(
+                        f"Programme {programme.id} ({p_code_postal}, {p_commune})"
+                    )
+
+        errors_unknown_code_postal = sorted(list(set(errors_unknown_code_postal)))
+        errors_multiple_choices = sorted(list(set(errors_multiple_choices)))
+
+        self.stdout.write("Traitement terminé.")
+        self.stdout.write("Résultats:")
+        self._print_status()
+
+        if len(errors_unknown_code_postal):
+            self.stdout.write(
+                self.style.ERROR(
+                    f"{len(errors_unknown_code_postal)} codes postaux inconnus par le référentiel."
+                )
+            )
+
+        if len(errors_multiple_choices):
+            self.stdout.write(
+                self.style.ERROR(
+                    f"{len(errors_multiple_choices)} codes postaux avec plusieurs choix possibles."
+                )
+            )
+
+        if output_dir := options["output_dir"]:
+            os.makedirs(output_dir, exist_ok=True)
+            with open(f"{output_dir}/insee_table.json", "w") as f:
+                f.write(json.dumps(insee_table, indent=2))
+            with open(f"{output_dir}/errors_unknown_code_postal.json", "w") as f:
+                f.write(json.dumps(errors_unknown_code_postal, indent=2))
+            with open(f"{output_dir}/errors_multiple_choices.json", "w") as f:
+                f.write(json.dumps(errors_multiple_choices, indent=2))
+            self.stdout.write(f"Données enregistrées dans {output_dir}.")

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -53,17 +53,25 @@ class Command(BaseCommand):
                 insee_table[postal_code].append(
                     {
                         "insee_com": entry["insee_com"],
+                        "postal_code": postal_code,
                         "nom_comm": self._normalize(entry["nom_comm"]),
                     }
                 )
 
         return insee_table
 
+    def _add_missing_code_insee(self, insee_table):
+        insee_table["49150"].append(
+            {"insee_com": "49018", "postal_code": "49150", "nom_comm": "BAUGE EN ANJOU"}
+            # TODO: Add more missing code postal / code INSEE pairs
+        )
+
     def handle(self, *args, **options):
         self._print_status()
 
         self.stdout.write("Chargement du référentiel des codes INSEE...")
         insee_table = self._load_code_insee_ref()
+        self._add_missing_code_insee(insee_table)
 
         errors_unknown_code_postal = []
         errors_multiple_choices = []

--- a/programmes/management/commands/complete_code_insee.py
+++ b/programmes/management/commands/complete_code_insee.py
@@ -61,10 +61,30 @@ class Command(BaseCommand):
         return insee_table
 
     def _add_missing_code_insee(self, insee_table):
-        insee_table["49150"].append(
-            {"insee_com": "49018", "postal_code": "49150", "nom_comm": "BAUGE EN ANJOU"}
+        for entry in [
+            {
+                "insee_com": "49018",
+                "postal_code": "49150",
+                "nom_comm": "BAUGE EN ANJOU",
+            },
+            {
+                "insee_com": "33067",
+                "postal_code": "33710",
+                "nom_comm": "BOURG SUR GIRONDE",
+            },
+            {
+                "insee_com": "49092",
+                "postal_code": "49120",
+                "nom_comm": "CHEMILLE EN ANJOU",
+            },
+            {
+                "insee_com": "24053",
+                "postal_code": "24750",
+                "nom_comm": "BOULAZAC ISLE MANOIRE",
+            },
             # TODO: Add more missing code postal / code INSEE pairs
-        )
+        ]:
+            insee_table[entry["postal_code"]].append(entry)
 
     def handle(self, *args, **options):
         self._print_status()

--- a/programmes/management/commands/fix_programme_communes.py
+++ b/programmes/management/commands/fix_programme_communes.py
@@ -19,6 +19,18 @@ class Command(BaseCommand):
             "saint remy les chevreuses": "Saint-Rémy-lès-Chevreuse",
             "isle sur la sorgue": "L'Isle-sur-la-Sorgue",
             "conde sur escaut": "Condé-sur-l'Escaut",
+            "libo": "Libourne",
+            "les molettes": "Les Mollettes",
+            "NEUF": "Neufchâtel-Hardelot",
+            "SAINT-CHRISOPHE DE DOUBLE": "Saint-Christophe-de-Double",
+            "SAN MARINA DI LOTA": "Santa-Maria-di-Lota",
+            "LAMBRES LES DOUAI": "LAMBRES LEZ DOUAI",
+            "CHAU": "Chaumont",
+            "NANTEUIL LE HAUDOIN": "NANTEUIL LE HAUDOUIN",
+            "ST LEU DESSERENT": "Saint-Leu-d'Esserent",
+            "SAINT PANTALEON DE L ARCHE": "SAINT PANTALEON DE LARCHE",
+            "STIRING WENEL": "STIRING WENDEL",
+            "SAINT-JUSTE-IBARRE": "Saint-Just-Ibarre",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k)
             if count := queryset.count():
@@ -32,11 +44,43 @@ class Command(BaseCommand):
             "gournay sur aronde": "60190",
             "seclin": "59113",
             "wittelsheim": "68310",
-            "billy berclau": "62138",
+            "billy-berclau": "62138",
             "vaux-sur-seine": "78740",
             "mignovillard": "39250",
+            "Aubigny-Les Clouzeaux": "85430",
+            "Enghien-les-Bains": "95880",
+            "pontoise les noyon": "60400",
+            "Puget-sur-Argens": "83480",
+            "Pontault-Combault": "77340",
+            "Ferney-Voltaire": "01210",
+            "coursan": "11110",
+            "ARNAC POMPADOUR": "19230",
+            "Morangis": "91420",
+            "FERRALS-LES-CORBIERES": "11200",
+            "Les Sorinières": "44840",
+            "La Gorgue": "59253",
+            "BARBY": "73230",
+            "Houlbec-Cocherel": "27120",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k).exclude(code_postal=v)
             if count := queryset.count():
                 self.stdout.write(f"{count} codes postaux mis à jour pour '{k}'")
                 queryset.update(code_postal=v)
+
+        # problème avec le "œ"
+        Programme.objects.filter(ville="Annœullin").update(code_insee_commune="59112")
+        Programme.objects.filter(ville="Crèvecœur le grand").update(
+            code_insee_commune="60178"
+        )
+
+        # Cournon existe aussi, mais dans le morbihan
+        Programme.objects.filter(pk__in=(644694, 644695)).update(
+            ville="Cournon-d'Auvergne"
+        )
+
+        # Divers, unitaires
+        Programme.objects.filter(pk=34847).update(code_postal="76600")
+        Programme.objects.filter(pk=647779).update(code_postal="02120")
+        Programme.objects.filter(pk=651951).update(
+            code_postal="18190", code_insee_commune="18270"
+        )

--- a/programmes/management/commands/fix_programme_communes.py
+++ b/programmes/management/commands/fix_programme_communes.py
@@ -31,6 +31,7 @@ class Command(BaseCommand):
             "SAINT PANTALEON DE L ARCHE": "SAINT PANTALEON DE LARCHE",
             "STIRING WENEL": "STIRING WENDEL",
             "SAINT-JUSTE-IBARRE": "Saint-Just-Ibarre",
+            "BOUSSIERE SUR SAMBRE": "BOUSSIERES SUR SAMBRE",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k)
             if count := queryset.count():
@@ -61,6 +62,10 @@ class Command(BaseCommand):
             "La Gorgue": "59253",
             "BARBY": "73230",
             "Houlbec-Cocherel": "27120",
+            "Bazoges-en-Paillers": "85130",
+            "Barr": "67140",
+            "Faches-Thumesnil": "59155",
+            "Beaumont-Monteux": "26600",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k).exclude(code_postal=v)
             if count := queryset.count():
@@ -83,4 +88,13 @@ class Command(BaseCommand):
         Programme.objects.filter(pk=647779).update(code_postal="02120")
         Programme.objects.filter(pk=651951).update(
             code_postal="18190", code_insee_commune="18270"
+        )
+        Programme.objects.filter(pk=651951).update(code_insee_commune="49125")
+        Programme.objects.filter(pk__in=(38830, 38831)).update(
+            code_insee_commune="50550"
+        )
+        Programme.objects.filter(pk=33185).update(code_insee_commune="49377")
+        Programme.objects.filter(pk=38847).update(code_insee_commune="50487")
+        Programme.objects.filter(pk=643940).update(
+            code_postal="77310", code_insee_commune="77407"
         )

--- a/programmes/management/commands/fix_programme_communes.py
+++ b/programmes/management/commands/fix_programme_communes.py
@@ -9,16 +9,33 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for k, v in {
             "croisille": "Croisilles",
-            "lamballe ARMOR": "Lamballe",
             "capavenir vosges": "Thaon-les-Vosges",
             "le luc en provence": "Le Luc",
+            "guesnain coron sans beurre": "Guesnain",
+            "hoodschoote": "Hondschoote",
+            "chamamont": "Chalamont",
+            "le viviers du lac": "Viviers-du-Lac",
+            "mesnil en thelle": "Le Mesnil-en-Thelle",
+            "saint remy les chevreuses": "Saint-Rémy-lès-Chevreuse",
+            "isle sur la sorgue": "L'Isle-sur-la-Sorgue",
+            "conde sur escaut": "Condé-sur-l'Escaut",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k)
             if count := queryset.count():
-                self.stdout.write(f"{count} noms de villes mis à jour pour '{k}'")
+                self.stdout.write(f"{count} noms de ville mis à jour pour '{v}'")
                 queryset.update(ville=v)
 
-        for k, v in {"biot": "06410"}.items():
+        for k, v in {
+            "biot": "06410",
+            "maing": "59233",
+            "vaux sur seine": "78740",
+            "gournay sur aronde": "60190",
+            "seclin": "59113",
+            "wittelsheim": "68310",
+            "billy berclau": "62138",
+            "vaux-sur-seine": "78740",
+            "mignovillard": "39250",
+        }.items():
             queryset = Programme.objects.filter(ville__iexact=k).exclude(code_postal=v)
             if count := queryset.count():
                 self.stdout.write(f"{count} codes postaux mis à jour pour '{k}'")

--- a/programmes/management/commands/fix_programme_communes.py
+++ b/programmes/management/commands/fix_programme_communes.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+
+from programmes.models import Programme
+
+
+class Command(BaseCommand):
+    help = "Fix communes names"
+
+    def handle(self, *args, **options):
+        for k, v in {
+            "croisille": "Croisilles",
+            "lamballe ARMOR": "Lamballe",
+            "capavenir vosges": "Thaon-les-Vosges",
+        }.items():
+            queryset = Programme.objects.filter(ville__iexact=k)
+            if count := queryset.count():
+                self.stdout.write(f"{count} noms de villes mis à jour pour '{k}'")
+                queryset.update(ville=v)
+
+        for k, v in {"biot": "06410"}.items():
+            queryset = Programme.objects.filter(ville__iexact=k)
+            if count := queryset.count():
+                self.stdout.write(f"{count} codes postaux mis à jour pour '{k}'")
+                queryset.update(code_postal=v)

--- a/programmes/management/commands/fix_programme_communes.py
+++ b/programmes/management/commands/fix_programme_communes.py
@@ -11,6 +11,7 @@ class Command(BaseCommand):
             "croisille": "Croisilles",
             "lamballe ARMOR": "Lamballe",
             "capavenir vosges": "Thaon-les-Vosges",
+            "le luc en provence": "Le Luc",
         }.items():
             queryset = Programme.objects.filter(ville__iexact=k)
             if count := queryset.count():
@@ -18,7 +19,7 @@ class Command(BaseCommand):
                 queryset.update(ville=v)
 
         for k, v in {"biot": "06410"}.items():
-            queryset = Programme.objects.filter(ville__iexact=k)
+            queryset = Programme.objects.filter(ville__iexact=k).exclude(code_postal=v)
             if count := queryset.count():
                 self.stdout.write(f"{count} codes postaux mis à jour pour '{k}'")
                 queryset.update(code_postal=v)


### PR DESCRIPTION
# Description succincte du problème résolu

Nouvelle commande django pour compléter les code insee manquants dans les programmes.

Après une première passe, j'ai encore des code insee manquants:

```bash
239/593754 programmes sans code insee commune.
12 programmes avec un code postal erroné.
226 programmes sans nom de commune.
1 programmes avec plusieurs choix possibles.
```


## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :

```bash
python manage.py fix_programme_communes
python manage.py check_code_insee_commune --output-dir=/tmp/apilos_insee
python manage.py check_code_insee_dpt
```
