### PR TITLE
fix: rétablir le délai d’expiration de Gunicorn à 26 secondes dans le Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: gunicorn --timeout 300 --chdir core core.wsgi --log-file -
+web: gunicorn --timeout 26 --chdir core core.wsgi --log-file -
 worker: python -m celery -A core.worker worker -B -l INFO
 postdeploy: bash bin/post_deploy


### PR DESCRIPTION
# Timeouts : Le routeur Scalingo interrompt toute requête n'ayant pas répondu sous 30 secondes.

Comme notre Gunicorn est configuré avec un timeout de 300s, il continue de traiter la requête pendant 4 minutes supplémentaires après que Scalingo a déjà coupé la connexion.

https://doc.scalingo.com/platform/networking/public/routing

**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
