### PR TITLE
Delete action alerts

### DIFF
--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -286,6 +286,8 @@ def convention_submit(request: HttpRequest, convention: Convention):
         )
 
         if switch_is_active(settings.SWITCH_SIAP_ALERTS_ON):
+            siap_credentials = get_siap_credentials_from_request(request)
+            utils.delete_action_alertes(convention, siap_credentials)
             create_alertes_instruction(convention, request)
 
         if not switch_is_active(settings.SWITCH_TRANSACTIONAL_EMAILS_OFF):
@@ -445,6 +447,8 @@ def convention_feedback(request: HttpRequest, convention: Convention):
     if notification_form.is_valid():
 
         if switch_is_active(settings.SWITCH_SIAP_ALERTS_ON):
+            siap_credentials = get_siap_credentials_from_request(request)
+            utils.delete_action_alertes(convention, siap_credentials)
             create_alertes_correction(
                 request=request,
                 convention=convention,

--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -288,7 +288,7 @@ def convention_submit(request: HttpRequest, convention: Convention):
         if switch_is_active(settings.SWITCH_SIAP_ALERTS_ON):
             siap_credentials = get_siap_credentials_from_request(request)
             utils.delete_action_alertes(convention, siap_credentials)
-            create_alertes_instruction(convention, request)
+            create_alertes_instruction(convention, siap_credentials)
 
         if not switch_is_active(settings.SWITCH_TRANSACTIONAL_EMAILS_OFF):
             send_email_instruction(
@@ -359,9 +359,9 @@ def collect_instructeur_emails(
     return instructeur_emails, submitted
 
 
-def create_alertes_instruction(convention: Convention, request: HttpRequest):
-    siap_credentials = get_siap_credentials_from_request(request)
-
+def create_alertes_instruction(
+    convention: Convention, siap_credentials: dict[str, Any]
+):
     redirect_url = reverse("conventions:recapitulatif", args=[convention.uuid])
 
     # Send an information notice to bailleurs
@@ -450,8 +450,8 @@ def convention_feedback(request: HttpRequest, convention: Convention):
             siap_credentials = get_siap_credentials_from_request(request)
             utils.delete_action_alertes(convention, siap_credentials)
             create_alertes_correction(
-                request=request,
                 convention=convention,
+                siap_credentials=siap_credentials,
                 from_instructeur=notification_form.cleaned_data["from_instructeur"],
             )
 
@@ -497,7 +497,9 @@ def convention_feedback(request: HttpRequest, convention: Convention):
     }
 
 
-def create_alertes_correction(request, convention, from_instructeur):
+def create_alertes_correction(
+    convention: Convention, siap_credentials: dict[str, Any], from_instructeur: bool
+):
     redirect_url = reverse("conventions:recapitulatif", args=[convention.uuid])
     if from_instructeur:
         destinataires_information = [Destinataire(role="INSTRUCTEUR", service="SG")]
@@ -531,7 +533,7 @@ def create_alertes_correction(request, convention, from_instructeur):
     )
     SIAPClient.get_instance().create_alerte(
         payload=alerte.to_json(),
-        **get_siap_credentials_from_request(request),
+        **siap_credentials,
     )
 
     # Send action notice
@@ -545,8 +547,7 @@ def create_alertes_correction(request, convention, from_instructeur):
         url_direction=redirect_url,
     )
     SIAPClient.get_instance().create_alerte(
-        payload=alerte.to_json(),
-        **get_siap_credentials_from_request(request),
+        payload=alerte.to_json(), **siap_credentials
     )
 
 

--- a/conventions/services/utils.py
+++ b/conventions/services/utils.py
@@ -192,14 +192,12 @@ def convention_upload_filename(convention: Convention) -> str:
 
 def _can_delete_action_alerte(alerte, destinataire):
     if destinataire == "MO":
-        for dest in alerte["destinataires"]:
-            if dest["codeProfil"] == "MO_PERS_MORALE":
-                return True
+        return any(
+            dest["codeProfil"] == "MO_PERS_MORALE" for dest in alerte["destinataires"]
+        )
 
     if destinataire == "SG":
-        for dest in alerte["destinataires"]:
-            if dest["codeProfil"] == "SER_GEST":
-                return True
+        return any(dest["codeProfil"] == "SER_GEST" for dest in alerte["destinataires"])
 
     return destinataire is None
 

--- a/conventions/services/utils.py
+++ b/conventions/services/utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 from enum import Enum
 
@@ -7,7 +8,11 @@ from django.http import HttpRequest
 from conventions.models import Convention, ConventionStatut
 from conventions.templatetags.custom_filters import is_bailleur, is_instructeur
 from core.utils import is_valid_uuid
+from siap.exceptions import SIAPException
+from siap.siap_client.client import SIAPClient
 from upload.models import UploadedFile
+
+logger = logging.getLogger(__name__)
 
 
 def format_date_for_form(date):
@@ -183,3 +188,43 @@ def convention_upload_filename(convention: Convention) -> str:
     parts.append(datetime.now().strftime("%Y-%m-%d_%H-%M"))
 
     return f"{'_'.join(parts)}.pdf"
+
+
+def _can_delete_action_alerte(alerte, destinataire):
+    if destinataire == "MO":
+        for dest in alerte["destinataires"]:
+            if dest["codeProfil"] == "MO_PERS_MORALE":
+                return True
+
+    if destinataire == "SG":
+        for dest in alerte["destinataires"]:
+            if dest["codeProfil"] == "SER_GEST":
+                return True
+
+    return destinataire is None
+
+
+def delete_action_alertes(convention, siap_credentials, destinataire=None):
+    """
+    Delete all action alertes related to the convention
+    """
+    client = SIAPClient.get_instance()
+    alertes = client.list_convention_alertes(
+        convention_id=convention.uuid, **siap_credentials
+    )
+    for alerte in alertes:
+
+        if alerte["categorie"] != "CATEGORIE_ALERTE_ACTION":
+            continue
+
+        can_delete = _can_delete_action_alerte(alerte, destinataire)
+
+        if can_delete:
+            try:
+                client.delete_alerte(
+                    user_login=siap_credentials["user_login"],
+                    habilitation_id=siap_credentials["habilitation_id"],
+                    alerte_id=alerte["id"],
+                )
+            except SIAPException as e:
+                logger.warning(e)

--- a/conventions/tasks.py
+++ b/conventions/tasks.py
@@ -19,6 +19,7 @@ from conventions.services.convention_generator import (
     get_tmp_local_path,
 )
 from conventions.services.file import ConventionFileService
+from conventions.services.utils import delete_action_alertes
 from conventions.templatetags.display_filters import (
     display_gender_terminaison,
     display_kind,
@@ -142,6 +143,7 @@ def task_send_email_to_bailleur(  # noqa: C901
         return
 
     if switch_is_active(settings.SWITCH_SIAP_ALERTS_ON):
+        delete_action_alertes(convention, siap_credentials)
         create_alertes_valide(
             convention=convention,
             siap_credentials=siap_credentials,
@@ -178,7 +180,7 @@ def create_alertes_valide(convention, siap_credentials):
     alerte = Alerte.from_convention(
         convention=convention,
         # Pas sûr on a mis information / action sur le doc
-        categorie_information="CATEGORIE_ALERTE_INFORMATION",
+        categorie_information="CATEGORIE_ALERTE_ACTION",
         destinataires=[
             Destinataire(role="INSTRUCTEUR", service="MO"),
         ],

--- a/conventions/tests/services/test_recapitulatif_service.py
+++ b/conventions/tests/services/test_recapitulatif_service.py
@@ -25,7 +25,6 @@ from programmes.models import Programme
 from siap.exceptions import SIAPException
 from siap.siap_client.client import SIAPClient
 from users.models import User
-from users.tests.factories import UserFactory
 from users.type_models import EmailPreferences
 
 
@@ -93,16 +92,14 @@ def test_create_alertes_valide():
 def test_create_alertes_instruction():
     convention = ConventionFactory()
     avenant = ConventionFactory(parent_id=convention.id)
-    request = RequestFactory().get("/")
-    user = UserFactory()
-    request.user = user
-    user.cerbere_login = 1
-    request.session = {"habilitation_id": "001"}
+    siap_credentials = {"habilitation_id": "001", "user_login": 1}
 
     with patch.object(SIAPClient, "get_instance") as mock_get_instance:
         mock_client = MagicMock()
         mock_get_instance.return_value = mock_client
-        recapitulatif.create_alertes_instruction(request=request, convention=convention)
+        recapitulatif.create_alertes_instruction(
+            convention=convention, siap_credentials=siap_credentials
+        )
         mock_client.create_alerte.assert_called()
         payload_bailleur = json.loads(
             mock_client.create_alerte.mock_calls[0].kwargs["payload"]
@@ -130,7 +127,9 @@ def test_create_alertes_instruction():
             "conventions:recapitulatif", args=[convention.uuid]
         )
 
-        recapitulatif.create_alertes_instruction(request=request, convention=avenant)
+        recapitulatif.create_alertes_instruction(
+            convention=avenant, siap_credentials=siap_credentials
+        )
         payload_bailleur = json.loads(
             mock_client.create_alerte.mock_calls[2].kwargs["payload"]
         )
@@ -145,16 +144,15 @@ def test_create_alertes_instruction():
 def test_create_alertes_correction_from_instructeur():
     convention = ConventionFactory()
     avenant = ConventionFactory(parent_id=convention.id)
-    request = RequestFactory().get("/")
-    user = UserFactory()
-    request.user = user
-    user.cerbere_login = 1
-    request.session = {"habilitation_id": "001"}
+    siap_credentials = {"habilitation_id": "001", "user_login": 1}
+
     with patch.object(SIAPClient, "get_instance") as mock_get_instance:
         mock_client = MagicMock()
         mock_get_instance.return_value = mock_client
         recapitulatif.create_alertes_correction(
-            request=request, convention=convention, from_instructeur=True
+            convention=convention,
+            siap_credentials=siap_credentials,
+            from_instructeur=True,
         )
         mock_client.create_alerte.assert_called()
 
@@ -188,7 +186,7 @@ def test_create_alertes_correction_from_instructeur():
         )
 
         recapitulatif.create_alertes_correction(
-            request=request, convention=avenant, from_instructeur=True
+            convention=avenant, siap_credentials=siap_credentials, from_instructeur=True
         )
         payload_information = json.loads(
             mock_client.create_alerte.mock_calls[2].kwargs["payload"]
@@ -204,16 +202,15 @@ def test_create_alertes_correction_from_instructeur():
 def test_create_alertes_correction_from_bailleur():
     convention = ConventionFactory()
     avenant = ConventionFactory(parent_id=convention.id)
-    request = RequestFactory().get("/")
-    user = UserFactory()
-    request.user = user
-    user.cerbere_login = 1
-    request.session = {"habilitation_id": "001"}
+    siap_credentials = {"habilitation_id": "001", "user_login": 1}
+
     with patch.object(SIAPClient, "get_instance") as mock_get_instance:
         mock_client = MagicMock()
         mock_get_instance.return_value = mock_client
         recapitulatif.create_alertes_correction(
-            request=request, convention=convention, from_instructeur=False
+            convention=convention,
+            siap_credentials=siap_credentials,
+            from_instructeur=False,
         )
         mock_client.create_alerte.assert_called()
 
@@ -244,7 +241,9 @@ def test_create_alertes_correction_from_bailleur():
         assert payload_action["categorieInformation"] == "CATEGORIE_ALERTE_ACTION"
 
         recapitulatif.create_alertes_correction(
-            request=request, convention=avenant, from_instructeur=False
+            convention=avenant,
+            siap_credentials=siap_credentials,
+            from_instructeur=False,
         )
         payload_information = json.loads(
             mock_client.create_alerte.mock_calls[2].kwargs["payload"]

--- a/conventions/tests/services/test_recapitulatif_service.py
+++ b/conventions/tests/services/test_recapitulatif_service.py
@@ -33,7 +33,7 @@ from users.type_models import EmailPreferences
 def test_create_alertes_valide():
     convention = ConventionFactory()
     avenant = ConventionFactory(parent_id=convention.id)
-    siap_credentials = {"habilitation_id": "001", "cerbere_login": 1}
+    siap_credentials = {"habilitation_id": "001", "user_login": 1}
 
     with patch.object(SIAPClient, "get_instance") as mock_get_instance:
         mock_client = MagicMock()
@@ -52,9 +52,7 @@ def test_create_alertes_valide():
         assert (
             payload_bailleur["etiquettePersonnalisee"] == "Convention validée à signer"
         )
-        assert (
-            payload_bailleur["categorieInformation"] == "CATEGORIE_ALERTE_INFORMATION"
-        )
+        assert payload_bailleur["categorieInformation"] == "CATEGORIE_ALERTE_ACTION"
 
         assert payload_bailleur["urlDirection"] == reverse(
             "conventions:preview", args=[convention.uuid]


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Airtable https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recPrJKGCRWGcq4NX?blocks=hide

Suppression des alertes action lors des changements de statut
Il me reste l'alerte de convention  à signer -> je compte le faire en même temps que l'ajout de la nouvelle alerte lorsque les deux parties ont signées

Je préfère faire la PR tout de suite pour tester en intégration
