### PR TITLE
Alert virus: pass convention uuid to upload

### DIFF
--- a/static/js/dropzone-client.js
+++ b/static/js/dropzone-client.js
@@ -3,9 +3,11 @@ function init_dropzone_from_file(form_id, accepted_files, singleFile = false) {
     csrf_token = document.getElementsByName('csrfmiddlewaretoken')[0].value
     object_name = document.getElementById(form_id + "_object_name").value
     object_uuid = document.getElementById(form_id + "_object_uuid").value
+    convention_uuid = document.getElementById(form_id + "_convention_uuid").value
 
     parameters = {}
     parameters[object_name] = object_uuid
+    parameters[convention_uuid] = convention_uuid
 
     let accepted_images = 'image/jpeg,image/png,image/gif,image/bmp,image/webp,image/tiff,image/heif,image/heic'
     let accepted_documents = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'

--- a/templates/common/form/input_upload.html
+++ b/templates/common/form/input_upload.html
@@ -91,7 +91,10 @@
                 type="hidden"
                 id="{{ form_input_files.id_for_label }}_object_uuid"
                 value="{{ object_uuid }}">
-
+            <input
+                type="hidden"
+                id="{{ form_input_files.id_for_label }}_convention_uuid"
+                value="{{ convention_uuid }}">
             <script type="text/javascript" nonce="{{ request.csp_nonce }}">
                 {
                     let formId = "{{ form_input_files.id_for_label }}";

--- a/templates/conventions/cadastre.html
+++ b/templates/conventions/cadastre.html
@@ -134,17 +134,17 @@
                             <p class="notes">
                                 <em>Pour toutes les sections ci-dessous, vous avez la possibilité de renseigner les champs en saisissant les informations ou en téléversant des images.</em>
                             </p>
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.vendeur form_input_files=form.vendeur_files object_name='programme' object_uuid=convention.programme.uuid textarea=True image_only=True file_list=convention.programme.vendeur|get_files_from_textfiles object_field="programme__vendeur__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.vendeur form_input_files=form.vendeur_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.programme.vendeur|get_files_from_textfiles object_field="programme__vendeur__"|add:form.uuid.value %}
 
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.acquereur form_input_files=form.acquereur_files object_name='programme' object_uuid=convention.programme.uuid textarea=True image_only=True file_list=convention.programme.acquereur|get_files_from_textfiles object_field="programme__acquereur__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.acquereur form_input_files=form.acquereur_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.programme.acquereur|get_files_from_textfiles object_field="programme__acquereur__"|add:form.uuid.value %}
 
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_notaire form_input_files=form.reference_notaire_files object_name='programme' object_uuid=convention.programme.uuid textarea=True image_only=True file_list=convention.programme.reference_notaire|get_files_from_textfiles object_field="programme__reference_notaire__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_notaire form_input_files=form.reference_notaire_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.programme.reference_notaire|get_files_from_textfiles object_field="programme__reference_notaire__"|add:form.uuid.value %}
 
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_publication_acte form_input_files=form.reference_publication_acte_files object_name='programme' object_uuid=convention.programme.uuid textarea=True image_only=True file_list=convention.programme.reference_publication_acte|get_files_from_textfiles object_field="programme__reference_publication_acte__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_publication_acte form_input_files=form.reference_publication_acte_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.programme.reference_publication_acte|get_files_from_textfiles object_field="programme__reference_publication_acte__"|add:form.uuid.value %}
                         </div>
                         <div class="apilos--p-relative">
                             <a href="https://www.cadastre.gouv.fr" target="_blank" class="fr-link apilos--right-top" rel="noreferrer">Vérifier mes informations sur cadastre.gouv.fr</a>
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_cadastrale form_input_files=form.reference_cadastrale_files object_name='programme' object_uuid=convention.programme.uuid image_only=True file_list=convention.programme.reference_cadastrale|get_files_from_textfiles object_field="programme__reference_cadastrale__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.reference_cadastrale form_input_files=form.reference_cadastrale_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid image_only=True file_list=convention.programme.reference_cadastrale|get_files_from_textfiles object_field="programme__reference_cadastrale__"|add:form.uuid.value %}
                         </div>
                         <div id='download_upload_block' {% if not editable %}hidden{% endif %}>
                             {% include "common/form/download_upload_form.html" with file_type='cadastre' upform=upform what="références cadastrales" file_field_label='cadastre' %}
@@ -220,7 +220,7 @@
                             </div>
                         </div>
                         <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-my-2w">
-                            {% include "common/form/input_upload.html" with single_file=False form_input=form.effet_relatif form_input_files=form.effet_relatif_files object_name='programme' object_uuid=convention.programme.uuid image_only=True file_list=convention.programme.effet_relatif|get_files_from_textfiles object_field="programme__effet_relatif__"|add:form.uuid.value %}
+                            {% include "common/form/input_upload.html" with single_file=False form_input=form.effet_relatif form_input_files=form.effet_relatif_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid image_only=True file_list=convention.programme.effet_relatif|get_files_from_textfiles object_field="programme__effet_relatif__"|add:form.uuid.value %}
                         </div>
                         <div class="apilos-bordered fr-my-3w">
                             <p class="notes">
@@ -229,10 +229,10 @@
 
                             <div class="fr-grid-row fr-grid-row--gutters">
                                 <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                    {% include "common/form/input_upload.html" with single_file=False form_input=form.acte_de_propriete form_input_files=form.acte_de_propriete_files object_name='programme' object_uuid=convention.programme.uuid file_list=convention.programme.acte_de_propriete|get_files_from_textfiles object_field="programme__acte_de_propriete__"|add:form.uuid.value %}
+                                    {% include "common/form/input_upload.html" with single_file=False form_input=form.acte_de_propriete form_input_files=form.acte_de_propriete_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid file_list=convention.programme.acte_de_propriete|get_files_from_textfiles object_field="programme__acte_de_propriete__"|add:form.uuid.value %}
                                 </div>
                                 <div class="fr-col-12 fr-col-md-12 fr-col-lg-6 fr-mb-2w">
-                                    {% include "common/form/input_upload.html" with single_file=False form_input=form.certificat_adressage form_input_files=form.certificat_adressage_files object_name='programme' object_uuid=convention.programme.uuid file_list=convention.programme.certificat_adressage|get_files_from_textfiles object_field="programme__certificat_adressage__"|add:form.uuid.value %}
+                                    {% include "common/form/input_upload.html" with single_file=False form_input=form.certificat_adressage form_input_files=form.certificat_adressage_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid file_list=convention.programme.certificat_adressage|get_files_from_textfiles object_field="programme__certificat_adressage__"|add:form.uuid.value %}
                                 </div>
                             </div>
                         </div>

--- a/templates/conventions/common/form_commentaires.html
+++ b/templates/conventions/common/form_commentaires.html
@@ -4,7 +4,7 @@
     <div class="fr-col-md-12">
 
         {% if convention.programme.is_foyer or convention.programme.is_residence %}
-            {% include "common/form/input_upload.html" with single_file=False form_input=form.attached form_input_files=form.attached_files object_name='convention' object_uuid=convention.uuid file_list=convention.attached|get_files_from_textfiles textarea=False object_field="convention__attached__"|add:form.uuid.value %}
+            {% include "common/form/input_upload.html" with single_file=False form_input=form.attached form_input_files=form.attached_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=convention.attached|get_files_from_textfiles textarea=False object_field="convention__attached__"|add:form.uuid.value %}
         {% endif %}
 
 
@@ -13,7 +13,7 @@
                 <em>Ces informations sont complémentaires et à destination de l’instructeur. Elles ne figureront pas dans le document final de la convention.</em>
             </p>
             {% with is_bailleur=request|is_bailleur %}
-                {% include "common/form/input_upload.html" with single_file=False form_input=form.commentaires form_input_files=form.commentaires_files object_name='convention' object_uuid=convention.uuid file_list=convention.commentaires|get_files_from_textfiles textarea=True verticalDisplay=True object_field="convention__commentaires__"|add:form.uuid.value editable=is_bailleur %}
+                {% include "common/form/input_upload.html" with single_file=False form_input=form.commentaires form_input_files=form.commentaires_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=convention.commentaires|get_files_from_textfiles textarea=True verticalDisplay=True object_field="convention__commentaires__"|add:form.uuid.value editable=is_bailleur %}
             {% endwith %}
         </div>
     </div>

--- a/templates/conventions/denonciation.html
+++ b/templates/conventions/denonciation.html
@@ -32,7 +32,7 @@
                     {% include "common/form/input_textarea.html" with form_input=form.motif_denonciation object_field="convention__motif_denonciation__"|add:form.uuid.value %}
                 </div>
                 <div class="fr-col-12 fr-mb-4w">
-                    {% include "common/form/input_upload.html" with single_file=False form_input=form.fichier_instruction_denonciation form_input_files=form.fichier_instruction_denonciation_files object_name='convention' object_uuid=convention.uuid file_list=convention.fichier_instruction_denonciation|get_files_from_textfiles object_field="convention__fichier_instruction_denonciation__"|add:form.uuid.value %}
+                    {% include "common/form/input_upload.html" with single_file=False form_input=form.fichier_instruction_denonciation form_input_files=form.fichier_instruction_denonciation_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=convention.fichier_instruction_denonciation|get_files_from_textfiles object_field="convention__fichier_instruction_denonciation__"|add:form.uuid.value %}
                 </div>
                 {% include "conventions/common/form_footer_button.html" %}
             </div>

--- a/templates/conventions/edd.html
+++ b/templates/conventions/edd.html
@@ -114,15 +114,15 @@
                         <hr>
                         {% comment %} TODO: reverse relation convention lot {% endcomment %}
 
-                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_volumetrique form_input_files=form.edd_volumetrique_files object_name='lot' object_uuid=convention.lot.uuid textarea=True image_only=True file_list=convention.lot.edd_volumetrique|get_files_from_textfiles object_field="lot__edd_volumetrique__"|add:form.lot_uuid.value %}
+                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_volumetrique form_input_files=form.edd_volumetrique_files object_name='lot' object_uuid=convention.lot.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.lot.edd_volumetrique|get_files_from_textfiles object_field="lot__edd_volumetrique__"|add:form.lot_uuid.value %}
 
                         {% include "common/form/input_textarea.html" with form_input=form.mention_publication_edd_volumetrique object_field="programme__mention_publication_edd_volumetrique__"|add:form.uuid.value %}
                         <hr>
-                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_classique form_input_files=form.edd_classique_files object_name='lot' object_uuid=convention.lot.uuid textarea=True image_only=True file_list=convention.lot.edd_classique|get_files_from_textfiles object_field="lot__edd_classique__"|add:form.lot_uuid.value %}
+                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_classique form_input_files=form.edd_classique_files object_name='lot' object_uuid=convention.lot.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.lot.edd_classique|get_files_from_textfiles object_field="lot__edd_classique__"|add:form.lot_uuid.value %}
 
                         {% include "common/form/input_textarea.html" with form_input=form.mention_publication_edd_classique object_field="programme__mention_publication_edd_classique__"|add:form.uuid.value %}
                         <hr>
-                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_stationnements form_input_files=form.edd_stationnements_files object_name='programme' object_uuid=convention.programme.uuid textarea=True image_only=True file_list=convention.programme.edd_stationnements|get_files_from_textfiles object_field="programme__edd_stationnements__"|add:form.uuid.value %}
+                        {% include "common/form/input_upload.html" with single_file=False form_input=form.edd_stationnements form_input_files=form.edd_stationnements_files object_name='programme' object_uuid=convention.programme.uuid convention_uuid=convention.uuid textarea=True image_only=True file_list=convention.programme.edd_stationnements|get_files_from_textfiles object_field="programme__edd_stationnements__"|add:form.uuid.value %}
                     </div>
                 </div>
 

--- a/templates/conventions/finalisation/cerfa.html
+++ b/templates/conventions/finalisation/cerfa.html
@@ -42,7 +42,7 @@
                     </div>
                     <form id="cerfa-form" method="post" action="{% url 'conventions:finalisation_cerfa' convention_uuid=convention.uuid %}" data-turbo="false">
                         {% csrf_token %}
-                        {% include "common/form/input_upload.html" with form_input=form.fichier_override_cerfa form_input_files=form.fichier_override_cerfa_files object_name='convention' single_file=True override_cerfa=True no_title=True object_uuid=convention.uuid file_list=convention.fichier_override_cerfa|get_files_from_textfiles object_field="convention__fichier_override_cerfa__"|add:form.uuid.value %}
+                        {% include "common/form/input_upload.html" with form_input=form.fichier_override_cerfa form_input_files=form.fichier_override_cerfa_files object_name='convention' convention_uuid=convention.uuid single_file=True override_cerfa=True no_title=True object_uuid=convention.uuid file_list=convention.fichier_override_cerfa|get_files_from_textfiles object_field="convention__fichier_override_cerfa__"|add:form.uuid.value %}
                     </form>
                 </div>
             </section>

--- a/templates/conventions/journal.html
+++ b/templates/conventions/journal.html
@@ -33,7 +33,7 @@
                                 </div>
                                 <div class="fr-col-12 fr-mb-4w">
                                     <label class="fr-label">Ajouter un fichier (optionnel)</label>
-                                    {% include "common/form/input_upload.html" with single_file=False no_title=True form_input=form.pieces_jointes form_input_files=form.pieces_jointes_files object_name='convention' object_uuid=convention.uuid file_list=evenement.pieces_jointes|get_files_from_textfiles object_field="evenement__pieces_jointes__"|add:form.uuid.value %}
+                                    {% include "common/form/input_upload.html" with single_file=False no_title=True form_input=form.pieces_jointes form_input_files=form.pieces_jointes_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=evenement.pieces_jointes|get_files_from_textfiles object_field="evenement__pieces_jointes__"|add:form.uuid.value %}
                                 </div>
                                 <div class="fr-grid-row fr-grid-row--right">
                                     <div class="fr-mr-4w fr-mt-1w">
@@ -80,7 +80,7 @@
                                         </div>
                                         <div class="fr-col-12 fr-mb-4w">
                                             <label class="fr-label">Ajouter des fichiers (optionnel)</label>
-                                            {% include "common/form/input_upload.html" with single_file=False no_title=True form_input=form.pieces_jointes form_input_files=form.pieces_jointes_files object_name='convention' object_uuid=convention.uuid file_list=evenement.pieces_jointes|get_files_from_textfiles object_field="evenement__pieces_jointes__"|add:form.uuid.value %}
+                                            {% include "common/form/input_upload.html" with single_file=False no_title=True form_input=form.pieces_jointes form_input_files=form.pieces_jointes_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=evenement.pieces_jointes|get_files_from_textfiles object_field="evenement__pieces_jointes__"|add:form.uuid.value %}
                                         </div>
                                     </div>
                                     <div class="fr-grid-row fr-grid-row--right">

--- a/templates/conventions/resiliation.html
+++ b/templates/conventions/resiliation.html
@@ -19,7 +19,7 @@
                     {% include "common/form/input_textarea.html" with form_input=form.motif_resiliation object_field="convention__motif_resiliation__"|add:form.uuid.value %}
                 </div>
                 <div class="fr-col-12 fr-mb-4w">
-                    {% include "common/form/input_upload.html" with single_file=False form_input=form.commentaires form_input_files=form.commentaires_files object_name='convention' object_uuid=convention.uuid file_list=convention.commentaires|get_files_from_textfiles textarea=True verticalDisplay=True object_field="convention__commentaires__"|add:form.uuid.value %}
+                    {% include "common/form/input_upload.html" with single_file=False form_input=form.commentaires form_input_files=form.commentaires_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=convention.commentaires|get_files_from_textfiles textarea=True verticalDisplay=True object_field="convention__commentaires__"|add:form.uuid.value %}
                 </div>
                 {% include "conventions/common/form_footer_button.html" %}
             </div>

--- a/templates/conventions/resiliation_acte.html
+++ b/templates/conventions/resiliation_acte.html
@@ -11,7 +11,7 @@
             {% csrf_token %}
             <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
                 <div class="fr-col-12 fr-mb-4w">
-                    {% include "common/form/input_upload.html" with single_file=False form_input=form.fichier_instruction_resiliation form_input_files=form.fichier_instruction_resiliation_files object_name='convention' object_uuid=convention.uuid file_list=convention.fichier_instruction_resiliation|get_files_from_textfiles object_field="convention__fichier_instruction_resiliation__"|add:form.uuid.value %}
+                    {% include "common/form/input_upload.html" with single_file=False form_input=form.fichier_instruction_resiliation form_input_files=form.fichier_instruction_resiliation_files object_name='convention' object_uuid=convention.uuid convention_uuid=convention.uuid file_list=convention.fichier_instruction_resiliation|get_files_from_textfiles object_field="convention__fichier_instruction_resiliation__"|add:form.uuid.value %}
                 </div>
                 {% include "conventions/common/form_footer_button.html" %}
             </div>

--- a/upload/tasks.py
+++ b/upload/tasks.py
@@ -64,7 +64,7 @@ def scan_uploaded_files(
                 ):
                     if not convention_uuid:
                         raise Exception(
-                            "/upload should be called with a convention parameter"
+                            "/upload should be called with a convention_uuid parameter"
                         )
                     convention = Convention.objects.get(uuid=convention_uuid)
                     alerte = Alerte.from_convention(

--- a/upload/views.py
+++ b/upload/views.py
@@ -30,14 +30,6 @@ def _compute_dirpath(request):
     return f"{object_name}/{uuid}/media/"
 
 
-def _get_convention_uuid_from_request(request):
-    if "convention" in request.POST:
-        convention_uuid = request.POST["convention"]
-    else:
-        return None
-    return convention_uuid
-
-
 @require_GET
 def display_file(request, convention_uuid, uploaded_file_uuid):
     uploaded_file = UploadedFile.objects.get(uuid=uploaded_file_uuid)
@@ -78,7 +70,7 @@ def upload_file(request):
         uploaded_files.append(UploadedFileSerializer(uploaded_file).data)
 
     scan_uploaded_files.delay(
-        _get_convention_uuid_from_request(request),
+        request.POST.get("convention_uuid"),
         paths_to_scan,
         request.user.id,
         get_siap_credentials_from_request(request),


### PR DESCRIPTION
# Description succincte du problème résolu

(Pas bloquant en production car derrière un flag)
Le `/upload` ne fonctinonne pas quand l'objet uploadé n'est pas une convention. On a besoin de la convention à chaque fois maintenant pour envoyer la notification, même si l'objet est rattaché à un programme ou un lot. 

https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recmRgIYdlBeKRIae?blocks=hide