### PR TITLE
Fix upload when alerts are disabled

### DIFF
--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -62,6 +62,10 @@ def scan_uploaded_files(
                     switch_is_active(settings.SWITCH_SIAP_ALERTS_ON)
                     and siap_credentials
                 ):
+                    if not convention_uuid:
+                        raise Exception(
+                            "/upload should be called with a convention parameter"
+                        )
                     convention = Convention.objects.get(uuid=convention_uuid)
                     alerte = Alerte.from_convention(
                         convention=convention,

--- a/upload/views.py
+++ b/upload/views.py
@@ -34,7 +34,7 @@ def _get_convention_uuid_from_request(request):
     if "convention" in request.POST:
         convention_uuid = request.POST["convention"]
     else:
-        raise Exception("/upload path should be called with a convention parameter")
+        return None
     return convention_uuid
 
 


### PR DESCRIPTION
# Description succincte du problème résolu

Mattermost : https://mattermost.incubateur.net/fabnum-mte/pl/saaexoew3iftzx7se9juh5gzqr

Problème à l'upload d'objets qui ne sont pas rattachés à la convention mais au lot ou au programme.
Cette PR fait en sorte que l'erreur n'arrive que lorsque le flag des alertes est activé, pour rapidement corriger en production