### PR TITLE
Allow to comment logements tables in avenants

### DIFF
--- a/static/js/comment-factory.js
+++ b/static/js/comment-factory.js
@@ -409,9 +409,9 @@ class CommentFactory {
       // specific, pourrait être passé en callback
       if (
         (parent_parent.tagName == "TR" || parent_parent.tagName == "TH") &&
-        document.getElementById("download_upload_block") !== null
+        document.querySelectorAll('[id^="download_upload_block"]').length > 0
       ) {
-        document.getElementById("download_upload_block").hidden = false;
+        document.querySelectorAll('[id^="download_upload_block"]').forEach((e) => e.hidden = false);
       }
       if (document.getElementById("save_after_comments") !== null) {
         document.getElementById("save_after_comments").hidden = false;
@@ -439,8 +439,8 @@ class CommentFactory {
           }
         }
         if (this.empty_toggle_on.tagName == "TR") {
-          if (document.getElementById("download_upload_block") !== null) {
-            document.getElementById("download_upload_block").hidden = false;
+          if (document.querySelectorAll('[id^="download_upload_block"]').length > 0) {
+            document.querySelectorAll('[id^="download_upload_block"]').forEach((e) => e.hidden = false);
           }
         }
       }
@@ -454,9 +454,9 @@ class CommentFactory {
       comment_icon.hidden = false;
       if (
         (parent_parent.tagName == "TR" || parent_parent.tagName == "TH") &&
-        document.getElementById("download_upload_block") !== null
+        document.querySelectorAll('[id^="download_upload_block"]').length > 0
       ) {
-        document.getElementById("download_upload_block").hidden = false;
+        document.querySelectorAll('[id^="download_upload_block"]').forEach((e) => e.hidden = false);
       }
       if (this.empty_toggle_on) {
         this.empty_toggle_on.onclick = null;
@@ -474,9 +474,9 @@ class CommentFactory {
       comment_icon.hidden = false;
       if (
         (parent_parent.tagName == "TR" || parent_parent.tagName == "TH") &&
-        document.getElementById("download_upload_block") !== null
+        document.querySelectorAll('[id^="download_upload_block"]').length > 0
       ) {
-        document.getElementById("download_upload_block").hidden = false;
+        document.querySelectorAll('[id^="download_upload_block"]').forEach((e) => e.hidden = false);
       }
       // NOT APPLICABLE FOR GLOBAL COMMENT
       if (this.empty_toggle_on) {

--- a/templates/conventions/common/formset_logements.html
+++ b/templates/conventions/common/formset_logements.html
@@ -42,7 +42,7 @@
                         <thead>
                             <tr>
                                 {% if convention|display_comments %}
-                                    {% include 'common/utils/comments_header.html' with object_name='logement' label='Logements' %}
+                                    {% include 'common/utils/comments_header.html' with object_name=file_type label=formset_title %}
                                 {% endif %}
                                 <th scope="col" class="col__width--200">
                                     Désignation

--- a/templates/conventions/recapitulatif/logements.html
+++ b/templates/conventions/recapitulatif/logements.html
@@ -126,7 +126,7 @@
                                                 <thead>
                                                     <tr>
                                                         {% if convention|display_comments %}
-                                                            {% include 'common/utils/comments_header.html' with object_name='logement' label='Logements' callback_click="refresh_opened_comments" %}
+                                                            {% include 'common/utils/comments_header.html' with object_name='logements_sans_loyer' label='Logements sans loyer' callback_click="refresh_opened_comments" %}
                                                         {% endif %}
                                                         <th scope="col" class="col__width--150">Désignation {% include "common/form/required_field_star.html" %}</th>
                                                         <th scope="col" class="col__width--120">Type {% include "common/form/required_field_star.html" %}</th>
@@ -197,7 +197,7 @@
                                                 <thead>
                                                     <tr>
                                                         {% if convention|display_comments %}
-                                                            {% include 'common/utils/comments_header.html' with object_name='logement' label='Logements' callback_click="refresh_opened_comments" %}
+                                                            {% include 'common/utils/comments_header.html' with object_name='logements_corrigee' label='Logements en surface corrigée' callback_click="refresh_opened_comments" %}
                                                         {% endif %}
                                                         <th scope="col" class="col__width--150">Désignation {% include "common/form/required_field_star.html" %}</th>
                                                         <th scope="col" class="col__width--120">Type {% include "common/form/required_field_star.html" %}</th>
@@ -275,7 +275,7 @@
                                                 <thead>
                                                     <tr>
                                                         {% if convention|display_comments %}
-                                                            {% include 'common/utils/comments_header.html' with object_name='logement' label='Logements' callback_click="refresh_opened_comments" %}
+                                                            {% include 'common/utils/comments_header.html' with object_name='logements_corrigee_sans_loyer' label='Logements en surface corrigée sans loyer' callback_click="refresh_opened_comments" %}
                                                         {% endif %}
                                                         <th scope="col" class="col__width--150">Désignation {% include "common/form/required_field_star.html" %}</th>
                                                         <th scope="col" class="col__width--120">Type {% include "common/form/required_field_star.html" %}</th>


### PR DESCRIPTION
 Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/pyinz11hajn13bj539xhsye1nh

Il y a de la logique js pour rendre le tableau de logement editable lorsque l'on commente
Je rends la logique plus générique pour marcher quand il y a 4 tableaux

Point pénible : ça rend les 4 editables si un seul est commenté. Il y a surement moyen d'améliorer mais je pense que ça suffit comme ça pour débloquer les utilisateurs

