### PR TITLE
Afficher les pièces jointe d'une convention dans l'admin et permettre de les supprimer

### DIFF
--- a/conventions/admin.py
+++ b/conventions/admin.py
@@ -1,10 +1,13 @@
 from django import forms
 from django.contrib import admin
-from django.contrib.admin import ChoicesFieldListFilter
+from django.contrib.admin import ChoicesFieldListFilter, TabularInline
+from django.urls import reverse
+from django.utils.html import format_html
 
 from admin.admin import ApilosModelAdmin
 from admin.filters import IsCloneFilter
 from conventions.models.choices import ConventionStatut
+from conventions.models.piece_jointe import PieceJointe
 
 from .models import AvenantType, Convention, Pret
 
@@ -60,6 +63,39 @@ class ConventionModelForm(forms.ModelForm):
 @admin.display(description="Numero d'opération")
 def view_programme_operation(convention):
     return convention.programme.numero_operation
+
+
+class PieceJointeInline(TabularInline):
+    model = PieceJointe
+    extra = 0
+
+    readonly_fields = fields = (
+        "id",
+        "uuid",
+        "type",
+        "fichier_link",
+        "nom_reel",
+        "description",
+        "cree_le",
+    )
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    def has_change_permission(self, request, obj):
+        return False
+
+    def has_delete_permission(self, request, obj):
+        return True
+
+    def fichier_link(self, obj):
+        if obj.fichier:
+            return format_html(
+                '<a href="{}" target="_blank">{}</a>',
+                reverse("conventions:piece_jointe", args=[obj.uuid]),
+                obj.fichier,
+            )
+        return "-"
 
 
 @admin.register(Convention)
@@ -132,6 +168,7 @@ class ConventionAdmin(ApilosModelAdmin):
     )
 
     form = ConventionModelForm
+    inlines = [PieceJointeInline]
 
     @admin.display(description="Lot")
     def lot(self, obj):

--- a/conventions/models/piece_jointe.py
+++ b/conventions/models/piece_jointe.py
@@ -1,6 +1,10 @@
+import logging
 import uuid
 
+from django.core.files.storage import default_storage
 from django.db import models
+
+logger = logging.getLogger(__name__)
 
 
 class PieceJointeType(models.TextChoices):
@@ -43,3 +47,8 @@ class PieceJointe(models.Model):
             return self.type == PieceJointeType.AVENANT
 
         return self.type == PieceJointeType.CONVENTION
+
+    def delete(self, *args, **kwargs):
+        if self.fichier:
+            default_storage.delete(self.fichier)
+        super().delete(*args, **kwargs)


### PR DESCRIPTION
# Description succincte du problème résolu

Lien Mattermost : [Supprimer PJ d'une convention](https://mattermost.incubateur.net/fabnum-mte/pl/7i3ykmg7gpggmqry6wpt6ysbrh)

## ⚠️ Attention : la suppression est définitive, pas de retour en arrière possible.

Dans l'admin django, afficher les pièces jointe d'écoloweb et permettre de supprimer celle-ci

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
