### PR TITLE
feat: ajout d’une commande permettant de lister les utilisateurs bail…

### DIFF
--- a/conventions/management/commands/list_users_by_administration.py
+++ b/conventions/management/commands/list_users_by_administration.py
@@ -1,17 +1,21 @@
 """
 Commande de diagnostic : liste les utilisateurs bailleur et instructeur
-liés à une administration donnée (par son code).
+liés à une administration donnée (par son code), et optionnellement les
+détails d'une opération spécifique.
 
 Utile pour investiguer les problèmes de notification par email :
 - Vérifie quels utilisateurs ont un rôle local dans APiLos
 - Affiche leur préférence email (TOUS, PARTIEL, AUCUN)
 - Affiche leur dernière connexion
+- Affiche les destinataires email pour une convention donnée
 
 Utilisation :
     python manage.py list_users_by_administration <code_administration>
+    python manage.py list_users_by_administration <code_administration> --operation <numero_operation>
 
-Exemple :
+Exemples :
     python manage.py list_users_by_administration 33063
+    python manage.py list_users_by_administration 33063 --operation 2021330630053
 """
 
 from django.core.management.base import BaseCommand, CommandError
@@ -19,6 +23,7 @@ from django.core.management.base import BaseCommand, CommandError
 from bailleurs.models import Bailleur
 from conventions.models import Convention
 from instructeurs.models import Administration
+from programmes.models import Programme
 from users.models import User
 from users.type_models import TypeRole
 
@@ -35,14 +40,23 @@ class Command(BaseCommand):
             type=str,
             help="Code de l'administration (ex: 33063 pour Bordeaux Métropole)",
         )
+        parser.add_argument(
+            "--operation",
+            type=str,
+            default=None,
+            help="Numéro d'opération pour afficher le détail d'une convention spécifique",
+        )
 
     def handle(self, *args, **options):
         code = options["code"]
+        operation = options["operation"]
 
         try:
             admin = Administration.objects.get(code=code)
         except Administration.DoesNotExist as err:
-            raise CommandError(f"Administration with code '{code}' not found.") from err
+            raise CommandError(
+                f"Administration avec le code '{code}' introuvable."
+            ) from err
 
         self.stdout.write(self.style.SUCCESS(f"Administration: {admin}"))
 
@@ -94,3 +108,49 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  {u.email} | pref_email={u.preferences_email} | last_login={u.last_login}"
             )
+
+        # Détail d'une opération spécifique
+        if operation:
+            self._display_operation_details(operation)
+
+    def _display_operation_details(self, numero_operation: str):
+        self.stdout.write(
+            self.style.SUCCESS(f"\n--- Détail opération {numero_operation} ---")
+        )
+
+        programmes = Programme.objects.filter(numero_operation=numero_operation)
+        if not programmes.exists():
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Aucun programme trouvé pour l'opération {numero_operation}"
+                )
+            )
+            return
+
+        for programme in programmes:
+            self.stdout.write(
+                f"\nProgramme: {programme.nom} | Bailleur: {programme.bailleur.nom} "
+                f"(SIREN: {programme.bailleur.siren})"
+            )
+
+            convs = programme.conventions.all()
+            for conv in convs:
+                self.stdout.write(f"\n  Convention: {conv.uuid} | statut={conv.statut}")
+                self.stdout.write(
+                    f"    Emails bailleur destinataires: {conv.get_email_bailleur_users()}"
+                )
+                self.stdout.write(
+                    f"    Emails instructeur destinataires: {conv.get_email_instructeur_users()}"
+                )
+
+                # Historique des interactions
+                histories = conv.conventionhistories.select_related("user").order_by(
+                    "-cree_le"
+                )[:10]
+                if histories:
+                    self.stdout.write("    Dernières interactions:")
+                    for h in histories:
+                        email = h.user.email if h.user else "N/A"
+                        self.stdout.write(
+                            f"      {email} | statut={h.statut_convention} | {h.cree_le}"
+                        )

--- a/conventions/management/commands/list_users_by_administration.py
+++ b/conventions/management/commands/list_users_by_administration.py
@@ -133,24 +133,26 @@ class Command(BaseCommand):
                 f"(SIREN: {programme.bailleur.siren})"
             )
 
-            convs = programme.conventions.all()
-            for conv in convs:
-                self.stdout.write(f"\n  Convention: {conv.uuid} | statut={conv.statut}")
-                self.stdout.write(
-                    f"    Emails bailleur destinataires: {conv.get_email_bailleur_users()}"
-                )
-                self.stdout.write(
-                    f"    Emails instructeur destinataires: {conv.get_email_instructeur_users()}"
-                )
+            for conv in programme.conventions.all():
+                self._display_convention_details(conv)
 
-                # Historique des interactions
-                histories = conv.conventionhistories.select_related("user").order_by(
-                    "-cree_le"
-                )[:10]
-                if histories:
-                    self.stdout.write("    Dernières interactions:")
-                    for h in histories:
-                        email = h.user.email if h.user else "N/A"
-                        self.stdout.write(
-                            f"      {email} | statut={h.statut_convention} | {h.cree_le}"
-                        )
+    def _display_convention_details(self, conv):
+        self.stdout.write(f"\n  Convention: {conv.uuid} | statut={conv.statut}")
+        self.stdout.write(
+            f"    Emails bailleur destinataires: {conv.get_email_bailleur_users()}"
+        )
+        self.stdout.write(
+            f"    Emails instructeur destinataires: {conv.get_email_instructeur_users()}"
+        )
+
+        # Historique des interactions
+        histories = conv.conventionhistories.select_related("user").order_by(
+            "-cree_le"
+        )[:10]
+        if histories:
+            self.stdout.write("    Dernières interactions:")
+            for h in histories:
+                email = h.user.email if h.user else "N/A"
+                self.stdout.write(
+                    f"      {email} | statut={h.statut_convention} | {h.cree_le}"
+                )

--- a/conventions/management/commands/list_users_by_administration.py
+++ b/conventions/management/commands/list_users_by_administration.py
@@ -1,0 +1,96 @@
+"""
+Commande de diagnostic : liste les utilisateurs bailleur et instructeur
+liés à une administration donnée (par son code).
+
+Utile pour investiguer les problèmes de notification par email :
+- Vérifie quels utilisateurs ont un rôle local dans APiLos
+- Affiche leur préférence email (TOUS, PARTIEL, AUCUN)
+- Affiche leur dernière connexion
+
+Utilisation :
+    python manage.py list_users_by_administration <code_administration>
+
+Exemple :
+    python manage.py list_users_by_administration 33063
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from bailleurs.models import Bailleur
+from conventions.models import Convention
+from instructeurs.models import Administration
+from users.models import User
+from users.type_models import TypeRole
+
+
+class Command(BaseCommand):
+    help = (
+        "Liste les utilisateurs bailleur et instructeur liés à une administration "
+        "(par code). Utile pour diagnostiquer les problèmes de notification email."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "code",
+            type=str,
+            help="Code de l'administration (ex: 33063 pour Bordeaux Métropole)",
+        )
+
+    def handle(self, *args, **options):
+        code = options["code"]
+
+        try:
+            admin = Administration.objects.get(code=code)
+        except Administration.DoesNotExist as err:
+            raise CommandError(f"Administration with code '{code}' not found.") from err
+
+        self.stdout.write(self.style.SUCCESS(f"Administration: {admin}"))
+
+        # Conventions count
+        conventions = Convention.objects.filter(programme__administration=admin)
+        self.stdout.write(f"Nb conventions: {conventions.count()}")
+
+        # Bailleurs linked via Programme
+        bailleur_ids = conventions.values_list(
+            "programme__bailleur", flat=True
+        ).distinct()
+        bailleurs = Bailleur.objects.filter(id__in=bailleur_ids)
+        self.stdout.write(self.style.SUCCESS(f"\nBailleurs ({bailleurs.count()}):"))
+        for b in bailleurs:
+            self.stdout.write(f"  - {b.nom} (SIREN: {b.siren})")
+
+        # Bailleur users (via Role)
+        users_bailleur = (
+            User.objects.filter(
+                roles__typologie=TypeRole.BAILLEUR,
+                roles__bailleur__in=bailleurs,
+            )
+            .distinct()
+            .order_by("email")
+        )
+        self.stdout.write(
+            self.style.SUCCESS(f"\nUtilisateurs bailleur ({users_bailleur.count()}):")
+        )
+        for u in users_bailleur:
+            self.stdout.write(
+                f"  {u.email} | pref_email={u.preferences_email} | last_login={u.last_login}"
+            )
+
+        # Instructeur users
+        users_instructeur = (
+            User.objects.filter(
+                roles__typologie=TypeRole.INSTRUCTEUR,
+                roles__administration=admin,
+            )
+            .distinct()
+            .order_by("email")
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nUtilisateurs instructeur ({users_instructeur.count()}):"
+            )
+        )
+        for u in users_instructeur:
+            self.stdout.write(
+                f"  {u.email} | pref_email={u.preferences_email} | last_login={u.last_login}"
+            )

--- a/docs/DEVELOPPEUR.md
+++ b/docs/DEVELOPPEUR.md
@@ -399,3 +399,35 @@ sphinx-build -M html docs _build
 ```
 
 La documentation est viualisable avec un navigateur à partir du fichier [_build/html/README.html](_build/html/README.html)
+
+## Commandes de diagnostic
+
+### Lister les utilisateurs par administration
+
+La commande `list_users_by_administration` permet de lister les utilisateurs bailleur et instructeur liés à une administration donnée. Elle est utile pour diagnostiquer les problèmes de notification par email.
+
+#### Utilisation
+
+```sh
+python manage.py list_users_by_administration <code_administration>
+```
+
+#### Exemple
+
+```sh
+python manage.py list_users_by_administration 33063
+```
+
+#### Informations affichées
+
+- Nom de l'administration
+- Nombre de conventions liées
+- Liste des bailleurs (nom + SIREN) ayant des conventions gérées par cette administration
+- Utilisateurs bailleur : email, préférence email (`TOUS`, `PARTIEL`, `AUCUN`), dernière connexion
+- Utilisateurs instructeur : email, préférence email, dernière connexion
+
+#### Cas d'usage
+
+- Vérifier qu'un utilisateur signalant un problème de notification a bien un rôle local dans APiLos
+- Vérifier que sa préférence email est compatible avec l'envoi de notifications (`TOUS` ou `PARTIEL`)
+- Identifier les utilisateurs qui ne se sont jamais connectés à APiLos (pas de rôle local créé)

--- a/docs/DEVELOPPEUR.md
+++ b/docs/DEVELOPPEUR.md
@@ -410,12 +410,17 @@ La commande `list_users_by_administration` permet de lister les utilisateurs bai
 
 ```sh
 python manage.py list_users_by_administration <code_administration>
+python manage.py list_users_by_administration <code_administration> --operation <numero_operation>
 ```
 
-#### Exemple
+#### Exemples
 
 ```sh
+# Lister tous les utilisateurs liés à Bordeaux Métropole
 python manage.py list_users_by_administration 33063
+
+# Lister les utilisateurs + détail d'une opération spécifique
+python manage.py list_users_by_administration 33063 --operation 2021330630053
 ```
 
 #### Informations affichées
@@ -426,8 +431,15 @@ python manage.py list_users_by_administration 33063
 - Utilisateurs bailleur : email, préférence email (`TOUS`, `PARTIEL`, `AUCUN`), dernière connexion
 - Utilisateurs instructeur : email, préférence email, dernière connexion
 
+Avec l'option `--operation` :
+- Programme et bailleur associés à l'opération
+- Conventions liées avec leur statut
+- Destinataires email (bailleur et instructeur) calculés par APiLos pour chaque convention
+- Historique des 10 dernières interactions (qui a changé le statut)
+
 #### Cas d'usage
 
 - Vérifier qu'un utilisateur signalant un problème de notification a bien un rôle local dans APiLos
 - Vérifier que sa préférence email est compatible avec l'envoi de notifications (`TOUS` ou `PARTIEL`)
 - Identifier les utilisateurs qui ne se sont jamais connectés à APiLos (pas de rôle local créé)
+- Vérifier quel bailleur est associé à une opération spécifique (un utilisateur peut avoir un rôle sur un bailleur différent de celui de l'opération)


### PR DESCRIPTION
Ajoute une commande Django pour lister les utilisateurs (bailleur et instructeur) liés à une administration donnée.

Contexte
Pour investiguer les problèmes de notification par email (utilisateurs qui ne reçoivent pas les mails de changement de statut de convention), il est nécessaire de pouvoir rapidement vérifier :

- Quels utilisateurs ont un rôle local dans APiLos pour une administration donnée
- Quelle est leur préférence email TOUS, PARTIEL AUCUN
- Quand ils se sont connectés pour la dernière fois

Output
- Administration trouvée
- Nombre de conventions liées
- Liste des bailleurs (nom + SIREN) ayant des conventions gérées par cette administration
- Utilisateurs bailleur avec leur preferences_email et last_login
- Utilisateurs instructeur avec leur preferences_email et last_login



**N'oublier pas de taguer** : `bug`, `enhancement`, `documentation`, `technical`, `dependencies` (+ `escalation`, `regression` si besion)

<!-- En cas d'évolution, se synchroniser avec l'équipe communication et répondre aux questions ci-dessous

## Evolution Utile / Utilisable / Utilisé

### Quelle communication sur cette Fonctionnalité

Décrire ici quels sont les elements que l'on souhaite comuniquer aux utilisateurs. Voir avec l'ensemble de l'équipe

### Comment s'assurer que cette fonctionnalité est utilisée

Décrire ici comment on collectera les informations de l'utilisation et des utilisateurs de la fonctionnalité

### Comment collecte du Feedback

Décrire les processus à mettre en place pour collecter les retours utilisateurs : sondages, interviews…

-->

## Auto-review

Les trucs à faire avant de demander une review :

- [ ] J'ai bien relu mon code
- [ ] La CI passe bien
- [ ] En cas d'ajout de variable d'environnement, j'ai bien mis à jour le `.env.template`
- [ ] J'ai ajouté des tests qui couvrent le nouveau code

## Comment tester

En local / staging :
- …

<!--

## Développement local

Dans le cas où il y a des instructions spécifiques pour garantir un local fonctionnel pour le reste de l'équipe

- …
 -->

<!--

## Déploiement

 Dans le cas où il y a des instructions spécifiques de déploiement

- …
 -->
