### PR TITLE
Fix fusion bailleur in siap client

### DIFF
--- a/siap/siap_client/client.py
+++ b/siap/siap_client/client.py
@@ -317,19 +317,16 @@ class SIAPClientRemote(SIAPClientInterface):
             return response.json()
         raise SIAPException(UNAUTHORIZED_MESSAGE)
 
-    @validate_response()
+    @validate_response(error_message=FUSION_MESSAGE)
     def get_fusion(
         self, user_login: str, habilitation_id: int, bailleur_siren: str
     ) -> list:
-        response = _call_siap_api(
+        return _call_siap_api(
             f"/journalisation-fusion?siren={bailleur_siren}",
             base_route="/services/operation",
             user_login=user_login,
             habilitation_id=habilitation_id,
         )
-        if response.status_code >= 200 and response.status_code < 300:
-            return response.json()
-        raise SIAPException(FUSION_MESSAGE + f" : {response.content}")
 
     @validate_response(error_message="user can't access alertes")
     def list_alertes(


### PR DESCRIPTION
# Description succincte du problème résolu

La plateforme intégration envoie un message d'erreur dès qu'on est connecté en tant que bailleur.

Le client SIAP a été refacto pour les alertes et il y a eu un soucis de rebase au niveau du endpoint de fusion, ce qui trigger une erreur systématiquement.

