### PR TITLE
[fix] Un utilisateur en lecture seule ne peut pas cocher un bloc d'avenant

### DIFF
--- a/templates/conventions/common/avenants_checkboxes.html
+++ b/templates/conventions/common/avenants_checkboxes.html
@@ -1,4 +1,4 @@
-{% if convention.is_avenant %}
+{% if convention.is_avenant and not request|is_readonly %}
     <div class="fr-toggle apilos-toggle-block">
         <form action="{% if checked %}{% url 'conventions:recapitulatif' convention_uuid=convention.uuid %}{% else %}{% url 'conventions:new_avenant' convention_uuid=convention.uuid %}{% endif %}" method="post">
             {% csrf_token %}


### PR DESCRIPTION
# Description succincte du problème résolu

[Airtable](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recwPMMPiS0qp1x29?blocks=hide)

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [x] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

Faker un utilisateur avec les droits en lecture seule et vérifier que les bloc ne sont plus accessibles.


