### PR TITLE
Fix habilitations linebreaks

### DIFF
--- a/static/css/ui_siap.css
+++ b/static/css/ui_siap.css
@@ -12,9 +12,10 @@
 .fr-nav__btn[aria-current].orange-background,
 .fr-nav__btn[aria-current].orange-background:hover,
 .fr-nav__btn[aria-current].orange-background:hover a {
-  background-color: #ff6f4c;
+  background-color: #e4794a;
   color: #fff;
   text-decoration: none;
+  width: 100%;
 }
 .fr-nav__btn[aria-current].orange-background::after {
   margin-left: auto;

--- a/templates/layout/siap/habilitations.html
+++ b/templates/layout/siap/habilitations.html
@@ -1,9 +1,9 @@
 <button class="fr-nav__btn orange-background" aria-expanded="false" aria-controls="list-habilitation" aria-current="true">
     {% for habilitation in request.session.habilitations %}
         {% if habilitation.id == request.session.habilitation_id %}
-            {% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}
+            {% if habilitation.entete %}{{ habilitation.entete }}{% else %}{{ habilitation.groupe.libelleRole }}{% endif %}<br>
             {% if habilitation.sousTitre1 %}
-                {{ habilitation.sousTitre1 }}
+                {{ habilitation.sousTitre1 }}<br>
             {% endif %}
             {% if habilitation.sousTitre2 %}
                 {{ habilitation.sousTitre2 }}


### PR DESCRIPTION
Mon précédent fix de l'apparence des habilitations fonctionnait quand l'utilisateur avait au moins une habilitation assez longue pour que tout se cale bien.

Ici je corrige les autres cas en assurant la non régression des précédents.

J'en profite pour uniformiser la couleur de fond avec le SIAP.

Cas court avant
![Capture d’écran 2025-03-19 à 09 50 21](https://github.com/user-attachments/assets/f6af352b-e683-4359-9986-4df563933c87)

Cas court après
![Capture d’écran 2025-03-19 à 09 53 47](https://github.com/user-attachments/assets/ab61ce98-548d-4f59-9837-63c3b7d6ab22)


Cas long avant
![Capture d’écran 2025-03-19 à 09 49 06](https://github.com/user-attachments/assets/40a6624f-222d-4875-9413-3d113199dc83)

Cas long après 
![Capture d’écran 2025-03-19 à 09 42 47](https://github.com/user-attachments/assets/f2760c3f-26eb-4048-97e4-aa083400ccb0)


