### PR TITLE
Correction de l'affichage notifiant les environnement autre que la production

### DIFF
--- a/templates/layout/header.html
+++ b/templates/layout/header.html
@@ -1,13 +1,8 @@
 {% load custom_filters static %}
 <header role="banner" class="fr-header">
-    {% if ENVIRONMENT == 'staging' %}
+    {% if ENVIRONMENT != 'production' %}
         <div role="alert" class="fr-alert fr-alert--info">
-            <p>Attention, vous utilisez actuellement la plateforme <strong>ÉCOLE</strong></p>
-        </div>
-    {% endif %}
-    {% if ENVIRONMENT == 'development' %}
-        <div role="alert" class="fr-alert fr-alert--info">
-            <p>Attention, vous utilisez actuellement la plateforme de <strong>DEVELOPPEMENT</strong></p>
+            <p>Attention, vous utilisez actuellement la plateforme <strong>{{ ENVIRONMENT|upper }}</strong></p>
         </div>
     {% endif %}
     <div id="browser_alert" hidden>


### PR DESCRIPTION
# Description succincte du problème résolu

L'affichage de l'environnement est faux, en staging, ça ffiche qu'on est sur la plateforme école, et en école, ça n'affiche rien

Dans cette PR, on affiche l'environnement dans le message sauf pour la production

<img width="2770" height="954" alt="CleanShot 2025-10-06 at 16 51 22@2x" src="https://github.com/user-attachments/assets/b78f19a3-4b38-49fc-88d9-4e885ad5f904" />

## Auto-review

Les trucs à faire avant de demander une review :

- [x] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- afficher l'interface dans chaque environnement, la notification de l'environnement doit s'afficher sur toutes les pages sauf pour la production
