### PR TITLE
Enable gestion délégataires for staff users

### DIFF
--- a/templates/common/form/disable_form_input.html
+++ b/templates/common/form/disable_form_input.html
@@ -1,6 +1,6 @@
 {% load custom_filters %}
 
-{% if request|is_readonly %}
+{% if request|is_readonly and not bypass_readonly %}
     disabled data-readonly="true"
 {% elif comments and parent_object_field %}
     {% if not editable and comments|hasnt_active_comments:parent_object_field %}disabled{% endif %}

--- a/templates/settings/delegataires/form.html
+++ b/templates/settings/delegataires/form.html
@@ -4,7 +4,7 @@
     <h4>Gestion des délégataires</h4>
     <form method="post" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        {% include "common/form/input_select.html" with form_input=form.administration without_empty_option=form.administration.field.choices|length_is:1 %}
+        {% include "common/form/input_select.html" with form_input=form.administration without_empty_option=form.administration.field.choices|length_is:1 bypass_readonly=request.user.is_staff %}
         <script type="text/javascript" nonce="{{ request.csp_nonce }}">
             document.addEventListener('DOMContentLoaded', function () {
                 VirtualSelect.init({
@@ -17,7 +17,7 @@
                 });
             });
         </script>
-        {% include "common/form/input_select.html" with form_input=form.departement editable=True required=False %}
+        {% include "common/form/input_select.html" with form_input=form.departement editable=True required=False bypass_readonly=request.user.is_staff %}
         <div id='download_upload_block'>
             {% include "common/form/download_upload_form.html" with file_type='communes' upform=form what='communes' file_field_label='commune' %}
         </div>


### PR DESCRIPTION
# Description succincte du problème résolu

Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/ztjoz1cqaiyi984py7wimar4go

J'ai besoin d'accéder à l'interface de gestion des délégataires en production, mais le readonly m'en empêche comme je suis lecteur national. Ici j'introduis un bypass utilisé uniquement sur l'interface gestion des délégataires.

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
