### PR TITLE
fix nature logement updating when codeFamilleMO is missing.

### DIFF
--- a/siap/siap_client/utils.py
+++ b/siap/siap_client/utils.py
@@ -183,9 +183,11 @@ def get_or_create_bailleur(bailleur_from_siap: dict):
         },
     )
     # Workaround waiting fix on SIAP Side :
-    # https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwarZ7MJFl9MSfsi/recuXwXkRXzvssine?blocks=hide
-    if not is_created and bailleur.nature_bailleur != _get_nature_bailleur(
-        bailleur_from_siap
+    # https://airtable.com/appqEzValO6eQoHbM/tblNIOUJttSKoH866/viwarZ7MJFl9MSfsi/recuXwXkRXzvssine?blocks=hide*
+    if (
+        "codeFamilleMO" in bailleur_from_siap
+        and not is_created
+        and bailleur.nature_bailleur != _get_nature_bailleur(bailleur_from_siap)
     ):
         bailleur.nature_bailleur = _get_nature_bailleur(bailleur_from_siap)
         bailleur.save()


### PR DESCRIPTION
Problème : Suite à la modification de la nature du MO  VILOGIA LOGIFIM 890924251 par l'équipe assistance.
Celle-ci reste instable , en effet ,l'utilisatrice signale que la nature actuelle dans APILOS est Autres bailleurs sociaux non HLM .
Il faudrait renseigner HLM.
capture écran utilisatrice

ticket du support Slack : https://plateforme-siap.slack.com/archives/C096JK9UH19/p1754042336393009

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
