### PR TITLE
Clear le fichier signé au retour à l'instruction

### DIFF
--- a/conventions/services/recapitulatif.py
+++ b/conventions/services/recapitulatif.py
@@ -263,6 +263,7 @@ def convention_submit(request: HttpRequest, convention: Convention):
             user=request.user,
         ).save()
         convention.statut = ConventionStatut.INSTRUCTION.label
+        convention.nom_fichier_signe = None
         convention.save()
         submitted = utils.ReturnStatus.ERROR
     # Submit the convention to the instruction


### PR DESCRIPTION
Lien Slack : https://plateforme-siap.slack.com/archives/C096JK9UH19/p1753196720898249

Corrige un problème de prévisualisation : le document signé apparaissait quand on passait du statut "validé" à "instruction" puis à "à signer". C'est un cas qui nécessite de clear `nom_fichier_signe` pour éviter d'afficher ce dernier plus tard.
