### PR TITLE
Don't send alertes when admin is DDT

### DIFF
--- a/conventions/services/alertes.py
+++ b/conventions/services/alertes.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 from django.urls import reverse
@@ -37,6 +38,9 @@ class AlerteService:
         self.convention = convention
         self.siap_credentials = siap_credentials
 
+    def _is_ddt(self):
+        return bool(re.match(r"^DD\d+$", self.convention.programme.administration.code))
+
     def delete_action_alertes(self):
         """
         Delete all action alertes related to the convention
@@ -60,6 +64,8 @@ class AlerteService:
                 logger.warning(e)
 
     def create_alertes_instruction(self):
+        if self._is_ddt():
+            return
         redirect_url = reverse("conventions:recapitulatif", args=[self.convention.uuid])
 
         # Send an information notice to bailleurs
@@ -97,6 +103,8 @@ class AlerteService:
         )
 
     def create_alertes_correction(self, from_instructeur: bool):
+        if self._is_ddt():
+            return
         redirect_url = reverse("conventions:recapitulatif", args=[self.convention.uuid])
         if from_instructeur:
             destinataires_information = [ALERTE_DESTINATAIRE_SG]
@@ -148,6 +156,8 @@ class AlerteService:
         )
 
     def create_alertes_valide(self):
+        if self._is_ddt():
+            return
         redirect_url = reverse("conventions:preview", args=[self.convention.uuid])
 
         # Information notice to bailleurs
@@ -188,6 +198,8 @@ class AlerteService:
         )
 
     def create_alertes_signed(self):
+        if self._is_ddt():
+            return
         redirect_url = reverse("conventions:preview", args=[self.convention.uuid])
         alerte = Alerte.from_convention(
             convention=self.convention,

--- a/conventions/tests/services/test_alertes.py
+++ b/conventions/tests/services/test_alertes.py
@@ -5,7 +5,8 @@ import pytest
 from django.urls import reverse
 
 from conventions.services.alertes import ALERTE_CATEGORY_MAPPING, AlerteService
-from core.tests.factories import ConventionFactory
+from core.tests.factories import ConventionFactory, ProgrammeFactory
+from instructeurs.tests.factories import AdministrationFactory
 from siap.siap_client.client import SIAPClient
 
 
@@ -271,3 +272,17 @@ def test_delete_action_alertes(alerte_service):
 
         mock_client.delete_alerte.assert_called_once()
         assert mock_client.delete_alerte.mock_calls[0].kwargs["alerte_id"] == 1
+
+
+@pytest.mark.parametrize(
+    "admin_code, expected",
+    [("DD068", True), ("DDI068", False), ("69123", False), ("CG031", False)],
+)
+@pytest.mark.django_db
+def test_is_ddt(siap_credentials, admin_code, expected):
+    admin = AdministrationFactory(code=admin_code)
+    programme = ProgrammeFactory(administration=admin)
+    convention = ConventionFactory(programme=programme)
+    service = AlerteService(convention=convention, siap_credentials=siap_credentials)
+
+    assert service._is_ddt() == expected


### PR DESCRIPTION
Lien Slack : https://plateforme-siap.slack.com/archives/C096JK9UH19/p1753367576157559

Les alertes fails sur les admin en code DDXXX.
Ca bloque les utilisateurs, pour l'instant je propose de désactiver les alertes pour ces administrations qui ne sont pas gérées par le siap.

