### PR TITLE
Remove workaround to not send alerts to ddt

### DIFF
--- a/conventions/services/alertes.py
+++ b/conventions/services/alertes.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from typing import Any
 
 from django.urls import reverse
@@ -38,9 +37,6 @@ class AlerteService:
         self.convention = convention
         self.siap_credentials = siap_credentials
 
-    def _is_ddt(self):
-        return bool(re.match(r"^DD\d+$", self.convention.programme.administration.code))
-
     def delete_action_alertes(self):
         """
         Delete all action alertes related to the convention
@@ -64,8 +60,6 @@ class AlerteService:
                 logger.warning(e)
 
     def create_alertes_instruction(self):
-        if self._is_ddt():
-            return
         redirect_url = reverse("conventions:recapitulatif", args=[self.convention.uuid])
 
         # Send an information notice to bailleurs
@@ -107,8 +101,6 @@ class AlerteService:
             logger.error(e)
 
     def create_alertes_correction(self, from_instructeur: bool):
-        if self._is_ddt():
-            return
         redirect_url = reverse("conventions:recapitulatif", args=[self.convention.uuid])
         if from_instructeur:
             destinataires_information = [ALERTE_DESTINATAIRE_SG]
@@ -166,8 +158,6 @@ class AlerteService:
             logger.error(e)
 
     def create_alertes_valide(self):
-        if self._is_ddt():
-            return
         redirect_url = reverse("conventions:preview", args=[self.convention.uuid])
 
         # Information notice to bailleurs
@@ -214,8 +204,6 @@ class AlerteService:
             logger.error(e)
 
     def create_alertes_signed(self):
-        if self._is_ddt():
-            return
         redirect_url = reverse("conventions:preview", args=[self.convention.uuid])
         alerte = Alerte.from_convention(
             convention=self.convention,

--- a/conventions/tests/services/test_alertes.py
+++ b/conventions/tests/services/test_alertes.py
@@ -5,8 +5,7 @@ import pytest
 from django.urls import reverse
 
 from conventions.services.alertes import ALERTE_CATEGORY_MAPPING, AlerteService
-from core.tests.factories import ConventionFactory, ProgrammeFactory
-from instructeurs.tests.factories import AdministrationFactory
+from core.tests.factories import ConventionFactory
 from siap.siap_client.client import SIAPClient
 
 
@@ -310,17 +309,3 @@ def test_delete_action_alertes(alerte_service):
 
         mock_client.delete_alerte.assert_called_once()
         assert mock_client.delete_alerte.mock_calls[0].kwargs["alerte_id"] == 1
-
-
-@pytest.mark.parametrize(
-    "admin_code, expected",
-    [("DD068", True), ("DDI068", False), ("69123", False), ("CG031", False)],
-)
-@pytest.mark.django_db
-def test_is_ddt(siap_credentials, admin_code, expected):
-    admin = AdministrationFactory(code=admin_code)
-    programme = ProgrammeFactory(administration=admin)
-    convention = ConventionFactory(programme=programme)
-    service = AlerteService(convention=convention, siap_credentials=siap_credentials)
-
-    assert service._is_ddt() == expected


### PR DESCRIPTION
Suppression du workaround qui évitait les erreurs 500 sur les DDT.
Maintenant les erreurs sont catch donc ce n'est plus bloquant, et on va migrer les DDT vers DDI à court terme.