### PR TITLE
Avenants creation: exclude spf fields

### DIFF
--- a/conventions/models/convention.py
+++ b/conventions/models/convention.py
@@ -627,6 +627,12 @@ class Convention(models.Model):
                 "soumis_le",
                 "televersement_convention_signee_le",
                 "valide_le",
+                "date_publication_spf",
+                "reference_spf",
+                "date_envoi_spf",
+                "date_refus_spf",
+                "motif_refus_spf",
+                "nom_fichier_publication_spf",
             ],
         ) | {
             "programme": cloned_programme,


### PR DESCRIPTION
On copiait les informations du spf à la création d'avenant, alors que celles-ci sont spécifiques à l'avenant