### PR TITLE
Add commentaire on identification bailleur

### DIFF
--- a/comments/models.py
+++ b/comments/models.py
@@ -174,6 +174,9 @@ class Comment(models.Model):
             "convention__gestionnaire_signataire_bloc_signature": (
                 "Bloc signature du gestionnaire"
             ),
+            "convention__identification_bailleur": (
+                "Identification personalisée du bailleur"
+            ),
             "convention__attribution_inclusif_conditions_specifiques": (
                 "Conditions spécifiques d'accueil"
             ),

--- a/templates/conventions/_bailleur_signataire.html
+++ b/templates/conventions/_bailleur_signataire.html
@@ -7,14 +7,19 @@
 {% block content %}
     <div class="fr-col-12">
         {% if convention.programme.is_logements_ordinaires %}
-            <div class="fr-toggle fr-mb-2w">
-                <input type="checkbox" {% if form.identification_bailleur.value %}checked="checked"{% endif %} class="fr-toggle__input" aria-describedby="{{ form.identification_bailleur.html_name }}-messages" id="{{ form.identification_bailleur.html_name }}" name="{{ form.identification_bailleur.html_name }}"{% include "common/form/disable_form_input.html" %}>
-                <label class="fr-toggle__label" for="{{ form.identification_bailleur.html_name }}">{{ form.identification_bailleur.label }}</label>
-                <div class="fr-messages-group" id="{{ form.identification_bailleur.html_name }}-messages" aria-live="polite"></div>
-            </div>
-            <div class="identification_bailleur_detail_outer_div fr-mb-2w">
-                {% include "common/form/input_textarea.html" with mandatory_input=True form_input=form.identification_bailleur_detail editable=True helptext_visible=True %}
-            </div>
+            {% with convention_uuid=convention.uuid|slugify %}
+                {% with object_field="convention__identification_bailleur__"|add:convention_uuid %}
+                    <div class="fr-toggle fr-mb-2w">
+                        <input type="checkbox" {% if form.identification_bailleur.value %}checked="checked"{% endif %} class="fr-toggle__input" aria-describedby="{{ form.identification_bailleur.html_name }}-messages" id="{{ form.identification_bailleur.html_name }}" name="{{ form.identification_bailleur.html_name }}"{% include "common/form/disable_form_input.html" %}>
+                        <label class="fr-toggle__label" for="{{ form.identification_bailleur.html_name }}">{{ form.identification_bailleur.label }}</label>
+                        <div class="fr-messages-group" id="{{ form.identification_bailleur.html_name }}-messages" aria-live="polite"></div>
+                    </div>
+                    <div class="identification_bailleur_detail_outer_div fr-mb-2w">
+                        {% include "common/form/input_textarea.html" with mandatory_input=True form_input=form.identification_bailleur_detail editable=True helptext_visible=True %}
+                    </div>
+                    {% include "common/utils/comments_field.html" %}
+                {% endwith %}
+            {% endwith %}
         {% endif %}
 
         <div class="signataire_infos">

--- a/templates/conventions/recapitulatif/bailleur.html
+++ b/templates/conventions/recapitulatif/bailleur.html
@@ -36,7 +36,7 @@
                 <p class="fr-my-1w"><strong>Signataire de la convention</strong>{% if convention.programme.is_foyer or convention.programme.is_residence %} (Propriétaire){% endif %}</p>
                 <div class="fr-ml-3w">
                     {% if convention.identification_bailleur %}
-                        {% include "common/display_field_if_exists.html" with label="Identification personalisée du bailleur" value=convention.identification_bailleur_detail object_field="convention__identification_bailleur_detail__"|add:convention_uuid %}
+                        {% include "common/display_field_if_exists.html" with label="Identification personalisée du bailleur" value=convention.identification_bailleur_detail object_field="convention__identification_bailleur__"|add:convention_uuid %}
                     {% else %}
                         {% if convention.signataire_nom %}
                             {% include "common/display_field_if_exists.html" with value=convention.signataire_nom object_field="bailleur__signataire_nom__"|add:bailleur_uuid %}


### PR DESCRIPTION
Lien Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/uoxtsbyoipdrmjrkxyffsh5gze

L'identification du bailleur n'était pas éditable en commentaire. Le commentaire sur un champ permet en fait d'en éditer deux (la checkbox + le text area) d'où la balise "with" qui englobe les deux champs


![Capture d’écran 2025-05-16 à 09 14 20](https://github.com/user-attachments/assets/477ed633-528d-46b2-838b-c5056f7d45c0)
![Capture d’écran 2025-05-16 à 09 14 29](https://github.com/user-attachments/assets/955c17e1-cffa-4881-9d3f-b6b10115d118)