### PR TITLE
Proposer la fiche CAF dès le statut «À signer»

### DIFF
--- a/templates/conventions/actions/fiche_caf.html
+++ b/templates/conventions/actions/fiche_caf.html
@@ -1,0 +1,19 @@
+<div class="fr-col-12">
+    <div class="fr-mb-2w block--row-strech">
+        <div class="block--row-strech-1 fr-my-2w">
+            <p class="fr-alert__title">
+                Générer la fiche CAF
+            </p>
+            <p class="fr-mb-0">
+                La fiche CAF sera générée en format docx et téléchargée automatiquement.
+            </p>
+        </div>
+        <form action="{% url 'conventions:fiche_caf' convention_uuid=convention.uuid %}">
+            {% csrf_token %}
+            <button class="fr-btn fr-btn--secondary fr-my-1w fr-icon-download-line fr-btn--icon-left">
+                Générer la fiche CAF
+            </button>
+        </form>
+    </div>
+</div>
+<hr>

--- a/templates/conventions/post_action.html
+++ b/templates/conventions/post_action.html
@@ -90,25 +90,7 @@
                 </div>
                 <hr>
             {% endif %}
-            <div class="fr-col-12">
-                <div class="fr-mb-2w block--row-strech">
-                    <div class="block--row-strech-1 fr-my-2w">
-                        <p class="fr-alert__title">
-                            Générer la fiche CAF
-                        </p>
-                        <p class="fr-mb-0">
-                            La fiche CAF sera générée en format docx et téléchargée automatiquement.
-                        </p>
-                    </div>
-                    <form action="{% url 'conventions:fiche_caf' convention_uuid=convention.uuid %}">
-                        {% csrf_token %}
-                        <button class="fr-btn fr-btn--secondary fr-my-1w fr-icon-download-line fr-btn--icon-left">
-                            Générer la fiche CAF
-                        </button>
-                    </form>
-                </div>
-            </div>
-            <hr>
+            {% include "conventions/actions/fiche_caf.html" %}
             <div class="fr-col-12">
                 <div class="fr-mb-2w block--row-strech">
                     <div class="block--row-strech-1 fr-my-2w">

--- a/templates/conventions/sent.html
+++ b/templates/conventions/sent.html
@@ -10,6 +10,7 @@
         {% include "common/nav_bar.html" with nav_bar_step="sent" %}
         <div class="fr-container fr-py-5w">
             {% include "conventions/actions/upload_signed_document.html" %}
+            {% include "conventions/actions/fiche_caf.html" %}
             {% include "conventions/actions/back_to_instruction.html" %}
         </div>
     </div>


### PR DESCRIPTION
# Description succincte du problème résolu

Carte Airtable : [Proposer la fiche CAF dès le statut "À signer"](https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwDAEFTTtrDtmrWs/recJ1XDtPOlU38hE2?blocks=hide)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
